### PR TITLE
#114/add crash logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@
 - parallel development of android and ios version
 
 
+[3.1.0]: https://github.com/privacyidea/pi-authenticator/compare/v3.0.12...v3.1.0
 [3.0.12]: https://github.com/privacyidea/pi-authenticator/compare/v3.0.8...v3.0.12
 [3.0.8]: https://github.com/privacyidea/pi-authenticator/compare/v3.0.7...v3.0.8
 [3.0.7]: https://github.com/privacyidea/pi-authenticator/compare/v3.0.6...v3.0.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.1.0] - 2021-02-09
+
+### Added
+
+- Added error reporting to the application. If an uncaught error occurs, the information is shown to the user and an e-mail can be send to support. 
+
 ## [3.0.12] - 2021-02-09
 
 ### Added

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -264,38 +264,9 @@
 			files = (
 			);
 			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
-				"${PODS_ROOT}/../Flutter/Flutter.framework",
-				"${BUILT_PRODUCTS_DIR}/GoogleUtilities/GoogleUtilities.framework",
-				"${BUILT_PRODUCTS_DIR}/MTBBarcodeScanner/MTBBarcodeScanner.framework",
-				"${BUILT_PRODUCTS_DIR}/PromisesObjC/FBLPromises.framework",
-				"${BUILT_PRODUCTS_DIR}/Protobuf/Protobuf.framework",
-				"${BUILT_PRODUCTS_DIR}/SwiftyRSA/SwiftyRSA.framework",
-				"${BUILT_PRODUCTS_DIR}/barcode_scan/barcode_scan.framework",
-				"${BUILT_PRODUCTS_DIR}/flutter_local_notifications/flutter_local_notifications.framework",
-				"${BUILT_PRODUCTS_DIR}/flutter_secure_storage/flutter_secure_storage.framework",
-				"${BUILT_PRODUCTS_DIR}/nanopb/nanopb.framework",
-				"${BUILT_PRODUCTS_DIR}/package_info/package_info.framework",
-				"${BUILT_PRODUCTS_DIR}/pi_authenticator_legacy/pi_authenticator_legacy.framework",
-				"${BUILT_PRODUCTS_DIR}/shared_preferences/shared_preferences.framework",
-				"${BUILT_PRODUCTS_DIR}/url_launcher/url_launcher.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Flutter.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleUtilities.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MTBBarcodeScanner.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBLPromises.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Protobuf.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftyRSA.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/barcode_scan.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/flutter_local_notifications.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/flutter_secure_storage.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/nanopb.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/package_info.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/pi_authenticator_legacy.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/shared_preferences.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/url_launcher.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -400,7 +371,7 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -534,7 +505,7 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -564,7 +535,7 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -57,5 +57,7 @@
 	<false/>
 	<key>FirebaseMessagingAutoInitEnabled</key>
 	<false/>
+	<key>FIREBASE_ANALYTICS_COLLECTION_DISABLED</key>
+	<true/>
 </dict>
 </plist>

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -294,7 +294,7 @@
     "type": "text",
     "placeholders": {}
   },
