### PR TITLE
Replace gms_check with google_api_availability for service checks

### DIFF
--- a/lib/utils/firebase_utils.dart
+++ b/lib/utils/firebase_utils.dart
@@ -23,7 +23,7 @@ import 'dart:io';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/services.dart';
-import 'package:gms_check/gms_check.dart';
+import 'package:google_api_availability/google_api_availability.dart';
 import 'package:mutex/mutex.dart';
 import 'package:privacyidea_authenticator/repo/secure_storage.dart';
 
@@ -100,7 +100,9 @@ class FirebaseUtils {
 
   static Future<bool> _checkGmsAvailability() async {
     try {
-      return await GmsCheck().checkGmsAvailability() ?? false;
+      final availability = await GoogleApiAvailability.instance
+          .checkGooglePlayServicesAvailability();
+      return availability == GooglePlayServicesAvailability.success;
     } catch (e, s) {
       Logger.error(
         'Error while checking GMS availability',

--- a/lib/utils/firebase_utils.dart
+++ b/lib/utils/firebase_utils.dart
@@ -116,39 +116,37 @@ class FirebaseUtils {
   static bool get isMessagingAvailable => _isMessagingAvailable ?? false;
 
   Future<FirebaseApp?> initializeApp() async {
-    await _initFbMutex.acquire();
-    try {
-      if (initializedFirebase) {
-        Logger.warning('Firebase already initialized');
-        _initFbMutex.release();
+    return _initFbMutex.protect(() async {
+      try {
+        if (initializedFirebase) {
+          Logger.warning('Firebase already initialized');
+          return null;
+        }
+        assert(
+          appFirebaseOptions != null,
+          'Firebase options must be set before initializing Firebase',
+        );
+        final FirebaseOptions options = appFirebaseOptions!;
+        final app = await Firebase.initializeApp(
+          name: "fb-${options.projectId}",
+          options: options,
+        );
+        await app.setAutomaticDataCollectionEnabled(false);
+        initializedFirebase = true;
+        assert(
+          app.isAutomaticDataCollectionEnabled == false,
+          'Automatic data collection should be disabled',
+        );
+        return app;
+      } catch (e, s) {
+        Logger.error(
+          'Error while initializing Firebase',
+          error: e,
+          stackTrace: s,
+        );
         return null;
       }
-      assert(
-        appFirebaseOptions != null,
-        'Firebase options must be set before initializing Firebase',
-      );
-      final FirebaseOptions options = appFirebaseOptions!;
-      final app = await Firebase.initializeApp(
-        name: "fb-${options.projectId}",
-        options: options,
-      );
-      await app.setAutomaticDataCollectionEnabled(false);
-      initializedFirebase = true;
-      assert(
-        app.isAutomaticDataCollectionEnabled == false,
-        'Automatic data collection should be disabled',
-      );
-      _initFbMutex.release();
-      return app;
-    } catch (e, s) {
-      _initFbMutex.release();
-      Logger.error(
-        'Error while initializing Firebase',
-        error: e,
-        stackTrace: s,
-      );
-      return null;
-    }
+    });
   }
 
   Future<void> setupHandler({
@@ -156,80 +154,81 @@ class FirebaseUtils {
     required Future<void> Function(RemoteMessage) backgroundHandler,
     required dynamic Function({String? firebaseToken}) updateFirebaseToken,
   }) async {
-    await _initFbMutex.acquire();
-    if (!initializedFirebase) {
-      Logger.error('Initialize Firebase before setting up the handler');
-      _initFbMutex.release();
-      return;
-    }
-    _initFbMutex.release();
-    await _initHandlerMutex.acquire();
-    if (initializedHandler) {
-      Logger.warning('Firebase handler already initialized');
-      _initHandlerMutex.release();
-      return;
-    }
-
-    Logger.info('FirebaseUtils: Initializing Firebase');
-
-    FirebaseMessaging.onMessage.listen(foregroundHandler);
-    FirebaseMessaging.onBackgroundMessage(backgroundHandler);
-
-    try {
-      String? firebaseToken = await getFBToken();
-
-      if (firebaseToken != await getCurrentFirebaseToken() &&
-          firebaseToken != null) {
-        updateFirebaseToken(firebaseToken: firebaseToken);
+    final canSetup = await _initFbMutex.protect(() async {
+      if (!initializedFirebase) {
+        Logger.error('Initialize Firebase before setting up the handler');
+        return false;
       }
-    } catch (error, stackTrace) {
-      if (error is PlatformException) {
-        if (error.code == FIREBASE_TOKEN_ERROR_CODE) {
-          _initHandlerMutex.release();
-          return;
+      return true;
+    });
+    if (!canSetup) return;
+
+    await _initHandlerMutex.protect(() async {
+      if (initializedHandler) {
+        Logger.warning('Firebase handler already initialized');
+        return;
+      }
+
+      Logger.info('FirebaseUtils: Initializing Firebase');
+
+      FirebaseMessaging.onMessage.listen(foregroundHandler);
+      FirebaseMessaging.onBackgroundMessage(backgroundHandler);
+
+      try {
+        String? firebaseToken = await getFBToken();
+
+        if (firebaseToken != await getCurrentFirebaseToken() &&
+            firebaseToken != null) {
+          updateFirebaseToken(firebaseToken: firebaseToken);
         }
-        showErrorStatusMessage(
-          message: (l) => l.pushInitializeUnavailable,
-          details: (_) =>
-              '${error.code}: ${error.message ?? 'no error message'}',
-        );
-      }
-      if (error is FirebaseException) {
-        if (error.code == FIREBASE_TOKEN_ERROR_CODE) {
-          _initHandlerMutex.release();
-          return;
-        }
-        showErrorStatusMessage(
-          message: (l) => l.pushInitializeUnavailable,
-          details: (_) =>
-              '${error.code}: ${error.message ?? 'no error message'}',
-        );
-      }
-
-      Logger.error(
-        'Unknown Firebase error',
-        error: error,
-        stackTrace: stackTrace,
-      );
-    }
-
-    FirebaseMessaging.instance.onTokenRefresh.listen((String newToken) async {
-      if ((await getCurrentFirebaseToken()) != newToken) {
-        await setNewFirebaseToken(newToken);
-        try {
-          updateFirebaseToken(firebaseToken: newToken);
-        } catch (error, stackTrace) {
-          Logger.error(
-            'Error updating firebase token',
-            error: error,
-            stackTrace: stackTrace,
+      } catch (error, stackTrace) {
+        if (error is PlatformException) {
+          if (error.code == FIREBASE_TOKEN_ERROR_CODE) {
+            return;
+          }
+          showErrorStatusMessage(
+            message: (l) => l.pushInitializeUnavailable,
+            details: (_) =>
+                '${error.code}: ${error.message ?? 'no error message'}',
           );
         }
-      }
-    });
+        if (error is FirebaseException) {
+          if (error.code == FIREBASE_TOKEN_ERROR_CODE) {
+            return;
+          }
+          showErrorStatusMessage(
+            message: (l) => l.pushInitializeUnavailable,
+            details: (_) =>
+                '${error.code}: ${error.message ?? 'no error message'}',
+          );
+        }
 
-    initializedHandler = true;
-    _initHandlerMutex.release();
+        Logger.error(
+          'Unknown Firebase error',
+          error: error,
+          stackTrace: stackTrace,
+        );
+      }
+
+      FirebaseMessaging.instance.onTokenRefresh.listen((
+        String newToken,
+      ) async {
+        if ((await getCurrentFirebaseToken()) != newToken) {
+          await setNewFirebaseToken(newToken);
+          try {
+            updateFirebaseToken(firebaseToken: newToken);
+          } catch (error, stackTrace) {
+            Logger.error(
+              'Error updating firebase token',
+              error: error,
+              stackTrace: stackTrace,
+            );
+          }
+        }
+      });
+
+      initializedHandler = true;
+    });
   }
 
   Future<String?> getFBToken() async {
@@ -255,7 +254,7 @@ class FirebaseUtils {
     if (firebaseToken == null) {
       throw PlatformException(
         message:
-            'Firebase token could not be retrieved, the only know cause of this is'
+            'Firebase token could not be retrieved, the only known cause of this is'
             ' that the firebase servers could not be reached.',
         code: FIREBASE_TOKEN_ERROR_CODE,
       );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -799,14 +799,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
-  gms_check:
+  google_api_availability:
     dependency: "direct main"
     description:
-      name: gms_check
-      sha256: b3fc08fd41da233f9761f9981303346aa9778b4802e90ce9bd8122674fcca6f0
+      name: google_api_availability
+      sha256: "2ffdc91e1e0cf4e7974fef6c2988a24cefa81f03526ff04b694df6dc0fcbca03"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "5.0.1"
+  google_api_availability_android:
+    dependency: transitive
+    description:
+      name: google_api_availability_android
+      sha256: "4794147f43a8f3eee6b514d3ae30dbe6f7b9048cae8cd2a74cb4055cd28d74a8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
+  google_api_availability_platform_interface:
+    dependency: transitive
+    description:
+      name: google_api_availability_platform_interface
+      sha256: "65b7da62fe5b582bb3d508628ad827d36d890710ea274766a992a56fa5420da6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   graphs:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -57,7 +57,7 @@ dependencies:
   flutter_zxing: ^2.3.0
   font_awesome_flutter: ^11.0.0
   freezed_annotation: ^3.1.0
-  gms_check: ^1.0.3
+  google_api_availability: ^5.0.1
   hex: ^0.2.0
   home_widget: ^0.9.0
   http: ^1.2.2

--- a/test/unit_test/state_notifiers/sortable_notifier_test.dart
+++ b/test/unit_test/state_notifiers/sortable_notifier_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:google_api_availability/google_api_availability.dart';
 import 'package:mockito/mockito.dart';
 import 'package:privacyidea_authenticator/model/enums/algorithms.dart';
 import 'package:privacyidea_authenticator/model/riverpod_states/settings_state.dart';
@@ -26,7 +25,6 @@ void _testSortableNotifier() {
   group('SortableNotifier test', () {
     test('handleNewList', () async {
       final mockSettingsRepo = MockSettingsRepository();
-      await GoogleApiAvailability.instance.checkGooglePlayServicesAvailability();
       when(
         mockSettingsRepo.loadSettings(),
       ).thenAnswer((_) async => SettingsState());

--- a/test/unit_test/state_notifiers/sortable_notifier_test.dart
+++ b/test/unit_test/state_notifiers/sortable_notifier_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:gms_check/gms_check.dart';
+import 'package:google_api_availability/google_api_availability.dart';
 import 'package:mockito/mockito.dart';
 import 'package:privacyidea_authenticator/model/enums/algorithms.dart';
 import 'package:privacyidea_authenticator/model/riverpod_states/settings_state.dart';
@@ -26,7 +26,7 @@ void _testSortableNotifier() {
   group('SortableNotifier test', () {
     test('handleNewList', () async {
       final mockSettingsRepo = MockSettingsRepository();
-      await GmsCheck().checkGmsAvailability();
+      await GoogleApiAvailability.instance.checkGooglePlayServicesAvailability();
       when(
         mockSettingsRepo.loadSettings(),
       ).thenAnswer((_) async => SettingsState());

--- a/test/unit_test/state_notifiers/token_container_notifier_test.dart
+++ b/test/unit_test/state_notifiers/token_container_notifier_test.dart
@@ -1,7 +1,6 @@
 import 'package:collection/collection.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:google_api_availability/google_api_availability.dart';
 import 'package:http/http.dart' as http;
 import 'package:mockito/mockito.dart';
 import 'package:privacyidea_authenticator/api/interfaces/container_api.dart';
@@ -667,7 +666,6 @@ void main() {
     test('handleProcessorResult', () async {
       // prepare
       TestWidgetsFlutterBinding.ensureInitialized();
-      await GoogleApiAvailability.instance.checkGooglePlayServicesAvailability();
       var containerRepoState = TokenContainerState(containerList: []);
       final mockContainerRepo = MockTokenContainerRepository();
       final mockContainerApi = MockTokenContainerApi();
@@ -784,7 +782,6 @@ void main() {
     test('finalizeContainer', () async {
       // prepare
       TestWidgetsFlutterBinding.ensureInitialized();
-      await GoogleApiAvailability.instance.checkGooglePlayServicesAvailability();
       var containerRepoState = buildUnfinalizedContainerState();
       final mockContainerRepo = MockTokenContainerRepository();
       final mockContainerApi = MockTokenContainerApi();
@@ -895,7 +892,6 @@ void main() {
       test('sync', () async {
         // prepare
         TestWidgetsFlutterBinding.ensureInitialized();
-        await GoogleApiAvailability.instance.checkGooglePlayServicesAvailability();
         var containerRepoState = buildFinalizedContainerState();
         final containerToSync =
             containerRepoState.containerList.first as TokenContainerFinalized;
@@ -1422,7 +1418,6 @@ void main() {
       'handleProcessorResults does not replace container when disabledUnregister is true',
       () async {
         TestWidgetsFlutterBinding.ensureInitialized();
-        await GoogleApiAvailability.instance.checkGooglePlayServicesAvailability();
         // buildFinalizedContainerState() returns a container with serial "CONTAINER01" and disabledUnregister: true
         var repoState = buildFinalizedContainerState();
         final originalNonce =

--- a/test/unit_test/state_notifiers/token_container_notifier_test.dart
+++ b/test/unit_test/state_notifiers/token_container_notifier_test.dart
@@ -1,7 +1,7 @@
 import 'package:collection/collection.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:gms_check/gms_check.dart';
+import 'package:google_api_availability/google_api_availability.dart';
 import 'package:http/http.dart' as http;
 import 'package:mockito/mockito.dart';
 import 'package:privacyidea_authenticator/api/interfaces/container_api.dart';
@@ -667,7 +667,7 @@ void main() {
     test('handleProcessorResult', () async {
       // prepare
       TestWidgetsFlutterBinding.ensureInitialized();
-      await GmsCheck().checkGmsAvailability();
+      await GoogleApiAvailability.instance.checkGooglePlayServicesAvailability();
       var containerRepoState = TokenContainerState(containerList: []);
       final mockContainerRepo = MockTokenContainerRepository();
       final mockContainerApi = MockTokenContainerApi();
@@ -784,7 +784,7 @@ void main() {
     test('finalizeContainer', () async {
       // prepare
       TestWidgetsFlutterBinding.ensureInitialized();
-      await GmsCheck().checkGmsAvailability();
+      await GoogleApiAvailability.instance.checkGooglePlayServicesAvailability();
       var containerRepoState = buildUnfinalizedContainerState();
       final mockContainerRepo = MockTokenContainerRepository();
       final mockContainerApi = MockTokenContainerApi();
@@ -895,7 +895,7 @@ void main() {
       test('sync', () async {
         // prepare
         TestWidgetsFlutterBinding.ensureInitialized();
-        await GmsCheck().checkGmsAvailability();
+        await GoogleApiAvailability.instance.checkGooglePlayServicesAvailability();
         var containerRepoState = buildFinalizedContainerState();
         final containerToSync =
             containerRepoState.containerList.first as TokenContainerFinalized;
@@ -1422,7 +1422,7 @@ void main() {
       'handleProcessorResults does not replace container when disabledUnregister is true',
       () async {
         TestWidgetsFlutterBinding.ensureInitialized();
-        await GmsCheck().checkGmsAvailability();
+        await GoogleApiAvailability.instance.checkGooglePlayServicesAvailability();
         // buildFinalizedContainerState() returns a container with serial "CONTAINER01" and disabledUnregister: true
         var repoState = buildFinalizedContainerState();
         final originalNonce =

--- a/test/unit_test/state_notifiers/token_folder_notifier_test.dart
+++ b/test/unit_test/state_notifiers/token_folder_notifier_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:google_api_availability/google_api_availability.dart';
 import 'package:mockito/mockito.dart';
 import 'package:privacyidea_authenticator/model/riverpod_states/token_folder_state.dart';
 import 'package:privacyidea_authenticator/model/token_folder.dart';
@@ -34,7 +33,6 @@ void _testTokenFolderNotifier() {
     });
 
     test('removeFolder', () async {
-      await GoogleApiAvailability.instance.checkGooglePlayServicesAvailability();
       final mockRepo = MockTokenFolderRepository();
       final mockTokenRepo = MockTokenRepository();
       when(mockTokenRepo.loadTokens()).thenAnswer((_) async => const []);

--- a/test/unit_test/state_notifiers/token_folder_notifier_test.dart
+++ b/test/unit_test/state_notifiers/token_folder_notifier_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:gms_check/gms_check.dart';
+import 'package:google_api_availability/google_api_availability.dart';
 import 'package:mockito/mockito.dart';
 import 'package:privacyidea_authenticator/model/riverpod_states/token_folder_state.dart';
 import 'package:privacyidea_authenticator/model/token_folder.dart';
@@ -34,7 +34,7 @@ void _testTokenFolderNotifier() {
     });
 
     test('removeFolder', () async {
-      await GmsCheck().checkGmsAvailability();
+      await GoogleApiAvailability.instance.checkGooglePlayServicesAvailability();
       final mockRepo = MockTokenFolderRepository();
       final mockTokenRepo = MockTokenRepository();
       when(mockTokenRepo.loadTokens()).thenAnswer((_) async => const []);

--- a/test/unit_test/utils/riverpod/riverpod_providers/generated_providers/token_notifier_test.dart
+++ b/test/unit_test/utils/riverpod/riverpod_providers/generated_providers/token_notifier_test.dart
@@ -20,7 +20,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:google_api_availability/google_api_availability.dart';
 import 'package:http/http.dart';
 import 'package:mockito/mockito.dart';
 import 'package:pointycastle/export.dart';
@@ -423,7 +422,6 @@ void _testTokenNotifier() {
     });
     test('addOrReplaceTokens', () async {
       final mockSettingsRepo = MockSettingsRepository();
-      await GoogleApiAvailability.instance.checkGooglePlayServicesAvailability();
       when(
         mockSettingsRepo.loadSettings(),
       ).thenAnswer((_) async => SettingsState());
@@ -494,7 +492,6 @@ void _testTokenNotifier() {
     });
     test('addTokenFromOtpAuth', () async {
       WidgetsFlutterBinding.ensureInitialized();
-      await GoogleApiAvailability.instance.checkGooglePlayServicesAvailability();
       final mockSettingsRepo = MockSettingsRepository();
       when(
         mockSettingsRepo.loadSettings(),

--- a/test/unit_test/utils/riverpod/riverpod_providers/generated_providers/token_notifier_test.dart
+++ b/test/unit_test/utils/riverpod/riverpod_providers/generated_providers/token_notifier_test.dart
@@ -20,7 +20,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:gms_check/gms_check.dart';
+import 'package:google_api_availability/google_api_availability.dart';
 import 'package:http/http.dart';
 import 'package:mockito/mockito.dart';
 import 'package:pointycastle/export.dart';
@@ -423,7 +423,7 @@ void _testTokenNotifier() {
     });
     test('addOrReplaceTokens', () async {
       final mockSettingsRepo = MockSettingsRepository();
-      await GmsCheck().checkGmsAvailability();
+      await GoogleApiAvailability.instance.checkGooglePlayServicesAvailability();
       when(
         mockSettingsRepo.loadSettings(),
       ).thenAnswer((_) async => SettingsState());
@@ -494,7 +494,7 @@ void _testTokenNotifier() {
     });
     test('addTokenFromOtpAuth', () async {
       WidgetsFlutterBinding.ensureInitialized();
-      await GmsCheck().checkGmsAvailability();
+      await GoogleApiAvailability.instance.checkGooglePlayServicesAvailability();
       final mockSettingsRepo = MockSettingsRepository();
       when(
         mockSettingsRepo.loadSettings(),


### PR DESCRIPTION
Refactor the service availability checks to use the `google_api_availability` package instead of `gms_check`, improving compatibility and reliability. Update dependencies accordingly.