### PR TITLE
Suggestion: new token overview

### DIFF
--- a/lib/views/main_view/main_view_widgets/drag_target_divider.dart
+++ b/lib/views/main_view/main_view_widgets/drag_target_divider.dart
@@ -51,6 +51,8 @@ class _DragTargetDividerState<T extends SortableMixin> extends ConsumerState<Dra
 
   @override
   Widget build(BuildContext context) {
+    Color dividerColor = Colors.transparent;
+
     final body = DragTarget(
       onWillAccept: (data) {
         if (data is T == false) return false;
@@ -116,9 +118,11 @@ class _DragTargetDividerState<T extends SortableMixin> extends ConsumerState<Dra
       },
       builder: (context, accepted, rejected) {
         final dividerHeight = expansionController.value * 40 + 1.5;
+        dividerColor = accepted.isNotEmpty ? Theme.of(context).dividerColor : Colors.transparent;
         return Container(
           height: dividerHeight,
           decoration: BoxDecoration(
+            color: dividerColor,
             borderRadius: BorderRadius.circular(dividerHeight / 4),
           ),
           margin: EdgeInsets.only(left: 8 - expansionController.value * 2, right: 8 - expansionController.value * 2, top: 8, bottom: 8),

--- a/lib/views/main_view/main_view_widgets/drag_target_divider.dart
+++ b/lib/views/main_view/main_view_widgets/drag_target_divider.dart
@@ -119,7 +119,6 @@ class _DragTargetDividerState<T extends SortableMixin> extends ConsumerState<Dra
         return Container(
           height: dividerHeight,
           decoration: BoxDecoration(
-            color: Theme.of(context).dividerColor,
             borderRadius: BorderRadius.circular(dividerHeight / 4),
           ),
           margin: EdgeInsets.only(left: 8 - expansionController.value * 2, right: 8 - expansionController.value * 2, top: 8, bottom: 8),

--- a/lib/views/main_view/main_view_widgets/main_view_tokens_list.dart
+++ b/lib/views/main_view/main_view_widgets/main_view_tokens_list.dart
@@ -86,7 +86,7 @@ class _MainViewTokensListState extends ConsumerState<MainViewTokensList> {
     if (sortables.isEmpty) return [];
     sortables.sort((a, b) => a.compareTo(b));
     // just for small space between appBar and first element
-    widgets.add(const SizedBox(height: 20));
+    widgets.add(const SizedBox(height: 2));
     for (var i = 0; i < sortables.length; i++) {
       final isFirst = i == 0;
       final isDraggingTheCurrent = draggingSortable == sortables[i];

--- a/lib/views/main_view/main_view_widgets/main_view_tokens_list.dart
+++ b/lib/views/main_view/main_view_widgets/main_view_tokens_list.dart
@@ -85,6 +85,8 @@ class _MainViewTokensListState extends ConsumerState<MainViewTokensList> {
     List<Widget> widgets = [];
     if (sortables.isEmpty) return [];
     sortables.sort((a, b) => a.compareTo(b));
+    // just for small space between appBar and first element
+    widgets.add(const SizedBox(height: 20));
     for (var i = 0; i < sortables.length; i++) {
       final isFirst = i == 0;
       final isDraggingTheCurrent = draggingSortable == sortables[i];

--- a/lib/views/main_view/main_view_widgets/token_widgets/day_password_token_widgets/actions/edit_day_password_token_action.dart
+++ b/lib/views/main_view/main_view_widgets/token_widgets/day_password_token_widgets/actions/edit_day_password_token_action.dart
@@ -1,11 +1,9 @@
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_slidable/flutter_slidable.dart';
 
 import '../../../../../../l10n/app_localizations.dart';
 import '../../../../../../model/tokens/day_password_token.dart';
-import '../../../../../../utils/app_customizer.dart';
 import '../../../../../../utils/customizations.dart';
 import '../../../../../../utils/lock_auth.dart';
 import '../../../../../../utils/riverpod_providers.dart';
@@ -17,32 +15,16 @@ class EditDayPassowrdTokenAction extends TokenAction {
   final DayPasswordToken token;
 
   const EditDayPassowrdTokenAction({
-    super.key,
     required this.token,
   });
 
   @override
-  CustomSlidableAction build(BuildContext context) => CustomSlidableAction(
-      backgroundColor: Theme.of(context).extension<ActionTheme>()!.editColor,
-      foregroundColor: Theme.of(context).extension<ActionTheme>()!.foregroundColor,
-      onPressed: (context) async {
-        if (token.isLocked && await lockAuth(context: context, localizedReason: AppLocalizations.of(context)!.editLockedToken) == false) {
-          return;
-        }
-        _showDialog();
-      },
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          const Icon(Icons.edit),
-          Text(
-            AppLocalizations.of(context)!.edit,
-            overflow: TextOverflow.fade,
-            softWrap: false,
-          ),
-        ],
-      ));
+  void handle(BuildContext context) async {
+    if (token.isLocked && await lockAuth(context: context, localizedReason: AppLocalizations.of(context)!.editLockedToken) == false) {
+      return;
+    }
+    _showDialog();
+  }
 
   void _showDialog() {
     final tokenLabel = TextEditingController(text: token.label);

--- a/lib/views/main_view/main_view_widgets/token_widgets/day_password_token_widgets/day_password_token_widget.dart
+++ b/lib/views/main_view/main_view_widgets/token_widgets/day_password_token_widgets/day_password_token_widget.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import '../../../../../model/tokens/day_password_token.dart';
 import '../token_widget.dart';
 import '../token_widget_base.dart';
-import 'actions/edit_day_password_token_action.dart';
 import 'day_password_token_widget_tile.dart';
 
 class DayPasswordTokenWidget extends TokenWidget {
@@ -17,7 +16,6 @@ class DayPasswordTokenWidget extends TokenWidget {
       token: token,
       tile: DayPasswordTokenWidgetTile(token),
       dragIcon: Icons.calendar_month,
-      editAction: EditDayPassowrdTokenAction(token: token, key: Key('${token.id}editAction')),
     );
   }
 }

--- a/lib/views/main_view/main_view_widgets/token_widgets/day_password_token_widgets/day_password_token_widget_tile.dart
+++ b/lib/views/main_view/main_view_widgets/token_widgets/day_password_token_widgets/day_password_token_widget_tile.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
+import 'package:privacyidea_authenticator/views/main_view/main_view_widgets/token_widgets/day_password_token_widgets/actions/edit_day_password_token_action.dart';
 
 import '../../../../../l10n/app_localizations.dart';
 import '../../../../../model/tokens/day_password_token.dart';
@@ -75,6 +76,8 @@ class _DayPasswordTokenWidgetTileState extends ConsumerState<DayPasswordTokenWid
     final duration = Duration(seconds: secondsLeft.ceil());
     final durationString = duration.toString().split('.').first;
     return TokenWidgetTile(
+      token: widget.token,
+      editAction: EditDayPassowrdTokenAction(token: widget.token),
       key: Key('${widget.token.hashCode}TokenWidgetTile'),
       tokenImage: widget.token.tokenImage,
       tokenIsLocked: widget.token.isLocked,
@@ -96,10 +99,6 @@ class _DayPasswordTokenWidgetTileState extends ConsumerState<DayPasswordTokenWid
           ),
         ),
       ),
-      subtitles: [
-        if (widget.token.label.isNotEmpty) widget.token.label,
-        if (widget.token.issuer.isNotEmpty) widget.token.issuer,
-      ],
       trailing: GestureDetector(
         behavior: HitTestBehavior.deferToChild,
         onTap: () {

--- a/lib/views/main_view/main_view_widgets/token_widgets/default_token_actions/default_delete_action.dart
+++ b/lib/views/main_view/main_view_widgets/token_widgets/default_token_actions/default_delete_action.dart
@@ -1,9 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_slidable/flutter_slidable.dart';
 
 import '../../../../../l10n/app_localizations.dart';
 import '../../../../../model/tokens/token.dart';
-import '../../../../../utils/app_customizer.dart';
 import '../../../../../utils/customizations.dart';
 import '../../../../../utils/lock_auth.dart';
 import '../../../../../utils/riverpod_providers.dart';
@@ -13,32 +11,14 @@ import '../token_action.dart';
 class DefaultDeleteAction extends TokenAction {
   final Token token;
 
-  const DefaultDeleteAction({super.key, required this.token});
+  const DefaultDeleteAction({required this.token});
 
   @override
-  CustomSlidableAction build(BuildContext context) {
-    return CustomSlidableAction(
-      backgroundColor: Theme.of(context).extension<ActionTheme>()!.deleteColor,
-      foregroundColor: Theme.of(context).extension<ActionTheme>()!.foregroundColor,
-      onPressed: (_) async {
-        if (token.isLocked && await lockAuth(context: context, localizedReason: AppLocalizations.of(context)?.deleteLockedToken ?? '') == false) {
-          return;
-        }
-        _showDialog();
-      },
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          const Icon(Icons.delete),
-          Text(
-            AppLocalizations.of(context)!.delete,
-            overflow: TextOverflow.fade,
-            softWrap: false,
-          ),
-        ],
-      ),
-    );
+  void handle(BuildContext context) async {
+    if (token.isLocked && await lockAuth(context: context, localizedReason: AppLocalizations.of(context)?.deleteLockedToken ?? '') == false) {
+      return;
+    }
+    _showDialog();
   }
 
   void _showDialog() => globalNavigatorKey.currentContext == null

--- a/lib/views/main_view/main_view_widgets/token_widgets/default_token_actions/default_edit_action.dart
+++ b/lib/views/main_view/main_view_widgets/token_widgets/default_token_actions/default_edit_action.dart
@@ -1,9 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_slidable/flutter_slidable.dart';
 
 import '../../../../../l10n/app_localizations.dart';
 import '../../../../../model/tokens/token.dart';
-import '../../../../../utils/app_customizer.dart';
 import '../../../../../utils/customizations.dart';
 import '../../../../../utils/lock_auth.dart';
 import '../../../../../utils/logger.dart';
@@ -13,31 +11,14 @@ import '../token_action.dart';
 
 class DefaultEditAction extends TokenAction {
   final Token token;
-  const DefaultEditAction({required this.token, super.key});
+  const DefaultEditAction({required this.token});
 
   @override
-  CustomSlidableAction build(BuildContext context) {
-    return CustomSlidableAction(
-        backgroundColor: Theme.of(context).extension<ActionTheme>()!.editColor,
-        foregroundColor: Theme.of(context).extension<ActionTheme>()!.foregroundColor,
-        onPressed: (context) async {
-          if (token.isLocked && await lockAuth(context: context, localizedReason: AppLocalizations.of(context)!.editLockedToken) == false) {
-            return;
-          }
-          _showDialog();
-        },
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            const Icon(Icons.edit),
-            Text(
-              AppLocalizations.of(context)!.rename,
-              overflow: TextOverflow.fade,
-              softWrap: false,
-            ),
-          ],
-        ));
+  void handle(BuildContext context) async {
+    if (token.isLocked && await lockAuth(context: context, localizedReason: AppLocalizations.of(context)!.editLockedToken) == false) {
+      return;
+    }
+    _showDialog();
   }
 
   void _showDialog() {

--- a/lib/views/main_view/main_view_widgets/token_widgets/default_token_actions/default_lock_action.dart
+++ b/lib/views/main_view/main_view_widgets/token_widgets/default_token_actions/default_lock_action.dart
@@ -1,9 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_slidable/flutter_slidable.dart';
 
 import '../../../../../l10n/app_localizations.dart';
 import '../../../../../model/tokens/token.dart';
-import '../../../../../utils/app_customizer.dart';
 import '../../../../../utils/lock_auth.dart';
 import '../../../../../utils/logger.dart';
 import '../../../../../utils/riverpod_providers.dart';
@@ -12,31 +10,15 @@ import '../token_action.dart';
 class DefaultLockAction extends TokenAction {
   final Token token;
 
-  const DefaultLockAction({required this.token, super.key});
+  const DefaultLockAction({required this.token});
 
   @override
-  CustomSlidableAction build(BuildContext context) {
-    return CustomSlidableAction(
-      backgroundColor: Theme.of(context).extension<ActionTheme>()!.lockColor,
-      foregroundColor: Theme.of(context).extension<ActionTheme>()!.foregroundColor,
-      onPressed: (context) async {
-        Logger.info('Changing lock status of token.', name: 'token_widgets.dart#_changeLockStatus');
-        if (await lockAuth(context: context, localizedReason: AppLocalizations.of(context)!.authenticateToUnLockToken) == false) return;
+  void handle(BuildContext context) async {
+    Logger.info('Changing lock status of token.', name: 'token_widgets.dart#_changeLockStatus');
+    if (await lockAuth(context: context, localizedReason: AppLocalizations.of(context)!.authenticateToUnLockToken) == false) {
+      return;
+    }
 
-        globalRef?.read(tokenProvider.notifier).updateToken(token, (p0) => p0.copyWith(isLocked: !token.isLocked));
-      },
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          const Icon(Icons.lock),
-          Text(
-            token.isLocked ? AppLocalizations.of(context)!.unlock : AppLocalizations.of(context)!.lock,
-            overflow: TextOverflow.fade,
-            softWrap: false,
-          ),
-        ],
-      ),
-    );
+    globalRef?.read(tokenProvider.notifier).updateToken(token, (p0) => p0.copyWith(isLocked: !token.isLocked));
   }
 }

--- a/lib/views/main_view/main_view_widgets/token_widgets/hotp_token_widgets/actions/edit_hotp_token_action.dart
+++ b/lib/views/main_view/main_view_widgets/token_widgets/hotp_token_widgets/actions/edit_hotp_token_action.dart
@@ -1,11 +1,9 @@
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_slidable/flutter_slidable.dart';
 
 import '../../../../../../l10n/app_localizations.dart';
 import '../../../../../../model/tokens/hotp_token.dart';
-import '../../../../../../utils/app_customizer.dart';
 import '../../../../../../utils/customizations.dart';
 import '../../../../../../utils/lock_auth.dart';
 import '../../../../../../utils/riverpod_providers.dart';
@@ -17,32 +15,16 @@ class EditHOTPTokenAction extends TokenAction {
   final HOTPToken token;
 
   const EditHOTPTokenAction({
-    super.key,
     required this.token,
   });
 
   @override
-  CustomSlidableAction build(BuildContext context) => CustomSlidableAction(
-      backgroundColor: Theme.of(context).extension<ActionTheme>()!.editColor,
-      foregroundColor: Theme.of(context).extension<ActionTheme>()!.foregroundColor,
-      onPressed: (context) async {
-        if (token.isLocked && await lockAuth(context: context, localizedReason: AppLocalizations.of(context)!.editLockedToken) == false) {
-          return;
-        }
-        _showDialog();
-      },
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          const Icon(Icons.edit),
-          Text(
-            AppLocalizations.of(context)!.edit,
-            overflow: TextOverflow.fade,
-            softWrap: false,
-          ),
-        ],
-      ));
+  void handle(BuildContext context) async {
+    if (token.isLocked && await lockAuth(context: context, localizedReason: AppLocalizations.of(context)!.editLockedToken) == false) {
+      return;
+    }
+    _showDialog();
+  }
 
   void _showDialog() {
     final tokenLabel = TextEditingController(text: token.label);

--- a/lib/views/main_view/main_view_widgets/token_widgets/hotp_token_widgets/hotp_token_widget.dart
+++ b/lib/views/main_view/main_view_widgets/token_widgets/hotp_token_widgets/hotp_token_widget.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import '../../../../../model/tokens/hotp_token.dart';
 import '../token_widget.dart';
 import '../token_widget_base.dart';
-import 'actions/edit_hotp_token_action.dart';
 import 'hotp_token_widget_tile.dart';
 
 class HOTPTokenWidget extends TokenWidget {
@@ -21,7 +20,6 @@ class HOTPTokenWidget extends TokenWidget {
       token: token,
       tile: HOTPTokenWidgetTile(token: token, key: ValueKey(token.id)),
       dragIcon: Icons.replay,
-      editAction: EditHOTPTokenAction(token: token),
     );
   }
 }

--- a/lib/views/main_view/main_view_widgets/token_widgets/hotp_token_widgets/hotp_token_widget_tile.dart
+++ b/lib/views/main_view/main_view_widgets/token_widgets/hotp_token_widgets/hotp_token_widget_tile.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacyidea_authenticator/views/main_view/main_view_widgets/token_widgets/hotp_token_widgets/actions/edit_hotp_token_action.dart';
 
 import '../../../../../l10n/app_localizations.dart';
 import '../../../../../model/tokens/hotp_token.dart';
@@ -79,6 +80,8 @@ class _HOTPTokenWidgetTileState extends ConsumerState<HOTPTokenWidgetTile> {
   @override
   Widget build(BuildContext context) {
     return TokenWidgetTile(
+      token: widget.token,
+      editAction: EditHOTPTokenAction(token: widget.token),
       key: Key('${widget.token.hashCode}TokenWidgetTile'),
       tokenImage: widget.token.tokenImage,
       tokenIsLocked: widget.token.isLocked,
@@ -100,10 +103,6 @@ class _HOTPTokenWidgetTileState extends ConsumerState<HOTPTokenWidgetTile> {
           ),
         ),
       ),
-      subtitles: [
-        if (widget.token.label.isNotEmpty) widget.token.label,
-        if (widget.token.issuer.isNotEmpty) widget.token.issuer,
-      ],
       trailing: HideableWidget(
         token: widget.token,
         isHiddenNotifier: isHidden,

--- a/lib/views/main_view/main_view_widgets/token_widgets/push_token_widgets/actions/edit_push_token_action.dart
+++ b/lib/views/main_view/main_view_widgets/token_widgets/push_token_widgets/actions/edit_push_token_action.dart
@@ -16,32 +16,16 @@ class EditPushTokenAction extends TokenAction {
   final PushToken token;
 
   const EditPushTokenAction({
-    super.key,
     required this.token,
   });
 
   @override
-  CustomSlidableAction build(BuildContext context) => CustomSlidableAction(
-      backgroundColor: Theme.of(context).extension<ActionTheme>()!.editColor,
-      foregroundColor: Theme.of(context).extension<ActionTheme>()!.foregroundColor,
-      onPressed: (context) async {
-        if (token.isLocked && await lockAuth(context: context, localizedReason: AppLocalizations.of(context)!.editLockedToken) == false) {
-          return;
-        }
-        _showDialog();
-      },
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          const Icon(Icons.edit),
-          Text(
-            AppLocalizations.of(context)!.edit,
-            overflow: TextOverflow.fade,
-            softWrap: false,
-          ),
-        ],
-      ));
+  void handle(BuildContext context) async {
+    if (token.isLocked && await lockAuth(context: context, localizedReason: AppLocalizations.of(context)!.editLockedToken) == false) {
+      return;
+    }
+    _showDialog();
+  }
 
   void _showDialog() {
     final tokenLabel = TextEditingController(text: token.label);

--- a/lib/views/main_view/main_view_widgets/token_widgets/push_token_widgets/push_token_widget.dart
+++ b/lib/views/main_view/main_view_widgets/token_widgets/push_token_widgets/push_token_widget.dart
@@ -37,7 +37,6 @@ class PushTokenWidget extends TokenWidget {
       token: token,
       tile: PushTokenWidgetTile(token),
       dragIcon: Icons.notifications,
-      editAction: EditPushTokenAction(token: token, key: Key('${token.id}editAction')),
       stack: [
         if (!token.isRolledOut)
           Positioned.fill(

--- a/lib/views/main_view/main_view_widgets/token_widgets/push_token_widgets/push_token_widget_tile.dart
+++ b/lib/views/main_view/main_view_widgets/token_widgets/push_token_widgets/push_token_widget_tile.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacyidea_authenticator/views/main_view/main_view_widgets/token_widgets/push_token_widgets/actions/edit_push_token_action.dart';
 
 import '../../../../../model/tokens/push_token.dart';
 import '../token_widget_tile.dart';
@@ -11,6 +12,8 @@ class PushTokenWidgetTile extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return TokenWidgetTile(
+      token: token,
+      editAction: EditPushTokenAction(token: token),
       key: Key('${token.hashCode}TokenWidgetTile'),
       tokenIsLocked: token.isLocked,
       tokenImage: token.tokenImage,
@@ -20,9 +23,6 @@ class PushTokenWidgetTile extends ConsumerWidget {
         overflow: TextOverflow.ellipsis,
         maxLines: 2,
       ),
-      subtitles: [
-        if (token.issuer.isNotEmpty) token.issuer,
-      ],
       trailing: const Icon(
         Icons.notifications,
         size: 26,

--- a/lib/views/main_view/main_view_widgets/token_widgets/token_action.dart
+++ b/lib/views/main_view/main_view_widgets/token_widgets/token_action.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_slidable/flutter_slidable.dart';
 
-abstract class TokenAction extends StatelessWidget {
-  const TokenAction({super.key});
-  @override
-  CustomSlidableAction build(BuildContext context);
+abstract class TokenAction {
+  const TokenAction();
+
+  void handle(BuildContext context);
 }

--- a/lib/views/main_view/main_view_widgets/token_widgets/token_widget_base.dart
+++ b/lib/views/main_view/main_view_widgets/token_widgets/token_widget_base.dart
@@ -7,27 +7,16 @@ import '../../../../model/mixins/sortable_mixin.dart';
 import '../../../../model/tokens/token.dart';
 import '../../../../utils/riverpod_providers.dart';
 import '../../../../utils/text_size.dart';
-import 'default_token_actions/default_delete_action.dart';
-import 'default_token_actions/default_edit_action.dart';
-import 'default_token_actions/default_lock_action.dart';
-import 'token_action.dart';
-import 'token_widget_slideable.dart';
 
 class TokenWidgetBase extends ConsumerWidget {
   final Widget tile;
   final Token token;
-  final TokenAction? deleteAction;
-  final TokenAction? editAction;
-  final TokenAction? lockAction;
   final List<Widget> stack;
   final IconData dragIcon;
 
   const TokenWidgetBase({
     required this.tile,
     required this.token,
-    this.deleteAction,
-    this.editAction,
-    this.lockAction,
     this.stack = const <Widget>[],
     this.dragIcon = Icons.drag_handle,
     super.key,
@@ -36,15 +25,7 @@ class TokenWidgetBase extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final SortableMixin? draggingSortable = ref.watch(draggingSortableProvider);
-    final List<TokenAction> actions = [
-      deleteAction ?? DefaultDeleteAction(token: token, key: Key('${token.id}deleteAction')),
-      editAction ?? DefaultEditAction(token: token, key: Key('${token.id}editAction')),
-    ];
-    if ((token.pin == false)) {
-      actions.add(
-        lockAction ?? DefaultLockAction(token: token, key: Key('${token.id}lockAction')),
-      );
-    }
+
     return draggingSortable == null
         ? LongPressDraggable(
             maxSimultaneousDrags: 1,
@@ -76,20 +57,10 @@ class TokenWidgetBase extends ConsumerWidget {
               ],
             ),
             data: token,
-            child: TokenWidgetSlideable(
-              token: token,
-              actions: actions,
-              stack: stack,
-              tile: tile,
-            ),
+            child: tile,
           )
         : draggingSortable == token
             ? const SizedBox()
-            : TokenWidgetSlideable(
-                token: token,
-                actions: actions,
-                stack: stack,
-                tile: tile,
-              );
+            : tile;
   }
 }

--- a/lib/views/main_view/main_view_widgets/token_widgets/token_widget_slideable.dart
+++ b/lib/views/main_view/main_view_widgets/token_widgets/token_widget_slideable.dart
@@ -19,19 +19,10 @@ class TokenWidgetSlideable extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) => Slidable(
-        key: ValueKey(token.id),
-        groupTag: 'myTag', // This is used to only let one be open at a time.
-        endActionPane: ActionPane(
-          motion: const DrawerMotion(),
-          extentRatio: 1,
-          children: actions,
-        ),
-        child: Stack(
-          children: [
-            tile,
-            for (var item in stack) item,
-          ],
-        ),
+  Widget build(BuildContext context) => Stack(
+        children: [
+          tile,
+          for (var item in stack) item,
+        ],
       );
 }

--- a/lib/views/main_view/main_view_widgets/token_widgets/token_widget_tile.dart
+++ b/lib/views/main_view/main_view_widgets/token_widgets/token_widget_tile.dart
@@ -41,17 +41,19 @@ class TokenWidgetTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => Container(
-        margin: const EdgeInsets.only(left: 20.0, right: 20.0),
+        margin: const EdgeInsets.only(left: 20.0, top: 0.1, right: 20.0, bottom: 0.1),
         decoration: BoxDecoration(
           color: Colors.transparent,
           borderRadius: const BorderRadius.only(
+            topLeft: Radius.circular(10),
+              topRight: Radius.circular(10),
               bottomLeft: Radius.circular(10),
               bottomRight: Radius.circular(10)),
           boxShadow: [
             BoxShadow(
               color: Colors.black.withOpacity(0.2),
-              spreadRadius: 5,
-              blurRadius: 7,
+              spreadRadius: 1,
+              blurRadius: 2,
               offset: const Offset(0, 3),
             ),
           ],

--- a/lib/views/main_view/main_view_widgets/token_widgets/totp_token_widgets/actions/edit_totp_token_action.dart
+++ b/lib/views/main_view/main_view_widgets/token_widgets/totp_token_widgets/actions/edit_totp_token_action.dart
@@ -15,32 +15,16 @@ class EditTOTPTokenAction extends TokenAction {
   final TOTPToken token;
 
   const EditTOTPTokenAction({
-    super.key,
     required this.token,
   });
 
   @override
-  CustomSlidableAction build(BuildContext context) => CustomSlidableAction(
-      backgroundColor: Theme.of(context).extension<ActionTheme>()!.editColor,
-      foregroundColor: Theme.of(context).extension<ActionTheme>()!.foregroundColor,
-      onPressed: (context) async {
-        if (token.isLocked && await lockAuth(context: context, localizedReason: AppLocalizations.of(context)!.editLockedToken) == false) {
-          return;
-        }
-        _showDialog();
-      },
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          const Icon(Icons.edit),
-          Text(
-            AppLocalizations.of(context)!.edit,
-            overflow: TextOverflow.fade,
-            softWrap: false,
-          ),
-        ],
-      ));
+  void handle(BuildContext context) async {
+    if (token.isLocked && await lockAuth(context: context, localizedReason: AppLocalizations.of(context)!.editLockedToken) == false) {
+      return;
+    }
+    _showDialog();
+  }
 
   void _showDialog() {
     final tokenLabel = TextEditingController(text: token.label);

--- a/lib/views/main_view/main_view_widgets/token_widgets/totp_token_widgets/totp_token_widget.dart
+++ b/lib/views/main_view/main_view_widgets/token_widgets/totp_token_widgets/totp_token_widget.dart
@@ -4,7 +4,6 @@ import '../../../../../model/mixins/sortable_mixin.dart';
 import '../../../../../model/tokens/totp_token.dart';
 import '../token_widget.dart';
 import '../token_widget_base.dart';
-import 'actions/edit_totp_token_action.dart';
 import 'totp_token_widget_tile.dart';
 
 class TOTPTokenWidget extends TokenWidget {
@@ -25,7 +24,6 @@ class TOTPTokenWidget extends TokenWidget {
       token: token,
       tile: TOTPTokenWidgetTile(token),
       dragIcon: Icons.alarm,
-      editAction: EditTOTPTokenAction(token: token),
     );
   }
 }

--- a/lib/views/main_view/main_view_widgets/token_widgets/totp_token_widgets/totp_token_widget_tile.dart
+++ b/lib/views/main_view/main_view_widgets/token_widgets/totp_token_widgets/totp_token_widget_tile.dart
@@ -11,6 +11,7 @@ import '../../../../../utils/utils.dart';
 import '../../../../../widgets/custom_texts.dart';
 import '../../../../../widgets/hideable_widget_.dart';
 import '../token_widget_tile.dart';
+import 'actions/edit_totp_token_action.dart';
 
 class TOTPTokenWidgetTile extends ConsumerStatefulWidget {
   final TOTPToken token;
@@ -106,6 +107,8 @@ class _TOTPTokenWidgetTileState extends ConsumerState<TOTPTokenWidgetTile> with 
     final appstate = ref.watch(appStateProvider);
     _onAppStateChange(appstate);
     return TokenWidgetTile(
+      token: widget.token,
+      editAction: EditTOTPTokenAction(token: widget.token),
       key: Key('${widget.token.hashCode}TokenWidgetTile'),
       tokenImage: widget.token.tokenImage,
       tokenIsLocked: widget.token.isLocked,
@@ -128,10 +131,6 @@ class _TOTPTokenWidgetTileState extends ConsumerState<TOTPTokenWidgetTile> with 
           ),
         ),
       ),
-      subtitles: [
-        if (widget.token.label.isNotEmpty) widget.token.label,
-        if (widget.token.issuer.isNotEmpty) widget.token.issuer,
-      ],
       trailing: HideableWidget(
         token: widget.token,
         isHiddenNotifier: isHidden,


### PR DESCRIPTION
Hello everyone,

I have recently heard from many of my colleagues (we use pi-authenticator for work) that it is not possible to delete or edit tokens in the app. My first idea was also to extend the instructions as described in the Google reviews, but I know too well that users don't look at instructions and try it themselves. The swipe gesture is not visible to the user, which is why I replaced it with three dots.

**Label**
The label of the token was previously displayed as subtext under the token code. I saw as problem here that a user will initially search for a label to get the correct token code, so why not put it first?

**Container per token**
Just looks better in my opinion. This makes each token a visible, coherent object for the user.

**Code**
I have continued to call the new "actions" actions. From my point of view, it is still an action and not a menu or anything like that. If you want to change the names of the classes, that's no problem (i.e. DefaultDeleteAction). If a merge is possible and I have to adjust something, please let me know. I started the whole thing for fun and for learning purposes, but I think the result is quite nice now.

The app has been tested on Android and in the iOS simulator.

**Screenshots**

Android (one token without label to demonstrate that this still works)
<img src="https://github.com/privacyidea/pi-authenticator/assets/43616562/69ea2f3c-9347-42f6-9a80-ae4c974180cc.png" alt="drawing" width="200"/>

iOS
<img src="https://github.com/privacyidea/pi-authenticator/assets/43616562/cf7fd698-593d-4b87-89f2-39553555eef7.png" alt="drawing" width="200"/>

Edit: I forgot to mention one more thing. The app cannot currently be used by blind people. To incorporate this in the future, a structure with buttons makes more sense. I don't know how a blind person can perform a swipe action. As far as I know, only a tap action can be performed (https://api.flutter.dev/flutter/widgets/Semantics-class.html)