### PR TITLE
Added language setting

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -482,5 +482,23 @@
     "description": "Tells the user that the roll-out failed because no network connection is available.",
     "type": "text",
     "placeholders": {}
+  },
+  "useDeviceLocaleTitle": "Nutze Systemsprache",
+  "@useDeviceLocaleTitle": {
+    "description": "Title of the switch tile where using the devices language can be enabled.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "useDeviceLocaleDescription": "Nutze Systemsprache, falls diese unterstützt wird. Anderenfalls nutze Englisch. ",
+  "@useDeviceLocaleDescription": {
+    "description": "Description of the switch tile where using the devices language can be enabled.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "language": "Sprache",
+  "@language": {
+    "description": "Title of language setting group.",
+    "type": "text",
+    "placeholders": {}
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -482,5 +482,23 @@
     "description": "Tells the user that the roll-out failed because no network connection is available.",
     "type": "text",
     "placeholders": {}
+  },
+  "useDeviceLocaleTitle": "Use device language",
+  "@useDeviceLocaleTitle": {
+    "description": "Title of the switch tile where using the devices language can be enabled.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "useDeviceLocaleDescription": "Use device language if it is supported, otherwise default to english.",
+  "@useDeviceLocaleDescription": {
+    "description": "Description of the switch tile where using the devices language can be enabled.",
+    "type": "text",
+    "placeholders": {}
+  },
+  "language": "Language",
+  "@language": {
+    "description": "Title of language setting group.",
+    "type": "text",
+    "placeholders": {}
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -80,15 +80,37 @@ class PrivacyIDEAAuthenticator extends StatelessWidget {
               ]),
             );
 
-            return MaterialApp(
-              navigatorKey: Catcher.navigatorKey,
-              localizationsDelegates: AppLocalizations.localizationsDelegates,
-              supportedLocales: AppLocalizations.supportedLocales,
-              title: applicationName,
-              theme: lightThemeData,
-              darkTheme: darkThemeData,
-              themeMode: EasyDynamicTheme.of(context).themeMode,
-              home: MainScreen(title: applicationName),
+            return StreamBuilder<bool>(
+              stream: AppSettings.of(context).streamUseSystemLocale(),
+              builder: (context, snapshot) {
+                bool useSystemLocale = true;
+                if (snapshot.hasData) {
+                  useSystemLocale = snapshot.data!;
+                }
+
+                return StreamBuilder<Locale>(
+                  stream: AppSettings.of(context).streamLocalePreference(),
+                  builder: (context, snapshot) {
+                    Locale? locale;
+                    if (!useSystemLocale && snapshot.hasData) {
+                      locale = snapshot.data!;
+                    }
+
+                    return MaterialApp(
+                      navigatorKey: Catcher.navigatorKey,
+                      localizationsDelegates:
+                          AppLocalizations.localizationsDelegates,
+                      supportedLocales: AppLocalizations.supportedLocales,
+                      locale: locale,
+                      title: applicationName,
+                      theme: lightThemeData,
+                      darkTheme: darkThemeData,
+                      themeMode: EasyDynamicTheme.of(context).themeMode,
+                      home: MainScreen(title: applicationName),
+                    );
+                  },
+                );
+              },
             );
           },
         ),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -84,7 +84,7 @@ class SettingsScreenState extends State<SettingsScreen> {
             ),
             Divider(),
             SettingsGroup(
-              title: 'Language', // TODO Translate
+              title: AppLocalizations.of(context)!.language,
               children: [
                 StreamBuilder<bool>(
                   stream: AppSettings.of(context).streamUseSystemLocale(),
@@ -100,12 +100,10 @@ class SettingsScreenState extends State<SettingsScreen> {
                     }
 
                     return SwitchListTile(
-                        // title:
-                        // Text(Localization.of(context).useDeviceLocaleTitle),
-                        // subtitle: Text(Localization.of(context)
-                        //     .useDeviceLocaleDescription),
-                        title: Text('Use device locale'), // TODO Translate
-                        subtitle: Text('Description'), // TODO Translate
+                        title: Text(
+                            AppLocalizations.of(context)!.useDeviceLocaleTitle),
+                        subtitle: Text(AppLocalizations.of(context)!
+                            .useDeviceLocaleDescription),
                         value: isActive,
                         onChanged: onChanged);
                   },

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -256,6 +256,8 @@ class AppSettings extends InheritedWidget {
   static String _prefEnablePoll = 'KEY_ENABLE_POLLING';
   static String _showGuideOnStartKey = 'KEY_SHOW_GUIDE_ON_START';
   static String _crashReportRecipientsKey = 'KEY_CRASH_REPORT_RECIPIENTS';
+  static String _localePreferenceKey = 'KEY_LOCALE_PREFERENCE';
+  static String _useSystemLocaleKey = 'KEY_USE_SYSTEM_LOCALE';
 
   @override
   bool updateShouldNotify(InheritedWidget oldWidget) => true;
@@ -275,12 +277,18 @@ class AppSettings extends InheritedWidget {
         _crashReportRecipients = preferences.getStringList(
             _crashReportRecipientsKey,
             defaultValue: [defaultCrashReportRecipient]),
+        _localePreference = preferences.getString(_localePreferenceKey,
+            defaultValue: _encodeLocale(AppLocalizations.supportedLocales[0])),
+        _useSystemLocale =
+            preferences.getBool(_useSystemLocaleKey, defaultValue: true),
         super(child: child);
 
   final Preference<bool> _hideOpts;
   final Preference<bool> _enablePolling;
   final Preference<bool> _showGuideOnStart;
   final Preference<List<String>> _crashReportRecipients;
+  final Preference<String> _localePreference;
+  final Preference<bool> _useSystemLocale;
 
   final bool isTestMode;
 
@@ -307,4 +315,28 @@ class AppSettings extends InheritedWidget {
   set showGuideOnStart(bool value) => _showGuideOnStart.setValue(value);
 
   Stream<bool> showGuideOnStartStream() => _showGuideOnStart;
+
+  void setLocalePreference(Locale locale) =>
+      _localePreference.setValue(_encodeLocale(locale));
+
+  Locale getLocalePreference() => _decodeLocale(_localePreference.getValue());
+
+  Stream<Locale> streamLocalePreference() {
+    return _localePreference.map((String str) => _decodeLocale(str));
+  }
+
+  Stream<bool> streamUseSystemLocale() => _useSystemLocale;
+
+  bool getUseSystemLocale() => _useSystemLocale.getValue();
+
+  void setUseSystemLocale(bool value) => _useSystemLocale.setValue(value);
+
+  static String _encodeLocale(Locale locale) {
+    return '${locale.languageCode}#${locale.countryCode}';
+  }
+
+  static Locale _decodeLocale(String str) {
+    var split = str.split('#');
+    return split[1] == "null" ? Locale(split[0]) : Locale(split[0], split[1]);
+  }
 }

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -82,6 +82,92 @@ class SettingsScreenState extends State<SettingsScreen> {
                 ),
               ],
             ),
+            Divider(),
+            SettingsGroup(
+              title: 'Language', // TODO Translate
+              children: [
+                StreamBuilder<bool>(
+                  stream: AppSettings.of(context).streamUseSystemLocale(),
+                  builder: (context, snapshot) {
+                    bool isActive = true;
+                    var onChanged; // TODO What is this?
+
+                    if (snapshot.hasData) {
+                      isActive = snapshot.data!;
+                      onChanged = (value) {
+                        AppSettings.of(context).setUseSystemLocale(value);
+                      };
+                    }
+
+                    return SwitchListTile(
+                        // title:
+                        // Text(Localization.of(context).useDeviceLocaleTitle),
+                        // subtitle: Text(Localization.of(context)
+                        //     .useDeviceLocaleDescription),
+                        title: Text('Use device locale'), // TODO Translate
+                        subtitle: Text('Description'), // TODO Translate
+                        value: isActive,
+                        onChanged: onChanged);
+                  },
+                ),
+                StreamBuilder<bool>(
+                  stream: AppSettings.of(context).streamUseSystemLocale(),
+                  builder: (context, snapshot) {
+                    bool enableDropDown = false;
+                    var onChanged; // TODO What is this?
+
+                    if (snapshot.hasData) {
+                      enableDropDown = !snapshot.data!;
+                    }
+
+                    if (enableDropDown) {
+                      onChanged = (Locale? locale) {
+                        AppSettings.of(context).setLocalePreference(locale!);
+                      };
+                    }
+
+                    return StreamBuilder<Locale>(
+                      stream: AppSettings.of(context).streamLocalePreference(),
+                      builder: (context, snapshot) {
+                        if (!snapshot.hasData || snapshot.hasError) {
+                          return Placeholder();
+                        } else {
+                          print(snapshot.data);
+                          return Padding(
+                            padding: EdgeInsets.symmetric(horizontal: 20),
+                            child: DropdownButton<Locale>(
+                              disabledHint: Text(
+                                "${snapshot.data}",
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .subtitle1!
+                                    .copyWith(color: Colors.grey),
+                              ),
+                              isExpanded: true,
+                              value: snapshot.data,
+                              // Initial value and current value
+                              items: AppLocalizations.supportedLocales
+                                  .map<DropdownMenuItem<Locale>>(
+                                      (Locale value) {
+                                return DropdownMenuItem<Locale>(
+                                  value: value,
+                                  child: Text(
+                                    "$value",
+                                    style:
+                                        Theme.of(context).textTheme.subtitle1,
+                                  ),
+                                );
+                              }).toList(),
+                              onChanged: onChanged,
+                            ),
+                          );
+                        }
+                      },
+                    );
+                  },
+                ),
+              ],
+            ),
             FutureBuilder<List<Token>>(
               initialData: [],
               future: StorageUtil.loadAllTokens(),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -90,7 +90,7 @@ class SettingsScreenState extends State<SettingsScreen> {
                   stream: AppSettings.of(context).streamUseSystemLocale(),
                   builder: (context, snapshot) {
                     bool isActive = true;
-                    var onChanged; // TODO What is this?
+                    ValueChanged<bool>? onChanged;
 
                     if (snapshot.hasData) {
                       isActive = snapshot.data!;
@@ -112,7 +112,7 @@ class SettingsScreenState extends State<SettingsScreen> {
                   stream: AppSettings.of(context).streamUseSystemLocale(),
                   builder: (context, snapshot) {
                     bool enableDropDown = false;
-                    var onChanged; // TODO What is this?
+                    ValueChanged<Locale?>? onChanged;
 
                     if (snapshot.hasData) {
                       enableDropDown = !snapshot.data!;


### PR DESCRIPTION
This allows the user to manually change the language from the settings.
The user can either chose to use the system default (defaults to English if that one is not supported) or chose from one of the supported languages. The language change is reflected in an instance.

To not further complicate the switch from v3.1+ to v3.2+ this is not supported in an older version of the app.

Closes #74