### PR TITLE
Fix parsing error of label and issuer of tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed attempt ui update on non-existing elements
+- Fixed parsing of token issuer and label
 
 ## [3.1.0] - 2021-02-09
 

--- a/lib/model/tokens.dart
+++ b/lib/model/tokens.dart
@@ -46,7 +46,7 @@ abstract class Token {
 
   String get id => _id;
 
-  String get issuer => _issuer == null ? "" : Uri.decodeFull(_issuer);
+  String get issuer => _issuer == null ? "" : _issuer;
 
   Token(this._label, this._issuer, this._id, this.type);
 

--- a/lib/model/tokens.dart
+++ b/lib/model/tokens.dart
@@ -38,7 +38,7 @@ abstract class Token {
 
   String get tokenVersion => _tokenVersion;
 
-  String get label => _label == null ? "" : Uri.decodeFull(_label);
+  String get label => _label == null ? "" : _label;
 
   set label(String label) {
     this._label = label;

--- a/lib/utils/parsing_utils.dart
+++ b/lib/utils/parsing_utils.dart
@@ -239,8 +239,7 @@ Map<String, dynamic> parsePiAuth(Uri uri) {
   Map<String, dynamic> uriMap = Map();
 
   uriMap[URI_TYPE] = uri.host;
-
-  uriMap[URI_ISSUER] = Uri.decodeFull(uri.queryParameters['issuer']);
+  uriMap[URI_ISSUER] = _parseIssuer(uri);
 
   // If we do not support the version of this piauth url, we can stop here.
   String pushVersionAsString = uri.queryParameters["v"];
@@ -326,7 +325,7 @@ Map<String, dynamic> parseOtpAuth(Uri uri) {
 
   // parse.host -> Type totp or hotp
   uriMap[URI_TYPE] = uri.host;
-  uriMap[URI_ISSUER] = Uri.decodeFull(uri.queryParameters['issuer']);
+  uriMap[URI_ISSUER] = _parseIssuer(uri);
 
 // parse.path.substring(1) -> Label
   log("Key: [..] | Value: [..]");
@@ -468,7 +467,29 @@ Map<String, dynamic> parseOtpAuth(Uri uri) {
 }
 
 String _parseLabel(Uri uri) {
-  return Uri.decodeFull(uri.path.substring(1));
+  String label;
+  String param = uri.path.substring(1);
+
+  try {
+    label = Uri.decodeFull(param);
+  } on ArgumentError {
+    label = param;
+  }
+
+  return label;
+}
+
+String _parseIssuer(Uri uri) {
+  String issuer;
+  String param = uri.queryParameters['issuer'];
+
+  try {
+    issuer = Uri.decodeFull(param);
+  } on ArgumentError {
+    issuer = param;
+  }
+
+  return issuer;
 }
 
 bool is2StepURI(Uri uri) {


### PR DESCRIPTION
This issue seems to have originated from renaming tokens. This is most likely also the reason for an error when attempting to save the token.

Closes #126 