### PR TITLE
Fix null check operator usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
 - Enable automatic polling per default on all devices (to fix missing push challenges on iOS)
 - Reduced automatic polling interval to three (3) seconds
 
+
+### Fixed
+
+- Added fix for null check operator being used on null value in the animation controller for TOTP tokens
+
 ## [3.1.3] - 2021-06-24
 
 ### Added

--- a/lib/widgets/token_widgets.dart
+++ b/lib/widgets/token_widgets.dart
@@ -806,7 +806,7 @@ class _HotpWidgetState extends _OTPTokenWidgetState {
 class _TotpWidgetState extends _OTPTokenWidgetState
     with SingleTickerProviderStateMixin {
   AnimationController
-      controller; // Controller for animating the LinearProgressAnimator
+      _controller; // Controller for animating the LinearProgressAnimator
 
   TOTPToken get _token => super._token as TOTPToken;
 
@@ -831,7 +831,7 @@ class _TotpWidgetState extends _OTPTokenWidgetState
   void initState() {
     super.initState();
 
-    controller = AnimationController(
+    _controller = AnimationController(
       duration: Duration(seconds: _token.period),
       // Animate the progress for the duration of the tokens period.
       vsync: this,
@@ -844,7 +844,7 @@ class _TotpWidgetState extends _OTPTokenWidgetState
       ..addStatusListener((status) {
         // Add listener to restart the animation after the period, also updates the otp value.
         if (status == AnimationStatus.completed) {
-          controller?.forward(from: _getCurrentProgress());
+          _controller?.forward(from: _getCurrentProgress());
           _updateOtpValue();
         }
       })
@@ -860,14 +860,18 @@ class _TotpWidgetState extends _OTPTokenWidgetState
       );
       if (msg == AppLifecycleState.resumed.toString()) {
         _updateOtpValue();
-        controller?.forward(from: _getCurrentProgress());
+        _controller?.forward(from: _getCurrentProgress());
       }
     });
   }
 
   @override
   void dispose() {
-    controller?.dispose(); // Dispose the controller to prevent memory leak.
+    _controller?.dispose(); // Dispose the controller to prevent memory leak.
+    // Set controller to null to prevent it being used after disposing.
+    // This may occur on state changes of the application and cause exceptions
+    // even if the widget was disposed.
+    _controller = null;
     super.dispose();
   }
 
@@ -887,7 +891,7 @@ class _TotpWidgetState extends _OTPTokenWidgetState
           ),
         ),
         LinearProgressIndicator(
-          value: controller?.value,
+          value: _controller?.value,
         ),
       ],
     );


### PR DESCRIPTION
This hopefully fixes #185. Because the animation controller was called on certain life-cycle events it could be called after being disposed of. This most likely caused the error.

Closes #185 