### PR TITLE
#108/display html encoded characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Notification with sound is shown when the app is open now too
 - Synchronized progress indicator of totp tokens
 
+### Fixed
+
+- Uri encoded characters (e.g. @ as %40) are now correctly displayed for token labels 
+
 
 ## [3.0.8] - 2021-01-07
 

--- a/lib/model/tokens.dart
+++ b/lib/model/tokens.dart
@@ -38,7 +38,7 @@ abstract class Token {
 
   String get tokenVersion => _tokenVersion;
 
-  String get label => Uri.decodeFull(_label);
+  String get label => _label == null ? "" : Uri.decodeFull(_label);
 
   set label(String label) {
     this._label = label;
@@ -46,7 +46,7 @@ abstract class Token {
 
   String get id => _id;
 
-  String get issuer => Uri.decodeFull(_issuer);
+  String get issuer => _issuer == null ? "" : Uri.decodeFull(_issuer);
 
   Token(this._label, this._issuer, this._id, this.type);
 

--- a/lib/model/tokens.dart
+++ b/lib/model/tokens.dart
@@ -38,7 +38,7 @@ abstract class Token {
 
   String get tokenVersion => _tokenVersion;
 
-  String get label => _label;
+  String get label => Uri.decodeFull(_label);
 
   set label(String label) {
     this._label = label;
@@ -46,7 +46,7 @@ abstract class Token {
 
   String get id => _id;
 
-  String get issuer => _issuer;
+  String get issuer => Uri.decodeFull(_issuer);
 
   Token(this._label, this._issuer, this._id, this.type);
 

--- a/lib/utils/parsing_utils.dart
+++ b/lib/utils/parsing_utils.dart
@@ -237,7 +237,8 @@ Map<String, dynamic> parsePiAuth(Uri uri) {
   Map<String, dynamic> uriMap = Map();
 
   uriMap[URI_TYPE] = uri.host;
-  uriMap[URI_ISSUER] = uri.queryParameters['issuer'];
+
+  uriMap[URI_ISSUER] = Uri.decodeFull(uri.queryParameters['issuer']);
 
   // If we do not support the version of this piauth url, we can stop here.
   String pushVersionAsString = uri.queryParameters["v"];
@@ -323,7 +324,7 @@ Map<String, dynamic> parseOtpAuth(Uri uri) {
 
   // parse.host -> Type totp or hotp
   uriMap[URI_TYPE] = uri.host;
-  uriMap[URI_ISSUER] = uri.queryParameters['issuer'];
+  uriMap[URI_ISSUER] = Uri.decodeFull(uri.queryParameters['issuer']);
 
 // parse.path.substring(1) -> Label
   log("Key: [..] | Value: [..]");
@@ -465,7 +466,7 @@ Map<String, dynamic> parseOtpAuth(Uri uri) {
 }
 
 String _parseLabel(Uri uri) {
-  return uri.path.substring(1);
+  return Uri.decodeFull(uri.path.substring(1));
 }
 
 bool is2StepURI(Uri uri) {


### PR DESCRIPTION
Closes #108. If a token is added the uri encoded characters (e.g. %40 or @) will be parsed as correctly. Existing tokens are fixed also.