### PR TITLE
Require explicit selection for initial container assignment

### DIFF
--- a/lib/api/impl/privacy_idea_container_api.dart
+++ b/lib/api/impl/privacy_idea_container_api.dart
@@ -51,8 +51,7 @@ import '../interfaces/container_api.dart';
 
 class PiContainerApi implements TokenContainerApi {
   final PrivacyideaIOClient _ioClient;
-  const PiContainerApi({required PrivacyideaIOClient ioClient})
-    : _ioClient = ioClient;
+  const PiContainerApi({required this._ioClient});
 
   /* //////////////////////////////
   //////// PUBLIC METHODS /////////
@@ -64,7 +63,6 @@ class PiContainerApi implements TokenContainerApi {
     TokenState tokenState, {
     SimpleKeyPair? withX25519Key,
     bool? isInitSync,
-    bool? sendAllOTPs,
   }) async {
     final containerTokenTemplates = tokenState
         .containerTokens(container.serial)
@@ -79,24 +77,21 @@ class PiContainerApi implements TokenContainerApi {
     final assignmentCandidates = initialTokenAssignment
         ? notLinkedTokens
         : <Token>[];
-    final templatesForAssignment = <TokenTemplate>[];
-    if (assignmentCandidates.isNotEmpty) {
-      final List<Token> selectedTokens;
-      if (sendAllOTPs == true) {
-        selectedTokens = assignmentCandidates;
-      } else {
-        final dialogSelection = await InitialTokenAssignmentDialog.showDialog(
-          container,
-          assignmentCandidates,
-        );
-
-        if (dialogSelection == null) {
-          // User canceled the dialog => cancel sync
-          return null;
-        }
-        selectedTokens = dialogSelection.toList();
+    // Tokens with a serial are identified by their serial, so no otp values are needed.
+    final templatesForAssignment = assignmentCandidates.withSerial
+        .toTemplates();
+    // Tokens without a serial are identified by otp values, which needs the users consent.
+    final tokensWithoutSerial = assignmentCandidates.withoutSerial;
+    if (tokensWithoutSerial.isNotEmpty) {
+      final selectedTokens = await InitialTokenAssignmentDialog.showDialog(
+        container,
+        tokensWithoutSerial,
+      );
+      if (selectedTokens == null) {
+        // User canceled the dialog => cancel sync
+        return null;
       }
-      templatesForAssignment.addAll(selectedTokens.toTemplates());
+      templatesForAssignment.addAll(selectedTokens.toList().toTemplates());
     }
 
     final ContainerChallenge challenge = await _getChallenge(

--- a/lib/api/impl/privacy_idea_container_api.dart
+++ b/lib/api/impl/privacy_idea_container_api.dart
@@ -110,11 +110,10 @@ class PiContainerApi implements TokenContainerApi {
       challenge: challenge,
       encKeyPair: encKeyPair,
       otpAuthMaps: [
-        for (var template in [
-          ...containerTokenTemplates,
-          ...templatesForAssignment,
-        ])
-          template.otpAuthMapSafeToSend,
+        for (var template in containerTokenTemplates)
+          template.tokenDataSafeToSend,
+        for (var template in templatesForAssignment)
+          template.tokenIdentification,
       ],
     );
 
@@ -426,7 +425,11 @@ class PiContainerApi implements TokenContainerApi {
     if (HttpStatusChecker.isError(challengeResponse.statusCode)) {
       PiServerResultError? piError;
       try {
-        final piResponse = PiServerResponse.fromResponse<ContainerChallenge, EmptyResultDetail>(challengeResponse);
+        final piResponse =
+            PiServerResponse.fromResponse<
+              ContainerChallenge,
+              EmptyResultDetail
+            >(challengeResponse);
         piError = piResponse.asSuccess?.result.error;
       } catch (_) {
         // Response body is not valid privacyIDEA JSON

--- a/lib/api/impl/privacy_idea_container_api.dart
+++ b/lib/api/impl/privacy_idea_container_api.dart
@@ -76,27 +76,27 @@ class PiContainerApi implements TokenContainerApi {
     final notLinkedTokens = tokenState.tokens.maybeContainerTokensOf(
       container.serial,
     );
-    final templatesForAssignment = initialTokenAssignment
-        ? notLinkedTokens.withSerial.toTemplates()
-        : <TokenTemplate>[];
-
-    final tokensWithoutSerial = notLinkedTokens.withoutSerial;
-    List<Token>? selectedTokens;
-    if (initialTokenAssignment && tokensWithoutSerial.isNotEmpty) {
+    final assignmentCandidates = initialTokenAssignment
+        ? notLinkedTokens
+        : <Token>[];
+    final templatesForAssignment = <TokenTemplate>[];
+    if (assignmentCandidates.isNotEmpty) {
+      final List<Token> selectedTokens;
       if (sendAllOTPs == true) {
-        templatesForAssignment.addAll(tokensWithoutSerial.toTemplates());
+        selectedTokens = assignmentCandidates;
       } else {
-        selectedTokens = (await InitialTokenAssignmentDialog.showDialog(
+        final dialogSelection = await InitialTokenAssignmentDialog.showDialog(
           container,
-          tokensWithoutSerial,
-        ))?.toList();
+          assignmentCandidates,
+        );
 
-        if (selectedTokens == null) {
+        if (dialogSelection == null) {
           // User canceled the dialog => cancel sync
           return null;
         }
-        templatesForAssignment.addAll(selectedTokens.toTemplates());
+        selectedTokens = dialogSelection.toList();
       }
+      templatesForAssignment.addAll(selectedTokens.toTemplates());
     }
 
     final ContainerChallenge challenge = await _getChallenge(
@@ -195,7 +195,7 @@ class PiContainerApi implements TokenContainerApi {
       newTokens: newTokens,
       updatedTokens: updatedTokens,
       deletedTokens: deleteTokens,
-      initAssignmentChecked: tokensWithoutSerial,
+      initAssignmentChecked: assignmentCandidates,
       newPolicies: syncResult.policies,
       containerSerial: container.serial,
     );

--- a/lib/api/impl/privacy_idea_container_api.dart
+++ b/lib/api/impl/privacy_idea_container_api.dart
@@ -76,7 +76,9 @@ class PiContainerApi implements TokenContainerApi {
     final notLinkedTokens = tokenState.tokens.maybeContainerTokensOf(
       container.serial,
     );
-    final templatesForAssignment = notLinkedTokens.withSerial.toTemplates();
+    final templatesForAssignment = initialTokenAssignment
+        ? notLinkedTokens.withSerial.toTemplates()
+        : <TokenTemplate>[];
 
     final tokensWithoutSerial = notLinkedTokens.withoutSerial;
     List<Token>? selectedTokens;

--- a/lib/model/token_template.dart
+++ b/lib/model/token_template.dart
@@ -78,8 +78,30 @@ sealed class TokenTemplate with _$TokenTemplate {
     name: Token.CONTAINER_SERIAL,
   );
 
-  Map<String, dynamic> get otpAuthMapSafeToSend =>
+  /// The complete token data without the secret.
+  /// Should only be sent for tokens that are already linked to the container.
+  Map<String, dynamic> get tokenDataSafeToSend =>
       Map<String, dynamic>.from(otpAuthMap)..remove(OTPToken.SECRET_BASE32);
+
+  /// Contains only the values the server needs to identify the token.
+  /// A token with a serial is identified by the serial, a token without a serial
+  /// by its type and two consecutive otp values.
+  Map<String, dynamic> get tokenIdentification => {
+    for (final key in serial != null ? _serialIdentifier : _otpIdentifier)
+      if (otpAuthMap[key] != null) key: otpAuthMap[key],
+  };
+
+  static const List<String> _serialIdentifier = [
+    Token.SERIAL,
+    Token.TOKENTYPE_OTPAUTH,
+  ];
+
+  /// 'counter' is HOTPToken.COUNTER, which can not be imported here without creating an import cycle.
+  static const List<String> _otpIdentifier = [
+    Token.TOKENTYPE_OTPAUTH,
+    OTPToken.OTP_VALUES,
+    'counter',
+  ];
 
   @override
   operator ==(Object other) {

--- a/lib/utils/riverpod/riverpod_providers/generated_providers/token_container_notifier.dart
+++ b/lib/utils/riverpod/riverpod_providers/generated_providers/token_container_notifier.dart
@@ -312,7 +312,7 @@ class TokenContainerNotifier extends _$TokenContainerNotifier
       await updateContainer(
         finalizedContainer,
         (TokenContainerFinalized c) =>
-            c.copyWith(syncState: SyncState.completed),
+            c.copyWith(syncState: SyncState.completed, initSynced: true),
       );
       ContainerSyncResultDialog.showDialog(
         container: finalizedContainer,

--- a/test/unit_test/api/privacy_idea_container_api_test.dart
+++ b/test/unit_test/api/privacy_idea_container_api_test.dart
@@ -21,28 +21,79 @@
 import 'dart:convert';
 
 import 'package:cryptography/cryptography.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart';
 import 'package:mockito/mockito.dart';
 import 'package:privacyidea_authenticator/api/impl/privacy_idea_container_api.dart';
+import 'package:privacyidea_authenticator/api/interfaces/container_api.dart';
+import 'package:privacyidea_authenticator/l10n/app_localizations.dart';
 import 'package:privacyidea_authenticator/model/container_policies.dart';
-import 'package:privacyidea_authenticator/model/exception_errors/pi_server_result_error.dart';
-import 'package:privacyidea_authenticator/model/exception_errors/response_error.dart';
 import 'package:privacyidea_authenticator/model/enums/algorithms.dart';
 import 'package:privacyidea_authenticator/model/enums/ec_key_algorithm.dart';
 import 'package:privacyidea_authenticator/model/enums/rollout_state.dart';
 import 'package:privacyidea_authenticator/model/enums/sync_state.dart';
+import 'package:privacyidea_authenticator/model/exception_errors/pi_server_result_error.dart';
+import 'package:privacyidea_authenticator/model/exception_errors/response_error.dart';
 import 'package:privacyidea_authenticator/model/riverpod_states/token_state.dart';
 import 'package:privacyidea_authenticator/model/token_container.dart';
 import 'package:privacyidea_authenticator/model/tokens/hotp_token.dart';
 import 'package:privacyidea_authenticator/model/tokens/totp_token.dart';
 import 'package:privacyidea_authenticator/utils/ecc_utils.dart';
 import 'package:privacyidea_authenticator/utils/logger.dart';
-import 'package:test/test.dart';
+import 'package:privacyidea_authenticator/widgets/dialog_widgets/container_dialogs/initial_token_assignment_dialog.dart';
+import 'package:privacyidea_authenticator/widgets/select_tokens_widget.dart';
 
+import '../../tests_app_wrapper.dart';
 import '../../tests_app_wrapper.mocks.dart';
 
 void main() {
   _testPrivacyIdeaContainerApi();
+}
+
+/// Synchronizes the container and selects all tokens if the assignment dialog is shown.
+Future<ContainerSyncUpdates?> _syncWithAssignment(
+  WidgetTester tester, {
+  required PiContainerApi containerApi,
+  required TokenContainerFinalized container,
+  required TokenState tokenState,
+  required SimpleKeyPair withX25519Key,
+}) async {
+  tester.view.physicalSize = const Size(600, 1000);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  await tester.pumpWidget(const TestsAppWrapper(child: SizedBox()));
+  final syncResult = containerApi.sync(
+    container,
+    tokenState,
+    withX25519Key: withX25519Key,
+    isInitSync: true,
+  );
+  // The token tiles animate, so the dialogs are advanced by a fixed duration instead of settling.
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 500));
+  if (find.byType(InitialTokenAssignmentDialog).evaluate().isEmpty) {
+    return syncResult;
+  }
+  final selectTokens = tester.widget<SelectTokensWidget>(
+    find.byType(SelectTokensWidget),
+  );
+  selectTokens.onSelect(selectTokens.tokens, {});
+  await tester.pump();
+  final localizations = AppLocalizations.of(
+    tester.element(find.byType(InitialTokenAssignmentDialog)),
+  )!;
+  await tester.tap(
+    find.text(localizations.initialTokenAssignmentDialogButtonSelected),
+  );
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 500));
+  if (!container.sslVerify) {
+    await tester.tap(find.text(localizations.send));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+  }
+  return syncResult;
 }
 
 void _testPrivacyIdeaContainerApi() {
@@ -284,83 +335,89 @@ void _testPrivacyIdeaContainerApi() {
       expect(policies.disabledTokenDeletion, true);
       expect(policies.disabledUnregister, true);
     });
-    test('finalizeContainer throws PiServerResultError on status false with error', () async {
-      final tokenContainer = getNewTokenContainer();
-      final mockIoClient = MockPrivacyideaIOClient();
-      final containerApi = PiContainerApi(ioClient: mockIoClient);
+    test(
+      'finalizeContainer throws PiServerResultError on status false with error',
+      () async {
+        final tokenContainer = getNewTokenContainer();
+        final mockIoClient = MockPrivacyideaIOClient();
+        final containerApi = PiContainerApi(ioClient: mockIoClient);
 
-      when(
-        mockIoClient.doPost(
-          url: anyNamed('url'),
-          body: anyNamed('body'),
-          sslVerify: anyNamed('sslVerify'),
-        ),
-      ).thenAnswer(
-        (_) async => Response(
-          jsonEncode({
-            'id': 1,
-            'jsonrpc': '2.0',
-            'result': {
-              'status': false,
-              'error': {
-                'code': 3002,
-                'message': 'ERR3002: Could not verify signature!',
+        when(
+          mockIoClient.doPost(
+            url: anyNamed('url'),
+            body: anyNamed('body'),
+            sslVerify: anyNamed('sslVerify'),
+          ),
+        ).thenAnswer(
+          (_) async => Response(
+            jsonEncode({
+              'id': 1,
+              'jsonrpc': '2.0',
+              'result': {
+                'status': false,
+                'error': {
+                  'code': 3002,
+                  'message': 'ERR3002: Could not verify signature!',
+                },
               },
-            },
-            'time': 1.0,
-            'version': 'privacyIDEA 3.6.2',
-            'detail': null,
-            'signature': 'signature',
-          }),
-          400,
-        ),
-      );
+              'time': 1.0,
+              'version': 'privacyIDEA 3.6.2',
+              'detail': null,
+              'signature': 'signature',
+            }),
+            400,
+          ),
+        );
 
-      await expectLater(
-        () => containerApi.finalizeContainer(tokenContainer),
-        throwsA(
-          isA<PiServerResultError>()
-              .having((e) => e.code, 'code', 3002)
-              .having(
-                (e) => e.message,
-                'message',
-                contains('Could not verify signature'),
-              ),
-        ),
-      );
-    });
+        await expectLater(
+          () => containerApi.finalizeContainer(tokenContainer),
+          throwsA(
+            isA<PiServerResultError>()
+                .having((e) => e.code, 'code', 3002)
+                .having(
+                  (e) => e.message,
+                  'message',
+                  contains('Could not verify signature'),
+                ),
+          ),
+        );
+      },
+    );
 
-    test('finalizeContainer throws ResponseError on status false without error field', () async {
-      final tokenContainer = getNewTokenContainer();
-      final mockIoClient = MockPrivacyideaIOClient();
-      final containerApi = PiContainerApi(ioClient: mockIoClient);
+    test(
+      'finalizeContainer throws ResponseError on status false without error field',
+      () async {
+        final tokenContainer = getNewTokenContainer();
+        final mockIoClient = MockPrivacyideaIOClient();
+        final containerApi = PiContainerApi(ioClient: mockIoClient);
 
-      when(
-        mockIoClient.doPost(
-          url: anyNamed('url'),
-          body: anyNamed('body'),
-          sslVerify: anyNamed('sslVerify'),
-        ),
-      ).thenAnswer(
-        (_) async => Response(
-          jsonEncode({
-            'id': 1,
-            'jsonrpc': '2.0',
-            'result': {'status': false},
-            'time': 1.0,
-            'version': 'privacyIDEA 3.6.2',
-            'detail': null,
-            'signature': 'signature',
-          }),
-          400,
-        ),
-      );
+        when(
+          mockIoClient.doPost(
+            url: anyNamed('url'),
+            body: anyNamed('body'),
+            sslVerify: anyNamed('sslVerify'),
+          ),
+        ).thenAnswer(
+          (_) async => Response(
+            jsonEncode({
+              'id': 1,
+              'jsonrpc': '2.0',
+              'result': {'status': false},
+              'time': 1.0,
+              'version': 'privacyIDEA 3.6.2',
+              'detail': null,
+              'signature': 'signature',
+            }),
+            400,
+          ),
+        );
 
-      await expectLater(
-        () => containerApi.finalizeContainer(tokenContainer),
-        throwsA(isA<ResponseError>()),
-      );
-    });
+        await expectLater(
+          () => containerApi.finalizeContainer(tokenContainer),
+          throwsA(isA<ResponseError>()),
+        );
+      },
+    );
 
     test('getRolloverQrData', () async {
       // Arrange
@@ -571,7 +628,71 @@ void _testPrivacyIdeaContainerApi() {
         );
       }
 
-      test('add', () async {
+      test(
+        'sends the identification of unlinked tokens with serial without asking the user',
+        () async {
+          final mockIoClient = MockPrivacyideaIOClient();
+          final containerApi = PiContainerApi(ioClient: mockIoClient);
+          final tokenContainer = getFinalizedTokenContainer(
+            withPolicies: ContainerPolicies(
+              rolloverAllowed: true,
+              initialTokenAssignment: true,
+              disabledTokenDeletion: false,
+              disabledUnregister: false,
+            ),
+          );
+          final tokenState = TokenState(
+            tokens: [
+              HOTPToken(
+                label: 'unlinked token',
+                serial: 'OATH00068B93',
+                issuer: 'privacyIDEA',
+                counter: 1,
+                id: 'id1',
+                algorithm: Algorithms.SHA1,
+                digits: 6,
+                secret: 'CDLDLKLUMPDR2IJJZJHF5XKFKBABU4XR',
+              ),
+            ],
+          );
+          Map<String, dynamic>? containerDictClient;
+
+          when(
+            mockIoClient.doPost(
+              url: anyNamed('url'),
+              body: anyNamed('body'),
+              sslVerify: anyNamed('sslVerify'),
+            ),
+          ).thenAnswer((invocation) async {
+            final Uri invocationUrl = invocation.namedArguments[Symbol('url')];
+            final Map<String, String?> invocationBody =
+                invocation.namedArguments[Symbol('body')];
+            if (invocationUrl.toString() ==
+                    'http://example.com/container/challenge' &&
+                invocationBody['scope'] ==
+                    'http://example.com/container/synchronize') {
+              return containerChallengeResponse;
+            }
+            containerDictClient =
+                jsonDecode(invocationBody[TokenContainer.SYNC_DICT_CLIENT]!)
+                    as Map<String, dynamic>;
+            return Response(jsonEncode(exampleError), 400);
+          });
+
+          // There is no dialog in this test, so the sync would be canceled if it was shown
+          await expectLater(
+            () =>
+                containerApi.sync(tokenContainer, tokenState, isInitSync: true),
+            throwsA(isA<ResponseError>()),
+          );
+
+          expect(containerDictClient?[TokenContainer.DICT_TOKENS], [
+            {'serial': 'OATH00068B93', 'tokentype': 'HOTP'},
+          ]);
+        },
+      );
+
+      testWidgets('add', (tester) async {
         // Arrange
         final mockIoClient = MockPrivacyideaIOClient();
         final containerApi = PiContainerApi(ioClient: mockIoClient);
@@ -688,12 +809,12 @@ void _testPrivacyIdeaContainerApi() {
         );
 
         // Act
-        final result = await containerApi.sync(
-          tokenContainer,
-          tokenState,
+        final result = await _syncWithAssignment(
+          tester,
+          containerApi: containerApi,
+          container: tokenContainer,
+          tokenState: tokenState,
           withX25519Key: publicSimpleKeyPair,
-          isInitSync: true,
-          sendAllOTPs: true,
         );
 
         // Asserta
@@ -724,7 +845,7 @@ void _testPrivacyIdeaContainerApi() {
         expect(token1.digits, 6);
         expect(token1.secret, 'XH5COUO6JSL5PE6VKOC3XNVENJHXCHIP');
       });
-      test('update unlinked token (with serial)', () async {
+      testWidgets('update unlinked token (with serial)', (tester) async {
         // Arrange
         final mockIoClient = MockPrivacyideaIOClient();
         final containerApi = PiContainerApi(ioClient: mockIoClient);
@@ -830,12 +951,12 @@ void _testPrivacyIdeaContainerApi() {
         );
 
         // Act
-        final result = await containerApi.sync(
-          tokenContainer,
-          tokenState,
+        final result = await _syncWithAssignment(
+          tester,
+          containerApi: containerApi,
+          container: tokenContainer,
+          tokenState: tokenState,
           withX25519Key: publicSimpleKeyPair,
-          isInitSync: true,
-          sendAllOTPs: true,
         );
 
         // Assert
@@ -869,7 +990,7 @@ void _testPrivacyIdeaContainerApi() {
         expect(token1.digits, 6);
         expect(token1.secret, '3LTZKAYTNIK5DUE4SLIGTKOC6ZK36E2G');
       });
-      test('update unlinked token (without serial)', () async {
+      testWidgets('update unlinked token (without serial)', (tester) async {
         // Arrange
         final mockIoClient = MockPrivacyideaIOClient();
         final containerApi = PiContainerApi(ioClient: mockIoClient);
@@ -984,12 +1105,12 @@ void _testPrivacyIdeaContainerApi() {
         );
 
         // Act
-        final result = await containerApi.sync(
-          tokenContainer,
-          tokenState,
+        final result = await _syncWithAssignment(
+          tester,
+          containerApi: containerApi,
+          container: tokenContainer,
+          tokenState: tokenState,
           withX25519Key: publicSimpleKeyPair,
-          isInitSync: true,
-          sendAllOTPs: true,
         );
         // Asserta
         expect(result, isNotNull);
@@ -1019,7 +1140,7 @@ void _testPrivacyIdeaContainerApi() {
         expect(token1.digits, 6);
         expect(token1.secret, 'CDLDLKLUMPDR2IJJZJHF5XKFKBABU4XR');
       });
-      test('sync with unknown tokens (with serial)', () async {
+      testWidgets('sync with unknown tokens (with serial)', (tester) async {
         // Arrange
         final mockIoClient = MockPrivacyideaIOClient();
         final containerApi = PiContainerApi(ioClient: mockIoClient);
@@ -1135,12 +1256,12 @@ void _testPrivacyIdeaContainerApi() {
         );
 
         // Act
-        final result = await containerApi.sync(
-          tokenContainer,
-          tokenState,
+        final result = await _syncWithAssignment(
+          tester,
+          containerApi: containerApi,
+          container: tokenContainer,
+          tokenState: tokenState,
           withX25519Key: publicSimpleKeyPair,
-          isInitSync: true,
-          sendAllOTPs: true,
         );
         // Asserta
         expect(result, isNotNull);
@@ -1164,7 +1285,7 @@ void _testPrivacyIdeaContainerApi() {
         expect(token0.secret, 'CDLDLKLUMPDR2IJJZJHF5XKFKBABU4XR');
         expect(token0.serial, 'TOTP00011B1F');
       });
-      test('sync with unknown tokens (without serial)', () async {
+      testWidgets('sync with unknown tokens (without serial)', (tester) async {
         // Arrange
         final mockIoClient = MockPrivacyideaIOClient();
         final containerApi = PiContainerApi(ioClient: mockIoClient);
@@ -1280,12 +1401,12 @@ void _testPrivacyIdeaContainerApi() {
         );
 
         // Act
-        final result = await containerApi.sync(
-          tokenContainer,
-          tokenState,
+        final result = await _syncWithAssignment(
+          tester,
+          containerApi: containerApi,
+          container: tokenContainer,
+          tokenState: tokenState,
           withX25519Key: publicSimpleKeyPair,
-          isInitSync: true,
-          sendAllOTPs: true,
         );
         // Asserta
         expect(result, isNotNull);

--- a/test/unit_test/api/privacy_idea_container_api_test.dart
+++ b/test/unit_test/api/privacy_idea_container_api_test.dart
@@ -492,6 +492,85 @@ void _testPrivacyIdeaContainerApi() {
       expect(result.success, true);
     });
     group("sync", () {
+      final nonAssignmentCases = [
+        (
+          name: 'when the policy is disabled',
+          policyEnabled: false,
+          isInitSync: true,
+        ),
+        (
+          name: 'after the initial synchronization',
+          policyEnabled: true,
+          isInitSync: false,
+        ),
+      ];
+      for (final testCase in nonAssignmentCases) {
+        test(
+          'does not send unlinked tokens with serial ${testCase.name}',
+          () async {
+            final mockIoClient = MockPrivacyideaIOClient();
+            final containerApi = PiContainerApi(ioClient: mockIoClient);
+            final tokenContainer = getFinalizedTokenContainer(
+              withPolicies: ContainerPolicies(
+                rolloverAllowed: true,
+                initialTokenAssignment: testCase.policyEnabled,
+                disabledTokenDeletion: false,
+                disabledUnregister: false,
+              ),
+            );
+            final tokenState = TokenState(
+              tokens: [
+                HOTPToken(
+                  label: 'unlinked token',
+                  serial: 'OATH00068B93',
+                  issuer: 'privacyIDEA',
+                  counter: 1,
+                  id: 'id1',
+                  algorithm: Algorithms.SHA1,
+                  digits: 6,
+                  secret: 'CDLDLKLUMPDR2IJJZJHF5XKFKBABU4XR',
+                ),
+              ],
+            );
+            Map<String, dynamic>? containerDictClient;
+
+            when(
+              mockIoClient.doPost(
+                url: anyNamed('url'),
+                body: anyNamed('body'),
+                sslVerify: anyNamed('sslVerify'),
+              ),
+            ).thenAnswer((invocation) async {
+              final Uri invocationUrl =
+                  invocation.namedArguments[Symbol('url')];
+              final Map<String, String?> invocationBody =
+                  invocation.namedArguments[Symbol('body')];
+              if (invocationUrl.toString() ==
+                      'http://example.com/container/challenge' &&
+                  invocationBody['scope'] ==
+                      'http://example.com/container/synchronize') {
+                return containerChallengeResponse;
+              }
+              containerDictClient =
+                  jsonDecode(invocationBody[TokenContainer.SYNC_DICT_CLIENT]!)
+                      as Map<String, dynamic>;
+              return Response(jsonEncode(exampleError), 400);
+            });
+
+            await expectLater(
+              () => containerApi.sync(
+                tokenContainer,
+                tokenState,
+                isInitSync: testCase.isInitSync,
+              ),
+              throwsA(isA<ResponseError>()),
+            );
+
+            expect(containerDictClient?[TokenContainer.DICT_TOKENS], isEmpty);
+          },
+        );
+      }
+
       test('add', () async {
         // Arrange
         final mockIoClient = MockPrivacyideaIOClient();

--- a/test/unit_test/api/privacy_idea_container_api_test.dart
+++ b/test/unit_test/api/privacy_idea_container_api_test.dart
@@ -841,6 +841,7 @@ void _testPrivacyIdeaContainerApi() {
         // Assert
         expect(result, isNotNull);
         final newPolicies = result!.newPolicies;
+        expect(result.initAssignmentChecked, tokenState.tokens);
         expect(newPolicies.initialTokenAssignment, false);
         expect(newPolicies.rolloverAllowed, false);
         expect(newPolicies.disabledTokenDeletion, true);

--- a/test/unit_test/api/privacy_idea_container_api_test.dart
+++ b/test/unit_test/api/privacy_idea_container_api_test.dart
@@ -609,7 +609,7 @@ void _testPrivacyIdeaContainerApi() {
           }
           final publicEncKeyClientB64 = invocationBody['public_enc_key_client'];
           final containerDictClient =
-              '{"container_serial":"SMPH00067A2F","type":"smartphone","tokens":[{"tokentype":"HOTP","label":"label1","issuer":"privacyIDEA","pin":"False","offline":false,"app_force_unlock":"none","algorithm":"SHA1","digits":"6","otp":["435986","964213"],"counter":"5"}]}';
+              '{"container_serial":"SMPH00067A2F","type":"smartphone","tokens":[{"tokentype":"HOTP","otp":["435986","964213"],"counter":"5"}]}';
 
           final signMessage2 =
               '$containerChallengeNonce|'
@@ -762,7 +762,7 @@ void _testPrivacyIdeaContainerApi() {
           }
           final publicEncKeyClientB64 = invocationBody['public_enc_key_client'];
           final containerDictClient =
-              '{"container_serial":"SMPH00067A2F","type":"smartphone","tokens":[{"serial":"OATH00068B93","tokentype":"HOTP","label":"OATH00068B93","issuer":"privacyIDEA","pin":"False","offline":false,"app_force_unlock":"none","algorithm":"SHA1","digits":"6","counter":"1"}]}';
+              '{"container_serial":"SMPH00067A2F","type":"smartphone","tokens":[{"serial":"OATH00068B93","tokentype":"HOTP"}]}';
 
           final signMessage2 =
               '$containerChallengeNonce|'
@@ -916,7 +916,7 @@ void _testPrivacyIdeaContainerApi() {
           }
           final publicEncKeyClientB64 = invocationBody['public_enc_key_client'];
           final containerDictClient =
-              '{"container_serial":"SMPH00067A2F","type":"smartphone","tokens":[{"serial":"TOTP00011B1F","tokentype":"TOTP","label":"TOTP00011B1F","issuer":"privacyIDEA","pin":"False","offline":false,"app_force_unlock":"none","algorithm":"SHA1","digits":"6","period":"30"},{"tokentype":"HOTP","label":"OATH00166051","issuer":"privacyIDEA","pin":"False","offline":false,"app_force_unlock":"none","algorithm":"SHA1","digits":"6","otp":["079447","501895"],"counter":"1"}]}';
+              '{"container_serial":"SMPH00067A2F","type":"smartphone","tokens":[{"serial":"TOTP00011B1F","tokentype":"TOTP"},{"tokentype":"HOTP","otp":["079447","501895"],"counter":"1"}]}';
 
           final signMessage2 =
               '$containerChallengeNonce|'
@@ -1067,7 +1067,7 @@ void _testPrivacyIdeaContainerApi() {
           }
           final publicEncKeyClientB64 = invocationBody['public_enc_key_client'];
           final containerDictClient =
-              '{"container_serial":"SMPH00067A2F","type":"smartphone","tokens":[{"serial":"TOTP00011B1F","tokentype":"TOTP","label":"TOTP00011B1F","issuer":"privacyIDEA","pin":"False","offline":false,"app_force_unlock":"none","algorithm":"SHA1","digits":"6","period":"30"},{"serial":"OATH00166051","tokentype":"HOTP","label":"OATH00166051","issuer":"privacyIDEA","pin":"False","offline":false,"app_force_unlock":"none","algorithm":"SHA1","digits":"6","counter":"1"}]}';
+              '{"container_serial":"SMPH00067A2F","type":"smartphone","tokens":[{"serial":"TOTP00011B1F","tokentype":"TOTP"},{"serial":"OATH00166051","tokentype":"HOTP"}]}';
 
           final signMessage2 =
               '$containerChallengeNonce|'
@@ -1212,7 +1212,7 @@ void _testPrivacyIdeaContainerApi() {
           final publicEncKeyClientB64 = invocationBody['public_enc_key_client'];
 
           final containerDictClient =
-              '{"container_serial":"SMPH00067A2F","type":"smartphone","tokens":[{"serial":"TOTP00011B1F","tokentype":"TOTP","label":"TOTP00011B1F","issuer":"privacyIDEA","pin":"False","offline":false,"app_force_unlock":"none","algorithm":"SHA1","digits":"6","period":"30"},{"tokentype":"HOTP","label":"OATH00166051","issuer":"privacyIDEA","pin":"False","offline":false,"app_force_unlock":"none","algorithm":"SHA1","digits":"6","otp":["079447","501895"],"counter":"1"}]}';
+              '{"container_serial":"SMPH00067A2F","type":"smartphone","tokens":[{"serial":"TOTP00011B1F","tokentype":"TOTP"},{"tokentype":"HOTP","otp":["079447","501895"],"counter":"1"}]}';
 
           final signMessage2 =
               '$containerChallengeNonce|'

--- a/test/unit_test/state_notifiers/token_container_notifier_test.dart
+++ b/test/unit_test/state_notifiers/token_container_notifier_test.dart
@@ -1085,6 +1085,7 @@ void main() {
         ).called(1);
         expect(stateContainer.policies, expectedContainer.policies);
         expect(stateContainer.syncState, SyncState.completed);
+        expect(stateContainer.initSynced, isTrue);
         expect(tokenState.tokens.length, 3);
         expect(
           tokenState.tokens,


### PR DESCRIPTION
## Summary

- send only tokens already linked to the smartphone container during normal synchronization
- treat every eligible unlinked token, including tokens with a serial, as an explicit initial-assignment candidate
- send only the candidates selected in the existing assignment dialog
- persist completion of the first successful synchronization so later synchronizations cannot repeat initial assignment
- keep initial assignment pending after a canceled or failed synchronization

## Root cause

`templatesForAssignment` was populated automatically with every eligible unlinked serial-bearing token. This happened outside the user-selection dialog, and the existing `initSynced` field was never set after a successful synchronization. Consequently, unrelated token details could be included during normal synchronization and initial assignment could be considered repeatedly.

## Behavior after this change

- policy disabled or initial synchronization already completed: only tokens linked to this container are sent
- initial assignment active: all eligible unlinked tokens are shown for selection and only selected tokens are sent
- dialog canceled or synchronization failed: `initSynced` remains false and synchronization can be retried
- synchronization succeeded: `initSynced` is persisted as true

## Validation

- `flutter test --no-pub test/unit_test/api/privacy_idea_container_api_test.dart`
- `flutter test --no-pub test/unit_test/state_notifiers/token_container_notifier_test.dart`
- both focused suites passed
- focused `flutter analyze --no-pub` found no errors or warnings; four pre-existing `prefer_initializing_formals` info diagnostics remain