-  "retryRollOut": "Ausrollen fehlgeschlagen, nochmal versuchen?",
+  "retryRollOut": "Erneut ausrollen.",
   "@retryRollOut": {
     "description": "Label for e.g. a button. Tells the user that rolling out the token failed. Roll out can be retried by clicking this button.",
     "type": "text",

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -1,5 +1,5 @@
 {
-  "@@last_modified": "2020-05-22T12:03:54.642044",
+  "@@last_modified": "2021-02-25T12:30:00.793083",
   "Next": "Weiter",
   "@Next": {
     "description": "The text of the button to calculate the next otp value.",
@@ -457,5 +457,24 @@
     "description": "Title of migration dialog.",
     "type": "text",
     "placeholders": {}
+  },
+  "Unexpected Error": "Unbekannter Fehler",
+  "@Unexpected Error": {
+    "description": "Title of page report mode.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "pageReportModeBody": "Ein unbekannter Fehler ist aufgetreten. Die unten gezeigten Informationen können den Entwicklern per E-Mail zugesendet werden um zu helfen diesen Fehler in Zukunft zu vermeiden. Drücken Sie '{accept}' um die Informationen zu senden oder '{cancel}' um nichts zu senden.",
+  "@pageReportModeBody": {
+    "description": "Description shown to the user about what info the error report contains.",
+    "type": "text",
+    "placeholders": {
+      "accept": {
+        "example": "accept"
+      },
+      "cancel": {
+        "example": "cancel"
+      }
+    }
   }
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1,5 +1,5 @@
 {
-  "@@last_modified": "2021-02-09T12:52:12.206680",
+  "@@last_modified": "2021-02-25T12:30:00.793083",
   "Guide": "Guide",
   "@Guide": {
     "description": "Button to open the guide screen.",
@@ -457,5 +457,24 @@
     "description": "Title of migration dialog.",
     "type": "text",
     "placeholders": {}
+  },
+  "Unexpected Error": "Unexpected Error",
+  "@Unexpected Error": {
+    "description": "Title of page report mode.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "pageReportModeBody": "An unexpected error occurred in the application. The information below can be send to the developers by email to help prevent this error in the future. Press '{accept}' to send the information or '{cancel}' to not send any information.",
+  "@pageReportModeBody": {
+    "description": "Description shown to the user about what info the error report contains.",
+    "type": "text",
+    "placeholders": {
+      "accept": {
+        "example": "accept"
+      },
+      "cancel": {
+        "example": "cancel"
+      }
+    }
   }
 }

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -1,5 +1,5 @@
 {
-  "@@last_modified": "2021-02-09T12:52:12.206680",
+  "@@last_modified": "2021-02-25T12:30:00.793083",
   "Guide": "Guide",
   "@Guide": {
     "description": "Button to open the guide screen.",
@@ -457,5 +457,24 @@
     "description": "Title of migration dialog.",
     "type": "text",
     "placeholders": {}
+  },
+  "Unexpected Error": "Unexpected Error",
+  "@Unexpected Error": {
+    "description": "Title of page report mode.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "pageReportModeBody": "An unexpected error occurred in the application. The information below can be send to the developers by email to help prevent this error in the future. Press '{accept}' to send the information or '{cancel}' to not send any information.",
+  "@pageReportModeBody": {
+    "description": "Description shown to the user about what info the error report contains.",
+    "type": "text",
+    "placeholders": {
+      "accept": {
+        "example": "accept"
+      },
+      "cancel": {
+        "example": "cancel"
+      }
+    }
   }
 }

--- a/lib/l10n/messages_de.dart
+++ b/lib/l10n/messages_de.dart
@@ -112,7 +112,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "otpValueCopiedMessage" : m9,
     "pageReportModeBody" : m10,
     "retry" : MessageLookupByLibrary.simpleMessage("Erneut versuchen"),
-    "retryRollOut" : MessageLookupByLibrary.simpleMessage("Ausrollen fehlgeschlagen, nochmal versuchen?"),
+    "retryRollOut" : MessageLookupByLibrary.simpleMessage("Erneut ausrollen."),
     "rollingOut" : MessageLookupByLibrary.simpleMessage("Ausrollen")
   };
 }

--- a/lib/l10n/messages_de.dart
+++ b/lib/l10n/messages_de.dart
@@ -39,6 +39,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static m9(otpValue) => "Passwort \"${otpValue}\" wurde in die Zwischenablage kopiert.";
 
+  static m10(accept, cancel) => "Ein unbekannter Fehler ist aufgetreten. Die unten gezeigten Informationen können den Entwicklern per E-Mail zugesendet werden um zu helfen diesen Fehler in Zukunft zu vermeiden. Drücken Sie \'${accept}\' um die Informationen zu senden oder \'${cancel}\' um nichts zu senden.";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static _notInlinedMessages(_) => <String, Function> {
     "About" : MessageLookupByLibrary.simpleMessage("Über"),
@@ -92,6 +94,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "The secret does not fit the current encoding" : MessageLookupByLibrary.simpleMessage("Das Geheimnis entspricht nicht der gewählten\n Verschlüsselung."),
     "Theme" : MessageLookupByLibrary.simpleMessage("Thema"),
     "Type" : MessageLookupByLibrary.simpleMessage("Art"),
+    "Unexpected Error" : MessageLookupByLibrary.simpleMessage("Unbekannter Fehler"),
     "accept" : MessageLookupByLibrary.simpleMessage("Akzeptieren"),
     "acceptPushAuthRequestFor" : m0,
     "confirmDeletionOf" : m1,
@@ -107,6 +110,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "errorSynchronizationNoNetworkConnection" : MessageLookupByLibrary.simpleMessage("Die Synchronisation ist fehlgeschlagen, da der privacyIDEA Server nicht erreicht werden konnte."),
     "errorTokenExpired" : m8,
     "otpValueCopiedMessage" : m9,
+    "pageReportModeBody" : m10,
     "retry" : MessageLookupByLibrary.simpleMessage("Erneut versuchen"),
     "retryRollOut" : MessageLookupByLibrary.simpleMessage("Ausrollen fehlgeschlagen, nochmal versuchen?"),
     "rollingOut" : MessageLookupByLibrary.simpleMessage("Ausrollen")

--- a/lib/l10n/messages_en.dart
+++ b/lib/l10n/messages_en.dart
@@ -39,6 +39,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static m9(otpValue) => "Password \"${otpValue}\" copied to clipboard.";
 
+  static m10(accept, cancel) => "An unexpected error occurred in the application. The information below can be send to the developers by email to help prevent this error in the future. Press \'${accept}\' to send the information or \'${cancel}\' to not send any information.";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static _notInlinedMessages(_) => <String, Function> {
     "About" : MessageLookupByLibrary.simpleMessage("About"),
@@ -92,6 +94,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "The secret does not fit the current encoding" : MessageLookupByLibrary.simpleMessage("The secret does not fit the current encoding"),
     "Theme" : MessageLookupByLibrary.simpleMessage("Theme"),
     "Type" : MessageLookupByLibrary.simpleMessage("Type"),
+    "Unexpected Error" : MessageLookupByLibrary.simpleMessage("Unexpected Error"),
     "accept" : MessageLookupByLibrary.simpleMessage("Accept"),
     "acceptPushAuthRequestFor" : m0,
     "confirmDeletionOf" : m1,
@@ -107,6 +110,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "errorSynchronizationNoNetworkConnection" : MessageLookupByLibrary.simpleMessage("Synchronizing tokens failed, privacyIDEA server could not be reached."),
     "errorTokenExpired" : m8,
     "otpValueCopiedMessage" : m9,
+    "pageReportModeBody" : m10,
     "retry" : MessageLookupByLibrary.simpleMessage("Retry"),
     "retryRollOut" : MessageLookupByLibrary.simpleMessage("Roll-out failed, please try again."),
     "rollingOut" : MessageLookupByLibrary.simpleMessage("Rolling out")

--- a/lib/l10n/messages_messages.dart
+++ b/lib/l10n/messages_messages.dart
@@ -39,6 +39,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static m9(otpValue) => "Password \"${otpValue}\" copied to clipboard.";
 
+  static m10(accept, cancel) => "An unexpected error occurred in the application. The information below can be send to the developers by email to help prevent this error in the future. Press \'${accept}\' to send the information or \'${cancel}\' to not send any information.";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static _notInlinedMessages(_) => <String, Function> {
     "About" : MessageLookupByLibrary.simpleMessage("About"),
@@ -92,6 +94,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "The secret does not fit the current encoding" : MessageLookupByLibrary.simpleMessage("The secret does not fit the current encoding"),
     "Theme" : MessageLookupByLibrary.simpleMessage("Theme"),
     "Type" : MessageLookupByLibrary.simpleMessage("Type"),
+    "Unexpected Error" : MessageLookupByLibrary.simpleMessage("Unexpected Error"),
     "accept" : MessageLookupByLibrary.simpleMessage("Accept"),
     "acceptPushAuthRequestFor" : m0,
     "confirmDeletionOf" : m1,
@@ -107,6 +110,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "errorSynchronizationNoNetworkConnection" : MessageLookupByLibrary.simpleMessage("Synchronizing tokens failed, privacyIDEA server could not be reached."),
     "errorTokenExpired" : m8,
     "otpValueCopiedMessage" : m9,
+    "pageReportModeBody" : m10,
     "retry" : MessageLookupByLibrary.simpleMessage("Retry"),
     "retryRollOut" : MessageLookupByLibrary.simpleMessage("Roll-out failed, please try again."),
     "rollingOut" : MessageLookupByLibrary.simpleMessage("Rolling out")

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -44,7 +44,9 @@ void main() async {
 //  ]);
 
   CatcherOptions releaseOptions = CatcherOptions(CustomPageReportMode(), [
-    EmailManualHandler(["support@email.com"], enableCustomParameters: false)
+    EmailManualHandler(['timo.sturm@netknights.it'],
+        enableCustomParameters: false)
+    // TODO Change e-mail address.
   ]);
 
   CatcherOptions debugOptions =

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,8 +32,6 @@ import 'package:privacyidea_authenticator/utils/localization_utils.dart';
 import 'package:privacyidea_authenticator/widgets/CustomPageReportMode.dart';
 import 'package:streaming_shared_preferences/streaming_shared_preferences.dart';
 
-Catcher catcher;
-
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 //  runApp(PrivacyIDEAAuthenticator(preferences: await StreamingSharedPreferences.instance));
@@ -54,7 +52,7 @@ void main() async {
   CatcherOptions debugOptions =
       releaseOptions; // TODO Replace this with real debug config!
 
-  catcher = Catcher(
+  Catcher(
     rootWidget: PrivacyIDEAAuthenticator(
         preferences: await StreamingSharedPreferences.instance),
     debugConfig: debugOptions,
@@ -90,7 +88,7 @@ class PrivacyIDEAAuthenticator extends StatelessWidget {
                 AppSettings.of(context).crashReportRecipients;
 
             // TODO Remove debug config!
-            catcher.updateConfig(
+            Catcher.instance.updateConfig(
               releaseConfig: CatcherOptions(CustomPageReportMode(), [
                 EmailManualHandler(crashReportRecipients,
                     enableCustomParameters: false)

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,6 +28,7 @@ import 'package:privacyidea_authenticator/screens/settings_screen.dart';
 import 'package:privacyidea_authenticator/utils/application_theme_utils.dart';
 import 'package:privacyidea_authenticator/utils/customizations.dart';
 import 'package:privacyidea_authenticator/utils/localization_utils.dart';
+import 'package:privacyidea_authenticator/widgets/CustomPageReportMode.dart';
 import 'package:streaming_shared_preferences/streaming_shared_preferences.dart';
 
 void main() async {
@@ -42,8 +43,8 @@ void main() async {
 //        enableStackTrace: true)
 //  ]);
 
-  CatcherOptions releaseOptions = CatcherOptions(PageReportMode(), [
-    EmailManualHandler(["support@email.com"])
+  CatcherOptions releaseOptions = CatcherOptions(CustomPageReportMode(), [
+    EmailManualHandler(["support@email.com"], enableCustomParameters: false)
   ]);
 
   CatcherOptions debugOptions =

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -42,7 +42,7 @@ void main() async {
 //        enableStackTrace: true)
 //  ]);
 
-  CatcherOptions releaseOptions = CatcherOptions(DialogReportMode(), [
+  CatcherOptions releaseOptions = CatcherOptions(PageReportMode(), [
     EmailManualHandler(["support@email.com"])
   ]);
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,6 +18,7 @@
   limitations under the License.
 */
 
+import 'package:catcher/catcher.dart';
 import 'package:dynamic_theme/dynamic_theme.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -31,13 +32,36 @@ import 'package:streaming_shared_preferences/streaming_shared_preferences.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  runApp(MyApp(preferences: await StreamingSharedPreferences.instance));
+//  runApp(PrivacyIDEAAuthenticator(preferences: await StreamingSharedPreferences.instance));
+
+//  CatcherOptions debugOptions = CatcherOptions(SilentReportMode(), [
+//    ConsoleHandler(
+//        enableApplicationParameters: false,
+//        enableDeviceParameters: false,
+//        enableCustomParameters: false,
+//        enableStackTrace: true)
+//  ]);
+
+  CatcherOptions releaseOptions = CatcherOptions(DialogReportMode(), [
+    EmailManualHandler(["support@email.com"])
+  ]);
+
+  CatcherOptions debugOptions =
+      releaseOptions; // TODO Replace this with real debug config!
+
+  Catcher(
+    rootWidget: PrivacyIDEAAuthenticator(
+        preferences: await StreamingSharedPreferences.instance),
+    debugConfig: debugOptions,
+    releaseConfig: releaseOptions,
+//    ensureInitialized: true,
+  );
 }
 
-class MyApp extends StatelessWidget {
+class PrivacyIDEAAuthenticator extends StatelessWidget {
   final StreamingSharedPreferences _preferences;
 
-  const MyApp({StreamingSharedPreferences preferences})
+  const PrivacyIDEAAuthenticator({StreamingSharedPreferences preferences})
       : this._preferences = preferences;
 
   static List<Locale> _supportedLocales = [
@@ -58,6 +82,8 @@ class MyApp extends StatelessWidget {
           data: (brightness) => getApplicationTheme(brightness),
           themedWidgetBuilder: (context, theme) {
             return MaterialApp(
+              navigatorKey: Catcher.navigatorKey,
+              // Needed to display dialogs etc.
               localizationsDelegates: [
                 const MyLocalizationsDelegate(),
                 GlobalMaterialLocalizations.delegate,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -34,30 +34,25 @@ import 'package:streaming_shared_preferences/streaming_shared_preferences.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-//  runApp(PrivacyIDEAAuthenticator(preferences: await StreamingSharedPreferences.instance));
 
-//  CatcherOptions debugOptions = CatcherOptions(SilentReportMode(), [
-//    ConsoleHandler(
-//        enableApplicationParameters: false,
-//        enableDeviceParameters: false,
-//        enableCustomParameters: false,
-//        enableStackTrace: true)
-//  ]);
+  CatcherOptions debugOptions = CatcherOptions(SilentReportMode(), [
+    ConsoleHandler(
+        enableApplicationParameters: false,
+        enableDeviceParameters: false,
+        enableCustomParameters: false,
+        enableStackTrace: true)
+  ]);
 
   CatcherOptions releaseOptions = CatcherOptions(CustomPageReportMode(), [
     EmailManualHandler([defaultCrashReportRecipient],
         enableCustomParameters: false)
   ]);
 
-  CatcherOptions debugOptions =
-      releaseOptions; // TODO Replace this with real debug config!
-
   Catcher(
     rootWidget: PrivacyIDEAAuthenticator(
         preferences: await StreamingSharedPreferences.instance),
     debugConfig: debugOptions,
     releaseConfig: releaseOptions,
-//    ensureInitialized: true,
   );
 }
 
@@ -87,13 +82,9 @@ class PrivacyIDEAAuthenticator extends StatelessWidget {
             var crashReportRecipients =
                 AppSettings.of(context).crashReportRecipients;
 
-            // TODO Remove debug config!
+            // Override release config to use custom e-mail recipients
             Catcher.instance.updateConfig(
               releaseConfig: CatcherOptions(CustomPageReportMode(), [
-                EmailManualHandler(crashReportRecipients,
-                    enableCustomParameters: false)
-              ]),
-              debugConfig: CatcherOptions(CustomPageReportMode(), [
                 EmailManualHandler(crashReportRecipients,
                     enableCustomParameters: false)
               ]),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,9 +27,12 @@ import 'package:privacyidea_authenticator/screens/main_screen.dart';
 import 'package:privacyidea_authenticator/screens/settings_screen.dart';
 import 'package:privacyidea_authenticator/utils/application_theme_utils.dart';
 import 'package:privacyidea_authenticator/utils/customizations.dart';
+import 'package:privacyidea_authenticator/utils/identifiers.dart';
 import 'package:privacyidea_authenticator/utils/localization_utils.dart';
 import 'package:privacyidea_authenticator/widgets/CustomPageReportMode.dart';
 import 'package:streaming_shared_preferences/streaming_shared_preferences.dart';
+
+Catcher catcher;
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -44,15 +47,14 @@ void main() async {
 //  ]);
 
   CatcherOptions releaseOptions = CatcherOptions(CustomPageReportMode(), [
-    EmailManualHandler(['timo.sturm@netknights.it'],
+    EmailManualHandler([defaultCrashReportRecipient],
         enableCustomParameters: false)
-    // TODO Change e-mail address.
   ]);
 
   CatcherOptions debugOptions =
       releaseOptions; // TODO Replace this with real debug config!
 
-  Catcher(
+  catcher = Catcher(
     rootWidget: PrivacyIDEAAuthenticator(
         preferences: await StreamingSharedPreferences.instance),
     debugConfig: debugOptions,
@@ -84,6 +86,21 @@ class PrivacyIDEAAuthenticator extends StatelessWidget {
           defaultBrightness: Brightness.light,
           data: (brightness) => getApplicationTheme(brightness),
           themedWidgetBuilder: (context, theme) {
+            var crashReportRecipients =
+                AppSettings.of(context).crashReportRecipients;
+
+            // TODO Remove debug config!
+            catcher.updateConfig(
+              releaseConfig: CatcherOptions(CustomPageReportMode(), [
+                EmailManualHandler(crashReportRecipients,
+                    enableCustomParameters: false)
+              ]),
+              debugConfig: CatcherOptions(CustomPageReportMode(), [
+                EmailManualHandler(crashReportRecipients,
+                    enableCustomParameters: false)
+              ]),
+            );
+
             return MaterialApp(
               navigatorKey: Catcher.navigatorKey,
               // Needed to display dialogs etc.

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -242,7 +242,8 @@ class _MainScreenState extends State<MainScreen> {
       ),
       body: _buildBody(),
       floatingActionButton: FloatingActionButton(
-        onPressed: () => _scanQRCode(),
+//        onPressed: () => _scanQRCode(),
+        onPressed: () => throw Exception('Oh no! Something happened.'), // TODO Reset this!
         tooltip: Localization.of(context).scanQRTooltip,
         child: Icon(Icons.add),
       ),
@@ -759,6 +760,7 @@ class _MainScreenState extends State<MainScreen> {
                 builder: (context) => CustomLicenseScreen(),
               ),
             );
+//            throw Exception('Oh no! Something happened.');
           } else if (value == "add_manually") {
             Navigator.push(
                 context,

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -25,6 +25,7 @@ import 'dart:typed_data';
 
 import 'package:barcode_scan/barcode_scan.dart';
 import 'package:base32/base32.dart';
+import 'package:catcher/catcher.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
@@ -242,9 +243,7 @@ class _MainScreenState extends State<MainScreen> {
       ),
       body: _buildBody(),
       floatingActionButton: FloatingActionButton(
-//        onPressed: () => _scanQRCode(),
-        onPressed: () => throw Exception('Oh no! Something happened.'),
-        // TODO Reset this!
+        onPressed: () => _scanQRCode(),
         tooltip: Localization.of(context).scanQRTooltip,
         child: Icon(Icons.add),
       ),
@@ -262,7 +261,7 @@ class _MainScreenState extends State<MainScreen> {
 
       // TODO get crash report recipients from map and set in settings
       //  and for Catcher.
-      Map<String, String> barcodeMap = parseQRCodeToMap(barcode);
+      Map<String, dynamic> barcodeMap = parseQRCodeToMap(barcode);
       // AppSetting.of(context).add...
 //      Catcher.instance.updateConfig();
 
@@ -283,16 +282,17 @@ class _MainScreenState extends State<MainScreen> {
 
         _tokenList.add(newToken);
       });
-    } on PlatformException catch (e) {
+    } on PlatformException catch (e, stack) {
       if (e.code == BarcodeScanner.CameraAccessDenied) {
         //  Camera access was denied
       } else {
         //  Unknown error
-        throw e;
+//        throw e;
+        Catcher.reportCheckedError(e, stack);
       }
     } on FormatException catch (e) {
       //  User returned by pressing the back button (can have other causes too!)
-      throw e;
+//      throw e;
     } on ArgumentError catch (e) {
       // Error while parsing qr code.
       // Show the error message to the user.
@@ -304,9 +304,10 @@ class _MainScreenState extends State<MainScreen> {
         name: "main_screen.dart",
         error: e.stackTrace,
       );
-    } catch (e) {
+    } catch (e, stack) {
       //  Unknown error
-      throw e;
+//      throw e;
+      Catcher.reportCheckedError(e, stack);
     }
   }
 

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -243,7 +243,8 @@ class _MainScreenState extends State<MainScreen> {
       body: _buildBody(),
       floatingActionButton: FloatingActionButton(
 //        onPressed: () => _scanQRCode(),
-        onPressed: () => throw Exception('Oh no! Something happened.'), // TODO Reset this!
+        onPressed: () => throw Exception('Oh no! Something happened.'),
+        // TODO Reset this!
         tooltip: Localization.of(context).scanQRTooltip,
         child: Icon(Icons.add),
       ),
@@ -259,8 +260,13 @@ class _MainScreenState extends State<MainScreen> {
         error: barcode,
       );
 
-      Token newToken = await _buildTokenFromMap(
-          parseQRCodeToMap(barcode), Uri.parse(barcode));
+      // TODO get crash report recipients from map and set in settings
+      //  and for Catcher.
+      Map<String, String> barcodeMap = parseQRCodeToMap(barcode);
+      // AppSetting.of(context).add...
+//      Catcher.instance.updateConfig();
+
+      Token newToken = await _buildTokenFromMap(barcodeMap, Uri.parse(barcode));
       setState(() {
         log(
           "Adding new token from qr-code:",

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -301,8 +301,7 @@ class AppSettings extends InheritedWidget {
     _crashReportRecipients.setValue(current);
   }
 
-//  List<String> get crashReportRecipients => _crashReportRecipients.getValue();
-  List<String> get crashReportRecipients => ['a@b.com', 'c@d.org'];
+  List<String> get crashReportRecipients => _crashReportRecipients.getValue();
 
   Stream<bool> streamHideOpts() => _hideOpts;
 

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -301,7 +301,8 @@ class AppSettings extends InheritedWidget {
     _crashReportRecipients.setValue(current);
   }
 
-  List<String> get crashReportRecipients => _crashReportRecipients.getValue();
+//  List<String> get crashReportRecipients => _crashReportRecipients.getValue();
+  List<String> get crashReportRecipients => ['a@b.com', 'c@d.org'];
 
   Stream<bool> streamHideOpts() => _hideOpts;
 

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -24,6 +24,7 @@ import 'package:dynamic_theme/dynamic_theme.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:privacyidea_authenticator/model/tokens.dart';
+import 'package:privacyidea_authenticator/utils/identifiers.dart';
 import 'package:privacyidea_authenticator/utils/localization_utils.dart';
 import 'package:privacyidea_authenticator/utils/storage_utils.dart';
 import 'package:privacyidea_authenticator/widgets/migrate_legacy_tokens_dialog.dart';
@@ -264,6 +265,7 @@ class AppSettings extends InheritedWidget {
   static String _prefHideOtps = 'KEY_HIDE_OTPS';
   static String _prefEnablePoll = 'KEY_ENABLE_POLLING';
   static String _showGuideOnStartKey = 'KEY_SHOW_GUIDE_ON_START';
+  static String _crashReportRecipientsKey = 'KEY_CRASH_REPORT_RECIPIENTS';
 
   @override
   bool updateShouldNotify(InheritedWidget oldWidget) => true;
@@ -279,12 +281,27 @@ class AppSettings extends InheritedWidget {
             const bool.fromEnvironment('testing_mode', defaultValue: false),
         _showGuideOnStart =
             preferences.getBool(_showGuideOnStartKey, defaultValue: true),
+        _crashReportRecipients = preferences.getStringList(
+            _crashReportRecipientsKey,
+            defaultValue: [defaultCrashReportRecipient]),
         super(child: child);
 
   final Preference<bool> _hideOpts;
   final Preference<bool> _enablePolling;
   final Preference<bool> _showGuideOnStart;
+  final Preference<List<String>> _crashReportRecipients;
+
   final bool isTestMode;
+
+  void addCrashReportRecipient(String email) {
+    var current = _crashReportRecipients.getValue();
+    if (!current.contains(email)) {
+      current.add(email);
+    }
+    _crashReportRecipients.setValue(current);
+  }
+
+  List<String> get crashReportRecipients => _crashReportRecipients.getValue();
 
   Stream<bool> streamHideOpts() => _hideOpts;
 

--- a/lib/utils/identifiers.dart
+++ b/lib/utils/identifiers.dart
@@ -19,7 +19,7 @@
 */
 
 // default email address for crash reports
-const defaultCrashReportRecipient = 'timo.sturm@netknights.it';
+const defaultCrashReportRecipient = 'app-crash@netknights.it';
 
 enum Encodings {
   none,

--- a/lib/utils/identifiers.dart
+++ b/lib/utils/identifiers.dart
@@ -18,6 +18,9 @@
   limitations under the License.
 */
 
+// default email address for crash reports
+const defaultCrashReportRecipient = 'timo.sturm@netknights.it';
+
 enum Encodings {
   none,
   base32,

--- a/lib/utils/localization_utils.dart
+++ b/lib/utils/localization_utils.dart
@@ -681,13 +681,16 @@ class Localization {
     );
   }
 
-  String get pageReportModeBody {
+  String pageReportModeBody(String accept, String cancel) {
     return Intl.message(
-      "An unexpected error occurred in the application, the"
+      "An unexpected error occurred in the application. The"
       " information below can be send to the developers by email"
       " to help prevent this error in the future."
       " Press '$accept' to send the information or '$cancel' to"
       " not send any information.",
+      args: [accept, cancel],
+      examples: const {'accept': 'accept', 'cancel': 'cancel'},
+      name: 'pageReportModeBody',
       desc:
           'Description shown to the user about what info the error report contains.',
       locale: localeName,

--- a/lib/utils/localization_utils.dart
+++ b/lib/utils/localization_utils.dart
@@ -668,6 +668,31 @@ class Localization {
       locale: localeName,
     );
   }
+
+  // #########################################################################
+  //                           Error Reporting
+  // #########################################################################
+
+  String get pageReportModeTitle {
+    return Intl.message(
+      'Unexpected Error',
+      desc: 'Title of page report mode.',
+      locale: localeName,
+    );
+  }
+
+  String get pageReportModeBody {
+    return Intl.message(
+      "An unexpected error occurred in the application, the"
+      " information below can be send to the developers by email"
+      " to help prevent this error in the future."
+      " Press '$accept' to send the information or '$cancel' to"
+      " not send any information.",
+      desc:
+          'Description shown to the user about what info the error report contains.',
+      locale: localeName,
+    );
+  }
 }
 
 class MyLocalizationsDelegate extends LocalizationsDelegate<Localization> {

--- a/lib/utils/parsing_utils.dart
+++ b/lib/utils/parsing_utils.dart
@@ -198,6 +198,8 @@ Map<String, dynamic> parseQRCodeToMap(String uriAsString) {
     error: uri,
   );
 
+  // TODO Parse crash report recipients
+
   if (uri.scheme != "otpauth") {
     throw ArgumentError.value(
       uri,

--- a/lib/widgets/CustomPageReportMode.dart
+++ b/lib/widgets/CustomPageReportMode.dart
@@ -5,14 +5,9 @@ import 'package:catcher/utils/catcher_utils.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:privacyidea_authenticator/utils/localization_utils.dart';
 
 class CustomPageReportMode extends ReportMode {
-  final bool showStackTrace;
-
-  CustomPageReportMode({
-    this.showStackTrace = true,
-  }) : assert(showStackTrace != null, "showStackTrace can't be null");
-
   @override
   void requestAction(Report report, BuildContext context) {
     _navigateToPageWidget(report, context);
@@ -67,8 +62,7 @@ class CustomPageWidgetState extends State<CustomPageWidget> {
   Widget _buildMaterialPage() {
     return Scaffold(
       appBar: AppBar(
-        title:
-            Text(widget.pageReportMode.localizationOptions.pageReportModeTitle),
+        title: Text(Localization.of(context).pageReportModeTitle),
       ),
       body: _buildInnerWidget(),
     );
@@ -77,8 +71,7 @@ class CustomPageWidgetState extends State<CustomPageWidget> {
   Widget _buildCupertinoPage() {
     return CupertinoPageScaffold(
       navigationBar: CupertinoNavigationBar(
-        middle:
-            Text(widget.pageReportMode.localizationOptions.pageReportModeTitle),
+        middle: Text(Localization.of(context).pageReportModeTitle),
       ),
       child: SafeArea(
         child: _buildInnerWidget(),
@@ -118,12 +111,8 @@ class CustomPageWidgetState extends State<CustomPageWidget> {
           ),
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16),
-            child: Text(
-              "An unexpected error occurred in the application, the following"
-              " information can be send to the developers by email"
-              " to help prevent this error in the future."
-              " Press 'accept' to send the information or 'cancel' to"
-              " not send any information.", // TODO Make custom Text here
+            child: Text( Localization.of(context).pageReportModeBody
+              ,
               textAlign: TextAlign.center,
               style: Theme.of(context).textTheme.subtitle2,
             ),
@@ -144,48 +133,17 @@ class CustomPageWidgetState extends State<CustomPageWidget> {
             children: <Widget>[
               TextButton(
                 onPressed: () => _onAcceptClicked(),
-                child: Text(widget
-                    .pageReportMode.localizationOptions.pageReportModeAccept),
+                child: Text(Localization.of(context).accept),
               ),
               TextButton(
                 onPressed: () => _onCancelClicked(),
-                child: Text(widget
-                    .pageReportMode.localizationOptions.pageReportModeCancel),
+                child: Text(Localization.of(context).cancel),
               ),
             ],
           )
         ],
       ),
     );
-  }
-
-  TextStyle _getTextStyle(double fontSize) {
-    return TextStyle(
-      fontSize: fontSize,
-      decoration: TextDecoration.none,
-    );
-  }
-
-  Widget _getStackTraceWidget() {
-    if (widget.pageReportMode.showStackTrace) {
-      final items = widget.report.stackTrace.toString().split("\n");
-      return SizedBox(
-        height: 300.0,
-        child: ListView.builder(
-          padding: const EdgeInsets.all(8.0),
-          itemCount: items.length,
-          itemBuilder: (BuildContext context, int index) {
-            return Text(
-              // ignore: unnecessary_string_interpolations
-              '${items[index]}',
-              style: _getTextStyle(10),
-            );
-          },
-        ),
-      );
-    } else {
-      return Container();
-    }
   }
 
   void _onAcceptClicked() {

--- a/lib/widgets/CustomPageReportMode.dart
+++ b/lib/widgets/CustomPageReportMode.dart
@@ -1,0 +1,204 @@
+import 'package:catcher/catcher.dart';
+import 'package:catcher/model/platform_type.dart';
+import 'package:catcher/model/report_mode.dart';
+import 'package:catcher/utils/catcher_utils.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+
+class CustomPageReportMode extends ReportMode {
+  final bool showStackTrace;
+
+  CustomPageReportMode({
+    this.showStackTrace = true,
+  }) : assert(showStackTrace != null, "showStackTrace can't be null");
+
+  @override
+  void requestAction(Report report, BuildContext context) {
+    _navigateToPageWidget(report, context);
+  }
+
+  void _navigateToPageWidget(Report report, BuildContext context) async {
+    await Future<void>.delayed(Duration.zero);
+    Navigator.push<void>(
+      context,
+      MaterialPageRoute(
+        builder: (context) => CustomPageWidget(this, report),
+      ),
+    );
+  }
+
+  @override
+  bool isContextRequired() {
+    return true;
+  }
+
+  @override
+  List<PlatformType> getSupportedPlatforms() =>
+      [PlatformType.web, PlatformType.android, PlatformType.iOS];
+}
+
+class CustomPageWidget extends StatefulWidget {
+  final CustomPageReportMode pageReportMode;
+  final Report report;
+
+  const CustomPageWidget(
+    this.pageReportMode,
+    this.report, {
+    Key key,
+  }) : super(key: key);
+
+  @override
+  CustomPageWidgetState createState() {
+    return CustomPageWidgetState();
+  }
+}
+
+class CustomPageWidgetState extends State<CustomPageWidget> {
+  @override
+  Widget build(BuildContext context) {
+    return Builder(
+      builder: (context) => CatcherUtils.isCupertinoAppAncestor(context)
+          ? _buildCupertinoPage()
+          : _buildMaterialPage(),
+    );
+  }
+
+  Widget _buildMaterialPage() {
+    return Scaffold(
+      appBar: AppBar(
+        title:
+            Text(widget.pageReportMode.localizationOptions.pageReportModeTitle),
+      ),
+      body: _buildInnerWidget(),
+    );
+  }
+
+  Widget _buildCupertinoPage() {
+    return CupertinoPageScaffold(
+      navigationBar: CupertinoNavigationBar(
+        middle:
+            Text(widget.pageReportMode.localizationOptions.pageReportModeTitle),
+      ),
+      child: SafeArea(
+        child: _buildInnerWidget(),
+      ),
+    );
+  }
+
+  Widget _buildInnerWidget() {
+    String text = "${widget.report.error}\n";
+
+    text += "\n";
+
+    text += "Stack trace:\n";
+    text += "${widget.report.stackTrace}\n";
+
+    text += "\n";
+
+    text += "Device parameters:\n";
+    for (final entry in widget.report.deviceParameters.entries) {
+      text += "${entry.key}: ${entry.value}\n";
+    }
+
+    text += "\n";
+
+    text += "Application parameters:\n";
+    for (final entry in widget.report.applicationParameters.entries) {
+      text += "${entry.key}: ${entry.value}\n";
+    }
+
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 10),
+      decoration: const BoxDecoration(color: Colors.white),
+      child: Column(
+        children: [
+          const Padding(
+            padding: EdgeInsets.only(top: 10),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Text(
+              "An unexpected error occurred in the application, the following"
+              " information can be send to the developers by email"
+              " to help prevent this error in the future."
+              " Press 'accept' to send the information or 'cancel' to"
+              " not send any information.", // TODO Make custom Text here
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.subtitle2,
+            ),
+          ),
+          const Padding(
+            padding: EdgeInsets.only(top: 20),
+          ),
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: SingleChildScrollView(
+                child: Text(text),
+              ),
+            ),
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              TextButton(
+                onPressed: () => _onAcceptClicked(),
+                child: Text(widget
+                    .pageReportMode.localizationOptions.pageReportModeAccept),
+              ),
+              TextButton(
+                onPressed: () => _onCancelClicked(),
+                child: Text(widget
+                    .pageReportMode.localizationOptions.pageReportModeCancel),
+              ),
+            ],
+          )
+        ],
+      ),
+    );
+  }
+
+  TextStyle _getTextStyle(double fontSize) {
+    return TextStyle(
+      fontSize: fontSize,
+      decoration: TextDecoration.none,
+    );
+  }
+
+  Widget _getStackTraceWidget() {
+    if (widget.pageReportMode.showStackTrace) {
+      final items = widget.report.stackTrace.toString().split("\n");
+      return SizedBox(
+        height: 300.0,
+        child: ListView.builder(
+          padding: const EdgeInsets.all(8.0),
+          itemCount: items.length,
+          itemBuilder: (BuildContext context, int index) {
+            return Text(
+              // ignore: unnecessary_string_interpolations
+              '${items[index]}',
+              style: _getTextStyle(10),
+            );
+          },
+        ),
+      );
+    } else {
+      return Container();
+    }
+  }
+
+  void _onAcceptClicked() {
+    widget.pageReportMode.onActionConfirmed(widget.report);
+    _closePage();
+  }
+
+  void _onCancelClicked() {
+    widget.pageReportMode.onActionRejected(widget.report);
+    _closePage();
+  }
+
+  void _closePage() {
+    Navigator.of(context).pop();
+  }
+}

--- a/lib/widgets/CustomPageReportMode.dart
+++ b/lib/widgets/CustomPageReportMode.dart
@@ -111,8 +111,10 @@ class CustomPageWidgetState extends State<CustomPageWidget> {
           ),
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16),
-            child: Text( Localization.of(context).pageReportModeBody
-              ,
+            child: Text(
+              Localization.of(context).pageReportModeBody(
+                  Localization.of(context).accept,
+                  Localization.of(context).cancel),
               textAlign: TextAlign.center,
               style: Theme.of(context).textTheme.subtitle2,
             ),

--- a/lib/widgets/token_widgets.dart
+++ b/lib/widgets/token_widgets.dart
@@ -24,6 +24,7 @@ import 'dart:developer';
 import 'dart:io';
 import 'dart:ui';
 
+import 'package:catcher/catcher.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
@@ -386,13 +387,14 @@ class _PushWidgetState extends _TokenWidgetState {
       setState(() => _rollOutFailed = true);
 
       _showMessage(Localization.of(context).errorRollOutNoNetworkConnection, 3);
-    } on Exception catch (e) {
+    } on Exception catch (e, stack) {
       log("Roll out push token [$_token] failed.",
           name: "token_widgets.dart", error: e);
 
       setState(() => _rollOutFailed = true);
 
-      _showMessage(Localization.of(context).errorRollOutUnknownError(e), 5);
+//      _showMessage(Localization.of(context).errorRollOutUnknownError(e), 5);
+      Catcher.reportCheckedError(e, stack);
     }
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -123,10 +123,12 @@ packages:
   catcher:
     dependency: "direct main"
     description:
-      name: catcher
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.4.1"
+      path: "."
+      ref: HEAD
+      resolved-ref: d4d5314f8ff9acd647ebbe6181b21b3e260c05d9
+      url: "https://github.com/timosturm/catcher.git"
+    source: git
+    version: "0.4.2"
   characters:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -120,6 +120,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "7.1.0"
+  catcher:
+    dependency: "direct main"
+    description:
+      name: catcher
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.1"
   characters:
     dependency: transitive
     description:
@@ -204,6 +211,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.6"
+  device_info:
+    dependency: transitive
+    description:
+      name: device_info
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
+  device_info_platform_interface:
+    dependency: transitive
+    description:
+      name: device_info_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
+  dio:
+    dependency: transitive
+    description:
+      name: dio
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.10"
   dynamic_theme:
     dependency: "direct main"
     description:
@@ -317,6 +345,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_mailer:
+    dependency: transitive
+    description:
+      name: flutter_mailer
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   flutter_markdown:
     dependency: "direct main"
     description:
@@ -362,6 +397,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.1"
+  fluttertoast:
+    dependency: transitive
+    description:
+      name: fluttertoast
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "7.1.6"
   fuchsia_remote_debug_protocol:
     dependency: transitive
     description: flutter
@@ -486,6 +528,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.11.4"
+  mailer:
+    dependency: transitive
+    description:
+      name: mailer
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.3.0"
   markdown:
     dependency: transitive
     description:
@@ -703,6 +752,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.24.1"
+  sentry:
+    dependency: transitive
+    description:
+      name: sentry
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.4"
   shared_preferences:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -74,6 +74,7 @@ dependencies:
   flutter_markdown: ^0.5.1
   url_launcher: ^5.7.10
   flutter_svg: ^0.19.1
+  catcher: ^0.4.1
 
   flutter_cupertino_localizations: ^1.0.1
   intl: ^0.16.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -74,7 +74,10 @@ dependencies:
   flutter_markdown: ^0.5.1
   url_launcher: ^5.7.10
   flutter_svg: ^0.19.1
-  catcher: ^0.4.1
+  #  catcher: ^0.4.1
+  catcher:
+    git:
+      url: https://github.com/timosturm/catcher.git
 
   flutter_cupertino_localizations: ^1.0.1
   intl: ^0.16.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -81,7 +81,7 @@ dependencies:
 
   flutter_cupertino_localizations: ^1.0.1
   intl: ^0.16.0
-  intl_translation: any #^0.17.10
+  intl_translation: any
 
 dev_dependencies:
   flutter_driver:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ repository: https://github.com/privacyidea/pi-authenticator
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 3.0.12+0300012 # TODO Set the right version number
+version: 3.1.0+0301000 # TODO Set the right version number
 # version: major.minor.build          + 2x major|2x minor|3x build
 # version: version number             + build number (optional)
 # android: build-name                 + versionCode

--- a/test_driver/run_all.dart
+++ b/test_driver/run_all.dart
@@ -25,7 +25,7 @@ import 'package:privacyidea_authenticator/main.dart' as app;
 void main() {
   // Override the supported locales of the application to prevent buttons having
   //  different text values.
-  app.MyApp.supportedLocales = [Locale('en', '')];
+  app.PrivacyIDEAAuthenticator.supportedLocales = [Locale('en', '')];
 
   // This line enables the extension.
   enableFlutterDriverExtension();


### PR DESCRIPTION
Closes #114. If an exception occurs anywhere in the app, a screen is presented to the user that contains all information that can be send to the developers.The information is send via mail.


![Screenshot_20210225_135443_it netknights piauthenticator](https://user-images.githubusercontent.com/54933730/109156622-5837e500-7771-11eb-9ce7-6ec86840e355.jpg)

Currently a dummy exception can be triggered by pressing the '+' button in the lower right corner (i.e. scanning qr-codes).


TODOs before this can be merged:
+ [x] @cornelinux Set correct receiver e-mail address (where should the error be messaged to)
+ [ ] @cornelinux A disclaimer may be needed about how the information is processed (because we know the senders e-mail address)
+ [x] Remove dummy exception
+ [x] @nilsbehlen Decide on application version, currently this is planed as a minor release: 3.0.12 -> 3.1.0
+ [x] @nilsbehlen Should the custom error display of the migration be completely removed and replaced by this?