### PR TITLE
Enable automatic polling on iOS devices as default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Changed android api target level to 30
 - Subject of error reports now start with version number
-- Enable automatic polling per default on iOS devices (to fix missing push challenges)
+- Enable automatic polling per default on all devices (to fix missing push challenges on iOS)
 
 ## [3.1.3] - 2021-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Changed android api target level to 30
 - Subject of error reports now start with version number
+- Enable automatic polling per default on iOS devices (to fix missing push challenges)
 
 ## [3.1.3] - 2021-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Changed android api target level to 30
 - Subject of error reports now start with version number
 - Enable automatic polling per default on all devices (to fix missing push challenges on iOS)
+- Reduced automatic polling interval to three (3) seconds
 
 ## [3.1.3] - 2021-06-24
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,6 +18,8 @@
   limitations under the License.
 */
 
+import 'dart:io';
+
 import 'package:catcher/catcher.dart';
 import 'package:dynamic_theme/dynamic_theme.dart';
 import 'package:flutter/cupertino.dart';
@@ -82,8 +84,13 @@ class PrivacyIDEAAuthenticator extends StatelessWidget {
           defaultBrightness: Brightness.light,
           data: (brightness) => getApplicationTheme(brightness),
           themedWidgetBuilder: (context, theme) {
-            var crashReportRecipients =
-                AppSettings.of(context).crashReportRecipients;
+            final settings = AppSettings.of(context);
+
+            var crashReportRecipients = settings.crashReportRecipients;
+
+            if (Platform.isIOS && settings.isFirstRun) {
+              settings.enablePolling = true;
+            }
 
             // Override release config to use custom e-mail recipients
             Catcher.instance.updateConfig(
@@ -92,6 +99,9 @@ class PrivacyIDEAAuthenticator extends StatelessWidget {
                     enableCustomParameters: false)
               ]),
             );
+
+            // Update indicator after al setup code is done.
+            settings.isFirstRun = false;
 
             return MaterialApp(
               navigatorKey: Catcher.navigatorKey,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -88,7 +88,7 @@ class PrivacyIDEAAuthenticator extends StatelessWidget {
 
             var crashReportRecipients = settings.crashReportRecipients;
 
-            if (Platform.isIOS && settings.isFirstRun) {
+            if (settings.isFirstRun) {
               settings.enablePolling = true;
             }
 

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -85,7 +85,7 @@ class _MainScreenState extends State<MainScreen> {
           if (event) {
             log('Polling is enabled.', name: 'main_screen.dart');
             _pollTimer = Timer.periodic(
-                Duration(seconds: 10), (_) => _pollForRequests());
+                Duration(seconds: 3), (_) => _pollForRequests());
             _pollForRequests();
           } else {
             log('Polling is disabled.', name: 'main_screen.dart');

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -191,7 +191,7 @@ class _MainScreenState extends State<MainScreen> {
     if (pushTokens.isEmpty) {
       log('No push token is available for polling, polling is disabled.',
           name: 'main_screen.dart');
-      AppSettings.of(context).setEnablePolling(false);
+      AppSettings.of(context).enablePolling = false;
       return;
     }
 

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -277,7 +277,7 @@ class AppSettings extends InheritedWidget {
   AppSettings({Widget child, StreamingSharedPreferences preferences})
       : _hideOpts = preferences.getBool(_prefHideOtps, defaultValue: false),
         _enablePolling =
-            preferences.getBool(_prefEnablePoll, defaultValue: false),
+            preferences.getBool(_prefEnablePoll, defaultValue: true),
         isTestMode =
             const bool.fromEnvironment('testing_mode', defaultValue: false),
         _showGuideOnStart =

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -138,7 +138,7 @@ class SettingsScreenState extends State<SettingsScreen> {
                               element.isRolledOut && element.url != null)) {
                             // Set onChange to activate switch in ui.
                             onChange = (value) =>
-                                AppSettings.of(context).setEnablePolling(value);
+                                AppSettings.of(context).enablePolling = value;
                           }
 
                           Widget title = RichText(
@@ -266,6 +266,7 @@ class AppSettings extends InheritedWidget {
   static String _prefEnablePoll = 'KEY_ENABLE_POLLING';
   static String _showGuideOnStartKey = 'KEY_SHOW_GUIDE_ON_START';
   static String _crashReportRecipientsKey = 'KEY_CRASH_REPORT_RECIPIENTS';
+  static String _isFirstRunKey = 'KEY_IS_FIRST_RUN';
 
   @override
   bool updateShouldNotify(InheritedWidget oldWidget) => true;
@@ -284,8 +285,10 @@ class AppSettings extends InheritedWidget {
         _crashReportRecipients = preferences.getStringList(
             _crashReportRecipientsKey,
             defaultValue: [defaultCrashReportRecipient]),
+        _isFirstRun = preferences.getBool(_isFirstRunKey, defaultValue: true),
         super(child: child);
 
+  final Preference<bool> _isFirstRun;
   final Preference<bool> _hideOpts;
   final Preference<bool> _enablePolling;
   final Preference<bool> _showGuideOnStart;
@@ -303,13 +306,17 @@ class AppSettings extends InheritedWidget {
 
   List<String> get crashReportRecipients => _crashReportRecipients.getValue();
 
+  set isFirstRun(bool value) => _isFirstRun.setValue(value);
+
+  bool get isFirstRun => _isFirstRun.getValue();
+
   Stream<bool> streamHideOpts() => _hideOpts;
 
   Stream<bool> streamEnablePolling() => _enablePolling;
 
-  void setHideOpts(bool value) => _hideOpts.setValue(value);
+  void set hideOTPs(bool value) => _hideOpts.setValue(value);
 
-  void setEnablePolling(bool value) => _enablePolling.setValue(value);
+  void set enablePolling(bool value) => _enablePolling.setValue(value);
 
   bool get showGuideOnStart => _showGuideOnStart.getValue();
 


### PR DESCRIPTION
On all iOS devices, automatic polling will be enabled as default (for new and existing installs). This is a workaround for the missing push challenges (see #180).

Closes #180