### PR TITLE
Replace no_screenshot with screen_security for screenshot management

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,7 +14,7 @@ subprojects {
 }
 
 // Force Kotlin language version 1.9 for plugins incompatible with Kotlin 2.x
-def kotlin19Projects = ['no_screenshot', 'home_widget']
+def kotlin19Projects = ['home_widget']
 gradle.projectsEvaluated {
     subprojects { subproject ->
         if (kotlin19Projects.contains(subproject.name)) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,10 +30,12 @@ gradle.projectsEvaluated {
 // home_widget uses glance-appwidget:1.+ which resolves to 1.3.0-alpha01 requiring compileSdk 37.
 // Pin to last stable release compatible with compileSdk 36.
 subprojects {
-    configurations.all {
-        resolutionStrategy {
-            force 'androidx.glance:glance-appwidget:1.1.1'
-            force 'androidx.glance:glance:1.1.1'
+    if (project.name == 'home_widget') {
+        configurations.all {
+            resolutionStrategy {
+                force 'androidx.glance:glance-appwidget:1.1.1'
+                force 'androidx.glance:glance:1.1.1'
+            }
         }
     }
 }

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -364,9 +364,9 @@
 				"${BUILT_PRODUCTS_DIR}/integration_test/integration_test.framework",
 				"${BUILT_PRODUCTS_DIR}/local_auth_darwin/local_auth_darwin.framework",
 				"${BUILT_PRODUCTS_DIR}/nanopb/nanopb.framework",
-				"${BUILT_PRODUCTS_DIR}/no_screenshot/no_screenshot.framework",
 				"${BUILT_PRODUCTS_DIR}/package_info_plus/package_info_plus.framework",
 				"${BUILT_PRODUCTS_DIR}/path_provider_foundation/path_provider_foundation.framework",
+				"${BUILT_PRODUCTS_DIR}/screen_security/screen_security.framework",
 				"${BUILT_PRODUCTS_DIR}/shared_preferences_foundation/shared_preferences_foundation.framework",
 				"${BUILT_PRODUCTS_DIR}/url_launcher_ios/url_launcher_ios.framework",
 			);
@@ -396,9 +396,9 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/integration_test.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/local_auth_darwin.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/nanopb.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/no_screenshot.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/package_info_plus.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/path_provider_foundation.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/screen_security.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/shared_preferences_foundation.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/url_launcher_ios.framework",
 			);

--- a/lib/utils/allow_screenshot_utils.dart
+++ b/lib/utils/allow_screenshot_utils.dart
@@ -17,23 +17,37 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import 'package:no_screenshot/no_screenshot.dart';
+import 'package:screen_security/screen_security.dart';
 
 import 'logger.dart';
 
 class AllowScreenshotUtils {
+  final _screenSecurity = ScreenSecurity();
+
   /// Enables the ability to take screenshots
   /// Returns true if the operation was successful
-  Future<bool> allowScreenshots() {
-    Logger.info("Screenshots allowed");
-    return NoScreenshot.instance.screenshotOn();
+  Future<bool> allowScreenshots() async {
+    try {
+      await _screenSecurity.disable();
+      Logger.info("Screenshots allowed");
+      return true;
+    } catch (e, s) {
+      Logger.warning("Failed to allow screenshots", error: e, stackTrace: s);
+      return false;
+    }
   }
 
   /// Disables the ability to take screenshots
   /// Returns true if the operation was successful
-  Future<bool> disallowScreenshots() {
-    Logger.info("Screenshots not allowed");
-    return NoScreenshot.instance.screenshotOff();
+  Future<bool> disallowScreenshots() async {
+    try {
+      await _screenSecurity.enable();
+      Logger.info("Screenshots not allowed");
+      return true;
+    } catch (e, s) {
+      Logger.warning("Failed to disallow screenshots", error: e, stackTrace: s);
+      return false;
+    }
   }
 
   /// Toggles the ability to take screenshots

--- a/lib/utils/allow_screenshot_utils.dart
+++ b/lib/utils/allow_screenshot_utils.dart
@@ -54,9 +54,9 @@ class AllowScreenshotUtils {
   /// Returns true if the operation was successful
   Future<bool> toggleAllowScreenshots(bool oldState) {
     if (oldState) {
-      return allowScreenshots();
-    } else {
       return disallowScreenshots();
+    } else {
+      return allowScreenshots();
     }
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1196,14 +1196,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.0"
-  no_screenshot:
-    dependency: "direct main"
-    description:
-      name: no_screenshot
-      sha256: "373cc7d9ec62f2fe0898318bfa38ad8f717e5b9729be78cd00112d3ab278cb18"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.0"
   node_preamble:
     dependency: transitive
     description:
@@ -1492,6 +1484,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.4-dev.1"
+  screen_security:
+    dependency: "direct main"
+    description:
+      name: screen_security
+      sha256: df8092294908cf5f4802a5f5660be594484ed63e4dd5791ea1ff119a8defb6d6
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -72,7 +72,6 @@ dependencies:
   logger: ^2.4.0
   material_symbols_icons: ^4.2906.0
   mutex: ^3.1.0
-  no_screenshot: ^1.0.0
   otp: ^3.1.4
   package_info_plus: ^9.0.0
   path_provider: ^2.1.4
@@ -80,6 +79,7 @@ dependencies:
   pointycastle: ^3.9.1
   protobuf: ^6.0.0
   riverpod_annotation: ^4.0.0
+  screen_security: ^1.1.0
   shared_preferences: ^2.3.2
   url_launcher: ^6.3.1
   uuid: ^4.5.1


### PR DESCRIPTION
Refactor screenshot management by replacing the no_screenshot package with screen_security. Update the logic for toggling screenshot permissions to improve clarity and error handling. This change enhances the functionality and maintainability of the code.