### PR TITLE
Replace password fields with PiTextField for improved visibility toggle

### DIFF
--- a/.github/workflows/flutter_build.yml
+++ b/.github/workflows/flutter_build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set Xcode version
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "16.4"
+          xcode-version: "26.6.0"
 
       - uses: actions/setup-java@v4
         with:

--- a/lib/api/impl/privacy_idea_container_api.dart
+++ b/lib/api/impl/privacy_idea_container_api.dart
@@ -267,6 +267,11 @@ class PiContainerApi implements TokenContainerApi {
       throw ResponseError(response);
     }
 
+    final errorResponse = piResponse.asError;
+    if (errorResponse != null) {
+      throw errorResponse.piServerResultError;
+    }
+
     final result = piResponse.asSuccess!.result;
     if (!result.status) {
       if (result.error != null) throw result.error!;

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -1989,6 +1989,8 @@
   "originDetails": "Podrobnosti o původu",
   "otpValueCopiedMessage": "Heslo “{otpValue}“ bylo zkopírováno do schránky.",
   "password": "Heslo",
+  "showPassword": "Zobrazit heslo",
+  "hidePassword": "Skrýt heslo",
   "passwordCannotBeEmpty": "Heslo nesmí být prázdné",
   "passwordCannotContainWhitespace": "Heslo nesmí obsahovat mezery",
   "passwordMustBeAtLeast8Characters": "Heslo musí obsahovat alespoň 8 znaků",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -2010,6 +2010,8 @@
   "originDetails": "Angaben zur Herkunft",
   "otpValueCopiedMessage": "Passwort “{otpValue}“ wurde in Zwischenablage kopiert.",
   "password": "Passwort",
+  "showPassword": "Passwort anzeigen",
+  "hidePassword": "Passwort verbergen",
   "passwordCannotBeEmpty": "Das Passwort darf nicht leer sein",
   "passwordCannotContainWhitespace": "Das Passwort darf keine Leerzeichen enthalten",
   "passwordMustBeAtLeast8Characters": "Das Passwort muss mindestens 8 Zeichen lang sein",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2010,6 +2010,8 @@
   "originDetails": "Origin details",
   "otpValueCopiedMessage": "Password “{otpValue}“ copied to clipboard.",
   "password": "Password",
+  "showPassword": "Show password",
+  "hidePassword": "Hide password",
   "passwordCannotBeEmpty": "Password cannot be empty",
   "passwordCannotContainWhitespace": "Password cannot contain whitespace",
   "passwordMustBeAtLeast8Characters": "Password must be at least 8 characters",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1989,6 +1989,8 @@
   "originDetails": "Datos de origen",
   "otpValueCopiedMessage": "Contraseña “{otpValue}“ copiada en el portapapeles.",
   "password": "Contraseña",
+  "showPassword": "Mostrar contraseña",
+  "hidePassword": "Ocultar contraseña",
   "passwordCannotBeEmpty": "La contraseña no puede estar vacía",
   "passwordCannotContainWhitespace": "La contraseña no puede contener espacios en blanco",
   "passwordMustBeAtLeast8Characters": "La contraseña debe tener al menos 8 caracteres",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1989,6 +1989,8 @@
   "originDetails": "Informations sur l'origine",
   "otpValueCopiedMessage": "Le mot de passe “{otpValue}“ a été copié dans le presse-papier.",
   "password": "Mot de passe",
+  "showPassword": "Afficher le mot de passe",
+  "hidePassword": "Masquer le mot de passe",
   "passwordCannotBeEmpty": "Le mot de passe ne peut pas être vide",
   "passwordCannotContainWhitespace": "Le mot de passe ne peut pas contenir d'espaces",
   "passwordMustBeAtLeast8Characters": "Le mot de passe doit contenir au moins 8 caractères",

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -1989,6 +1989,8 @@
   "originDetails": "Rincian asal",
   "otpValueCopiedMessage": "Kata sandi “{otpValue}“ disalin ke papan klip.",
   "password": "Kata sandi",
+  "showPassword": "Tampilkan kata sandi",
+  "hidePassword": "Sembunyikan kata sandi",
   "passwordCannotBeEmpty": "Kata sandi tidak boleh kosong",
   "passwordCannotContainWhitespace": "Kata sandi tidak boleh mengandung spasi",
   "passwordMustBeAtLeast8Characters": "Kata sandi minimal harus terdiri dari 8 karakter",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -1989,6 +1989,8 @@
   "originDetails": "Details over de oorsprong",
   "otpValueCopiedMessage": "Wachtwoord “{otpValue}“ gekopieerd naar het klembord.",
   "password": "Wachtwoord",
+  "showPassword": "Wachtwoord weergeven",
+  "hidePassword": "Wachtwoord verbergen",
   "passwordCannotBeEmpty": "Wachtwoord mag niet leeg zijn",
   "passwordCannotContainWhitespace": "Wachtwoord mag geen spaties bevatten",
   "passwordMustBeAtLeast8Characters": "Wachtwoord moet minimaal 8 tekens lang zijn",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -1989,6 +1989,8 @@
   "originDetails": "Szczegóły dotyczące pochodzenia",
   "otpValueCopiedMessage": "Jednorazowe hasło “{otpValue}“ skopiowane do schowka.",
   "password": "Hasło",
+  "showPassword": "Pokaż hasło",
+  "hidePassword": "Skryj hasło",
   "passwordCannotBeEmpty": "Hasło nie może być puste",
   "passwordCannotContainWhitespace": "Hasło nie może zawierać spacji",
   "passwordMustBeAtLeast8Characters": "Hasło musi mieć co najmniej 8 znaków",

--- a/lib/utils/riverpod/riverpod_providers/generated_providers/token_container_notifier.dart
+++ b/lib/utils/riverpod/riverpod_providers/generated_providers/token_container_notifier.dart
@@ -963,8 +963,15 @@ class TokenContainerNotifier extends _$TokenContainerNotifier
     // final signature = finalizationResponse.signature;
     final finalizedContainer = await updateContainer(
       container,
-      (TokenContainerUnfinalized c) =>
-          c.copyWith(policies: response.policies).finalize()!,
+      (TokenContainerUnfinalized c) {
+        final finalized = c.copyWith(policies: response.policies).finalize();
+        if (finalized == null) {
+          throw StateError(
+            'Unable to finalize container ${c.serial}: missing client key pair',
+          );
+        }
+        return finalized;
+      },
     );
     if (finalizedContainer == null) {
       throw StateError(

--- a/lib/views/import_tokens_view/pages/import_encrypted_data_page.dart
+++ b/lib/views/import_tokens_view/pages/import_encrypted_data_page.dart
@@ -25,6 +25,7 @@ import '../../../model/processor_result.dart';
 import '../../../model/tokens/token.dart';
 import '../../../processors/mixins/token_import_processor.dart';
 import '../../../processors/token_import_file_processor/two_fas_import_file_processor.dart';
+import '../../../widgets/pi_text_field.dart';
 import '../import_tokens_view.dart';
 import 'import_plain_tokens_page.dart';
 
@@ -52,7 +53,6 @@ class _ImportEncryptedDataPageState extends State<ImportEncryptedDataPage> {
   final _passwordController = TextEditingController();
   final _passwordFocusNode = FocusNode();
   Future? processingFuture;
-  bool isPasswordVisible = false;
   bool wrongPassword = false;
 
   @override
@@ -79,52 +79,18 @@ class _ImportEncryptedDataPageState extends State<ImportEncryptedDataPage> {
                 AppLocalizations.of(context)!.tokensAreEncrypted,
                 textAlign: TextAlign.center,
               ),
-              SizedBox(
-                height: ImportTokensView.itemSpacingHorizontal * 4,
-                child: Row(
-                  children: [
-                    Flexible(
-                      flex: 9,
-                      child: TextField(
-                        controller: _passwordController,
-                        focusNode: _passwordFocusNode,
-                        enabled: processingFuture == null,
-                        style: Theme.of(context).textTheme.bodyMedium,
-                        decoration: InputDecoration(
-                          labelText: AppLocalizations.of(context)!.password,
-                          labelStyle: Theme.of(context).textTheme.titleSmall,
-                          errorText: wrongPassword
-                              ? AppLocalizations.of(context)!.wrongPassword
-                              : null,
-                        ),
-                        onChanged: (value) => setState(() {
-                          wrongPassword = false;
-                        }),
-                        obscureText: !isPasswordVisible,
-                      ),
-                    ),
-                    const SizedBox(width: ImportTokensView.itemSpacingVertical),
-                    Flexible(
-                      child: GestureDetector(
-                        child: const SizedBox(
-                          height: 200,
-                          width: 200,
-                          child: Center(
-                            child: Icon(Icons.visibility, size: 36),
-                          ),
-                        ),
-                        onPanDown: (_) =>
-                            setState(() => isPasswordVisible = true),
-                        onPanStart: (_) =>
-                            setState(() => isPasswordVisible = true),
-                        onPanCancel: () =>
-                            setState(() => isPasswordVisible = false),
-                        onPanEnd: (_) =>
-                            setState(() => isPasswordVisible = false),
-                      ),
-                    ),
-                  ],
-                ),
+              PiTextField(
+                controller: _passwordController,
+                focusNode: _passwordFocusNode,
+                enabled: processingFuture == null,
+                obscureText: true,
+                labelText: AppLocalizations.of(context)!.password,
+                errorText: wrongPassword
+                    ? AppLocalizations.of(context)!.wrongPassword
+                    : null,
+                onChanged: (value) => setState(() {
+                  wrongPassword = false;
+                }),
               ),
               const SizedBox(height: ImportTokensView.itemSpacingHorizontal),
               processingFuture != null

--- a/lib/views/import_tokens_view/pages/import_encrypted_data_page.dart
+++ b/lib/views/import_tokens_view/pages/import_encrypted_data_page.dart
@@ -56,6 +56,13 @@ class _ImportEncryptedDataPageState extends State<ImportEncryptedDataPage> {
   bool wrongPassword = false;
 
   @override
+  void dispose() {
+    _passwordController.dispose();
+    _passwordFocusNode.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) => Scaffold(
     appBar: AppBar(
       title: Text(

--- a/lib/views/settings_view/settings_groups/import_export_tokens_widgets/dialogs/export_tokens_to_file_dialog.dart
+++ b/lib/views/settings_view/settings_groups/import_export_tokens_widgets/dialogs/export_tokens_to_file_dialog.dart
@@ -52,6 +52,13 @@ class _ExportTokensToFileDialogState
   bool _exportPressed = false;
 
   @override
+  void dispose() {
+    _passwordTextController.dispose();
+    _confirmTextController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     final appLocalizations = AppLocalizations.of(context)!;
     return DefaultDialog(

--- a/lib/views/settings_view/settings_groups/import_export_tokens_widgets/dialogs/export_tokens_to_file_dialog.dart
+++ b/lib/views/settings_view/settings_groups/import_export_tokens_widgets/dialogs/export_tokens_to_file_dialog.dart
@@ -33,6 +33,7 @@ import '../../../../../utils/encryption/token_encryption.dart';
 import '../../../../../utils/lock_auth.dart';
 import '../../../../../utils/validators.dart';
 import '../../../../../widgets/dialog_widgets/default_dialog.dart';
+import '../../../../../widgets/pi_text_field.dart';
 
 class ExportTokensToFileDialog extends ConsumerStatefulWidget {
   final Iterable<Token> tokens;
@@ -46,9 +47,7 @@ class ExportTokensToFileDialog extends ConsumerStatefulWidget {
 class _ExportTokensToFileDialogState
     extends ConsumerState<ExportTokensToFileDialog> {
   final _passwordTextController = TextEditingController();
-  bool _passwordHidden = true;
   final _confirmTextController = TextEditingController();
-  bool _confirmHidden = true;
 
   bool _exportPressed = false;
 
@@ -62,67 +61,21 @@ class _ExportTokensToFileDialogState
         children: (!_exportPressed)
             ? [
                 Text(appLocalizations.enterPasswordToEncrypt),
-                Row(
-                  children: [
-                    Expanded(
-                      child: TextFormField(
-                        controller: _passwordTextController,
-                        style: Theme.of(context).textTheme.bodyMedium,
-                        obscureText: _passwordHidden,
-                        onChanged: (value) => setState(() {}),
-                        autovalidateMode: AutovalidateMode.onUserInteraction,
-                        validator: Validators(appLocalizations).password,
-                        decoration: InputDecoration(
-                          labelText: appLocalizations.password,
-                          labelStyle: Theme.of(context).textTheme.titleSmall,
-                          errorMaxLines: 2,
-                        ),
-                      ),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 8.0),
-                      child: GestureDetector(
-                        onTapDown: (_) =>
-                            setState(() => _passwordHidden = false),
-                        onTapUp: (_) => setState(() => _passwordHidden = true),
-                        onTapCancel: () =>
-                            setState(() => _passwordHidden = true),
-                        child: const Icon(Icons.visibility),
-                      ),
-                    ),
-                  ],
+                PiTextField(
+                  controller: _passwordTextController,
+                  obscureText: true,
+                  onChanged: (value) => setState(() {}),
+                  validator: Validators(appLocalizations).password,
+                  labelText: appLocalizations.password,
                 ),
-                Row(
-                  children: [
-                    Expanded(
-                      child: TextFormField(
-                        controller: _confirmTextController,
-                        style: Theme.of(context).textTheme.bodyMedium,
-                        obscureText: _confirmHidden,
-                        onChanged: (value) => setState(() {}),
-                        autovalidateMode: AutovalidateMode.onUserInteraction,
-                        validator: (value) => Validators(
-                          appLocalizations,
-                        ).confirmPassword(_passwordTextController.text, value),
-                        decoration: InputDecoration(
-                          labelText: appLocalizations.confirmPassword,
-                          labelStyle: Theme.of(context).textTheme.titleSmall,
-                          errorMaxLines: 2,
-                        ),
-                      ),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 8),
-                      child: GestureDetector(
-                        onTapDown: (_) =>
-                            setState(() => _confirmHidden = false),
-                        onTapUp: (_) => setState(() => _confirmHidden = true),
-                        onTapCancel: () =>
-                            setState(() => _confirmHidden = true),
-                        child: const Icon(Icons.visibility),
-                      ),
-                    ),
-                  ],
+                PiTextField(
+                  controller: _confirmTextController,
+                  obscureText: true,
+                  onChanged: (value) => setState(() {}),
+                  validator: (value) => Validators(
+                    appLocalizations,
+                  ).confirmPassword(_passwordTextController.text, value),
+                  labelText: appLocalizations.confirmPassword,
                 ),
               ]
             : [

--- a/lib/widgets/dialog_widgets/enter_passphrase_dialog.dart
+++ b/lib/widgets/dialog_widgets/enter_passphrase_dialog.dart
@@ -23,6 +23,7 @@ import 'package:flutter/material.dart';
 import 'package:privacyidea_authenticator/l10n/app_localizations.dart';
 import 'package:privacyidea_authenticator/utils/view_utils.dart';
 import 'package:privacyidea_authenticator/widgets/dialog_widgets/default_dialog.dart';
+import 'package:privacyidea_authenticator/widgets/pi_text_field.dart';
 
 class EnterPassphraseDialog extends StatefulWidget {
   final String question;
@@ -53,12 +54,9 @@ class _EnterPassphraseDialogState extends State<EnterPassphraseDialog> {
         children: [
           Text(widget.question, style: Theme.of(context).textTheme.bodyLarge),
           SizedBox(height: 8),
-          TextField(
-            style: Theme.of(context).textTheme.bodyMedium,
-            decoration: InputDecoration(
-              labelText: appLocalizations.enterPassphraseDialogHint,
-              labelStyle: Theme.of(context).textTheme.bodyMedium,
-            ),
+          PiTextField(
+            obscureText: true,
+            labelText: appLocalizations.enterPassphraseDialogHint,
             onChanged: (value) => setState(() {
               text = value;
             }),

--- a/lib/widgets/pi_text_field.dart
+++ b/lib/widgets/pi_text_field.dart
@@ -19,6 +19,8 @@
  */
 import 'package:flutter/material.dart';
 
+import '../l10n/app_localizations.dart';
+
 class PiTextField extends StatefulWidget {
   final String? labelText;
   final void Function(String)? onChanged;
@@ -32,7 +34,7 @@ class PiTextField extends StatefulWidget {
   final AutovalidateMode autovalidateMode;
   final String? Function(String?)? validator;
   final TextInputAction? textInputAction;
-  final Function(String)? onFieldSubmitted;
+  final void Function(String)? onFieldSubmitted;
   final bool enabled;
   final String? errorText;
 
@@ -73,6 +75,9 @@ class _PiTextFieldState extends State<PiTextField> {
               icon: Icon(
                 _obscureText ? Icons.visibility : Icons.visibility_off,
               ),
+              tooltip: _obscureText
+                  ? AppLocalizations.of(context)!.showPassword
+                  : AppLocalizations.of(context)!.hidePassword,
               onPressed: () => setState(() => _obscureText = !_obscureText),
             )
           : null,

--- a/lib/widgets/pi_text_field.dart
+++ b/lib/widgets/pi_text_field.dart
@@ -19,9 +19,9 @@
  */
 import 'package:flutter/material.dart';
 
-class PiTextField extends StatelessWidget {
+class PiTextField extends StatefulWidget {
   final String? labelText;
-  final Function(String)? onChanged;
+  final void Function(String)? onChanged;
   final TextEditingController? controller;
   final TextInputType? keyboardType;
   final FocusNode? focusNode;
@@ -33,6 +33,8 @@ class PiTextField extends StatelessWidget {
   final String? Function(String?)? validator;
   final TextInputAction? textInputAction;
   final Function(String)? onFieldSubmitted;
+  final bool enabled;
+  final String? errorText;
 
   const PiTextField({
     super.key,
@@ -49,23 +51,45 @@ class PiTextField extends StatelessWidget {
     this.validator,
     this.textInputAction,
     this.onFieldSubmitted,
+    this.enabled = true,
+    this.errorText,
   });
 
   @override
+  State<PiTextField> createState() => _PiTextFieldState();
+}
+
+class _PiTextFieldState extends State<PiTextField> {
+  late bool _obscureText = widget.obscureText;
+
+  @override
   Widget build(BuildContext context) => TextFormField(
-    decoration: InputDecoration(labelText: labelText, errorMaxLines: 2),
-    onChanged: onChanged,
-    controller: controller,
-    keyboardType: keyboardType,
-    focusNode: focusNode,
-    autofocus: autofocus,
-    obscureText: obscureText,
-    autocorrect: autocorrect,
-    enableSuggestions: enableSuggestions,
-    textInputAction: textInputAction,
-    onFieldSubmitted: onFieldSubmitted,
+    decoration: InputDecoration(
+      labelText: widget.labelText,
+      errorText: widget.errorText,
+      errorMaxLines: 2,
+      suffixIcon: widget.obscureText
+          ? IconButton(
+              icon: Icon(
+                _obscureText ? Icons.visibility : Icons.visibility_off,
+              ),
+              onPressed: () => setState(() => _obscureText = !_obscureText),
+            )
+          : null,
+    ),
+    onChanged: widget.onChanged,
+    controller: widget.controller,
+    keyboardType: widget.keyboardType,
+    focusNode: widget.focusNode,
+    autofocus: widget.autofocus,
+    enabled: widget.enabled,
+    obscureText: _obscureText,
+    autocorrect: widget.autocorrect,
+    enableSuggestions: widget.enableSuggestions,
+    textInputAction: widget.textInputAction,
+    onFieldSubmitted: widget.onFieldSubmitted,
     style: Theme.of(context).textTheme.titleSmall,
-    autovalidateMode: autovalidateMode,
-    validator: validator,
+    autovalidateMode: widget.autovalidateMode,
+    validator: widget.validator,
   );
 }

--- a/test/unit_test/widgets/button_widgets/dialog_widgets/enter_passphrase_dialog_test.dart
+++ b/test/unit_test/widgets/button_widgets/dialog_widgets/enter_passphrase_dialog_test.dart
@@ -137,5 +137,30 @@ void main() {
       expect(textField.decoration?.labelText, isNotNull);
       expect(textField.style?.fontSize, isNotNull);
     });
+
+    testWidgets(
+      'passphrase is obscured by default and can be toggled visible',
+      (tester) async {
+        await tester.pumpWidget(
+          const TestsAppWrapper(child: EnterPassphraseDialog(question: 'Q')),
+        );
+
+        final textFieldFinder = find.byType(TextField);
+        expect(
+          tester.widget<TextField>(textFieldFinder).obscureText,
+          isTrue,
+        );
+        expect(find.byIcon(Icons.visibility), findsOneWidget);
+
+        await tester.tap(find.byIcon(Icons.visibility));
+        await tester.pump();
+
+        expect(
+          tester.widget<TextField>(textFieldFinder).obscureText,
+          isFalse,
+        );
+        expect(find.byIcon(Icons.visibility_off), findsOneWidget);
+      },
+    );
   });
 }


### PR DESCRIPTION
Introduce PiTextField to enhance password visibility management in the EnterPassphraseDialog and ImportEncryptedDataPage. This change allows users to toggle the visibility of their passphrase, improving usability and security.