### PR TITLE
Require immediate Google Play updates

### DIFF
--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -2160,6 +2160,8 @@
   "unsupported": "Příkaz {name} [{value}] není touto verzí aplikace podporován.",
   "useDeviceLocaleDescription": "Použít jazyk zařízení, pokud je podporován, případně angličtinu.",
   "useDeviceLocaleTitle": "Použít jazyk zařízení",
+  "updateNow": "Aktualizovat",
+  "updateRequired": "Vyžadována aktualizace",
   "valueNotAllowed": "Typ {type} „{value}“ není povolenou hodnotou pro „{parameter}“",
   "valueNotAllowedIn": "Typ {type} „{value}“ není povolenou hodnotou pro „{parameter}“ v „{map}“",
   "verboseLogging": "Zevrubné protokolování",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -2181,6 +2181,8 @@
   "unsupported": "Der {name} [{value}] wird von dieser Version der App nicht unterstützt.",
   "useDeviceLocaleDescription": "Nutze Systemsprache, falls diese unterstützt wird. Anderenfalls nutze Englisch. ",
   "useDeviceLocaleTitle": "Nutze Systemsprache",
+  "updateNow": "Aktualisieren",
+  "updateRequired": "Aktualisierung erforderlich",
   "valueNotAllowed": "Typ {type} „{value}“ ist kein zulässiger Wert für „{parameter}“",
   "valueNotAllowedIn": "Typ {type} „{value}“ ist kein zulässiger Wert für „{parameter}“ in „{map}“",
   "verboseLogging": "Ausführliche Protokollierung",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2181,6 +2181,8 @@
   "unsupported": "The {name} [{value}] is not supported by this version of the app.",
   "useDeviceLocaleDescription": "Use device language if it is supported, otherwise default to english.",
   "useDeviceLocaleTitle": "Use device language",
+  "updateNow": "Update",
+  "updateRequired": "Update required",
   "valueNotAllowed": "Type {type} “{value}” is not a permitted value for “{parameter}”",
   "valueNotAllowedIn": "Type {type} “{value}” is not a valid value for “{parameter}” in “{map}”",
   "verboseLogging": "Verbose logging",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -2160,6 +2160,8 @@
   "unsupported": "{name} [{value}] no es compatible con esta versión de la aplicación.",
   "useDeviceLocaleDescription": "Utilizar el idioma del dispositivo si está soportado, en caso contrario por defecto inglés.",
   "useDeviceLocaleTitle": "Utiliza el idioma del teléfono",
+  "updateNow": "Actualizar",
+  "updateRequired": "Actualización requerida",
   "valueNotAllowed": "Tipo {type} «{value}» no es un valor permitido para »{parameter}»",
   "valueNotAllowedIn": "Tipo {type} «{value}» no es un valor válido para “{parameter}” en »{map}»d",
   "verboseLogging": "Registro detallado",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -2160,6 +2160,8 @@
   "unsupported": "Le {name} [{value}] n'est pas pris en charge par cette version de l'application.",
   "useDeviceLocaleDescription": "Utilisez la langue de l'appareil si elle est prise en charge, sinon l'anglais par défaut.",
   "useDeviceLocaleTitle": "Utiliser la langue de l'appareil",
+  "updateNow": "Mettre à jour",
+  "updateRequired": "Mise à jour requise",
   "valueNotAllowed": "Type {type} « {value} » n'est pas une valeur autorisée pour »{parameter} »",
   "valueNotAllowedIn": "Type {type} « {value} » n'est pas une valeur valide pour “{parameter}” dans »{map} »",
   "verboseLogging": "Journalisation verbeuse",

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -2160,6 +2160,8 @@
   "unsupported": "Nama {name} [{value}] tidak didukung oleh versi aplikasi ini.",
   "useDeviceLocaleDescription": "Gunakan bahasa perangkat jika didukung, jika tidak, default ke bahasa Inggris.",
   "useDeviceLocaleTitle": "Gunakan bahasa perangkat",
+  "updateNow": "Perbarui",
+  "updateRequired": "Pembaruan diperlukan",
   "valueNotAllowed": "Ketik {type} “{value}” bukan nilai yang diizinkan untuk ”{parameter}”",
   "valueNotAllowedIn": "Ketik {type} “{value}” bukan merupakan nilai yang valid untuk “{parameter}“ di ”{map}”",
   "verboseLogging": "Penebangan kata demi kata",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -2160,6 +2160,8 @@
   "unsupported": "De {name} [{value}] wordt niet ondersteund door deze versie van de app.",
   "useDeviceLocaleDescription": "Gebruik de taal van het apparaat wanneer het wordt ondersteund, val anders terug op Engels.",
   "useDeviceLocaleTitle": "Gebruik de taal van het apparaat",
+  "updateNow": "Bijwerken",
+  "updateRequired": "Update vereist",
   "valueNotAllowed": "Type {type} “{value}” is geen toegestane waarde voor “{parameter}“",
   "valueNotAllowedIn": "Type {type} “{value}” is geen geldige waarde voor “{parameter}“ in ”{map}”",
   "verboseLogging": "Verbose loggen",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -2160,6 +2160,8 @@
   "unsupported": "Opcja {name} [{value}] nie jest obsługiwana przez tę wersję aplikacji.",
   "useDeviceLocaleDescription": "Użyj języka urządzenia, jeśli jest wspierany. W innym wypadku zostanie ustawiony domyślny język angielski.",
   "useDeviceLocaleTitle": "Użyj języka urządzenia.",
+  "updateNow": "Aktualizuj",
+  "updateRequired": "Wymagana aktualizacja",
   "valueNotAllowed": "Typ {type} „{value}” nie jest dozwoloną wartością dla »{parameter}«.",
   "valueNotAllowedIn": "Typ {type} „{value}” nie jest prawidłową wartością dla »{parameter}« w »{map}«.",
   "verboseLogging": "Wyczerpujące rejestrowanie",

--- a/lib/mains/main_customizer.dart
+++ b/lib/mains/main_customizer.dart
@@ -42,13 +42,16 @@ import '../views/qr_scanner_view/qr_scanner_view.dart';
 import '../views/settings_view/settings_view.dart';
 import '../views/splash_screen/splash_screen.dart';
 import '../widgets/app_wrapper.dart';
+import '../widgets/app_wrappers/immediate_update_gate.dart';
 
 void main() async {
   await initializeApp();
   runApp(
     AppWrapper(
-      child: CustomizationAuthenticator(
-        initialCustomization: ApplicationCustomization.defaultCustomization,
+      child: ImmediateUpdateGate(
+        child: CustomizationAuthenticator(
+          initialCustomization: ApplicationCustomization.defaultCustomization,
+        ),
       ),
     ),
   );

--- a/lib/mains/main_netknights.dart
+++ b/lib/mains/main_netknights.dart
@@ -45,6 +45,7 @@ import '../views/qr_scanner_view/qr_scanner_view.dart';
 import '../views/settings_view/settings_view.dart';
 import '../views/splash_screen/splash_screen.dart';
 import '../widgets/app_wrapper.dart';
+import '../widgets/app_wrappers/immediate_update_gate.dart';
 
 void main() async {
   Logger.init(
@@ -56,8 +57,10 @@ void main() async {
       );
       runApp(
         AppWrapper(
-          child: PrivacyIDEAAuthenticator(
-            ApplicationCustomization.defaultCustomization,
+          child: ImmediateUpdateGate(
+            child: PrivacyIDEAAuthenticator(
+              ApplicationCustomization.defaultCustomization,
+            ),
           ),
         ),
       );

--- a/lib/widgets/app_wrappers/immediate_update_gate.dart
+++ b/lib/widgets/app_wrappers/immediate_update_gate.dart
@@ -1,0 +1,175 @@
+/*
+ * privacyIDEA Authenticator
+ *
+ * Author: Krzysztof Wielgosz <14099566+frankii91@users.noreply.github.com>
+ *
+ * Copyright (c) 2026 Krzysztof Wielgosz
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:in_app_update/in_app_update.dart';
+
+import '../../l10n/app_localizations.dart';
+import '../../utils/globals.dart';
+import '../../utils/logger.dart';
+
+enum ImmediateUpdateAvailability { unavailable, available, inProgress }
+
+abstract interface class ImmediateUpdateClient {
+  Future<ImmediateUpdateAvailability> checkAvailability();
+
+  Future<void> performImmediateUpdate();
+}
+
+class PlayImmediateUpdateClient implements ImmediateUpdateClient {
+  const PlayImmediateUpdateClient();
+
+  @override
+  Future<ImmediateUpdateAvailability> checkAvailability() async {
+    if (kIsWeb || defaultTargetPlatform != TargetPlatform.android) {
+      return ImmediateUpdateAvailability.unavailable;
+    }
+
+    final updateInfo = await InAppUpdate.checkForUpdate();
+    if (updateInfo.updateAvailability ==
+        UpdateAvailability.developerTriggeredUpdateInProgress) {
+      return ImmediateUpdateAvailability.inProgress;
+    }
+    if (updateInfo.updateAvailability == UpdateAvailability.updateAvailable &&
+        updateInfo.immediateUpdateAllowed) {
+      return ImmediateUpdateAvailability.available;
+    }
+    return ImmediateUpdateAvailability.unavailable;
+  }
+
+  @override
+  Future<void> performImmediateUpdate() async {
+    await InAppUpdate.performImmediateUpdate();
+  }
+}
+
+class ImmediateUpdateGate extends StatefulWidget {
+  static const updateButtonKey = Key('immediate-update');
+
+  final Widget child;
+  final ImmediateUpdateClient client;
+  final GlobalKey<NavigatorState>? navigatorKey;
+
+  const ImmediateUpdateGate({
+    required this.child,
+    this.client = const PlayImmediateUpdateClient(),
+    this.navigatorKey,
+    super.key,
+  });
+
+  @override
+  State<ImmediateUpdateGate> createState() => _ImmediateUpdateGateState();
+}
+
+class _ImmediateUpdateGateState extends State<ImmediateUpdateGate> {
+  late final AppLifecycleListener _lifecycleListener;
+  bool _checking = false;
+  bool _promptHandledForSession = false;
+  bool _startingUpdate = false;
+
+  GlobalKey<NavigatorState> get _navigatorKey =>
+      widget.navigatorKey ?? globalNavigatorKey;
+
+  @override
+  void initState() {
+    super.initState();
+    _lifecycleListener = AppLifecycleListener(onResume: _checkForUpdate);
+    WidgetsBinding.instance.addPostFrameCallback((_) => _checkForUpdate());
+  }
+
+  @override
+  void dispose() {
+    _lifecycleListener.dispose();
+    super.dispose();
+  }
+
+  Future<void> _checkForUpdate() async {
+    if (!mounted || _checking) return;
+
+    _checking = true;
+    try {
+      final availability = await widget.client.checkAvailability();
+      if (!mounted) return;
+
+      if (availability == ImmediateUpdateAvailability.inProgress) {
+        await _startImmediateUpdate();
+        return;
+      }
+      if (availability != ImmediateUpdateAvailability.available ||
+          _promptHandledForSession) {
+        return;
+      }
+
+      final navigatorContext = _navigatorKey.currentContext;
+      if (navigatorContext == null || !navigatorContext.mounted) return;
+
+      _promptHandledForSession = true;
+      await showDialog<void>(
+        context: navigatorContext,
+        barrierDismissible: false,
+        builder: (dialogContext) {
+          final localizations = AppLocalizations.of(dialogContext)!;
+          return PopScope(
+            canPop: false,
+            child: AlertDialog(
+              title: Text(localizations.updateRequired),
+              actions: [
+                FilledButton(
+                  key: ImmediateUpdateGate.updateButtonKey,
+                  onPressed: _startImmediateUpdate,
+                  child: Text(localizations.updateNow),
+                ),
+              ],
+            ),
+          );
+        },
+      );
+    } catch (error, stackTrace) {
+      Logger.warning(
+        'Could not check or start the Google Play in-app update.',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    } finally {
+      _checking = false;
+    }
+  }
+
+  Future<void> _startImmediateUpdate() async {
+    if (_startingUpdate) return;
+
+    _startingUpdate = true;
+    try {
+      await widget.client.performImmediateUpdate();
+    } catch (error, stackTrace) {
+      Logger.warning(
+        'Could not start the Google Play in-app update.',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    } finally {
+      _startingUpdate = false;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -975,6 +975,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.2"
+  in_app_update:
+    dependency: "direct main"
+    description:
+      name: in_app_update
+      sha256: c55b4da41baf34b440ba627843932aa6f1689b5c499cfac98aec156b3113d89e
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.0"
   integration_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,6 +63,7 @@ dependencies:
   image: ^4.3.0
   image_cropper: ^11.0.0
   image_picker: ^1.1.2
+  in_app_update: ^5.0.0
   intl: ^0.20.2
   json_annotation: ^4.9.0
   local_auth: ^3.0.0

--- a/test/unit_test/widgets/app_wrappers/immediate_update_gate_test.dart
+++ b/test/unit_test/widgets/app_wrappers/immediate_update_gate_test.dart
@@ -1,0 +1,163 @@
+/*
+ * privacyIDEA Authenticator
+ *
+ * Author: Krzysztof Wielgosz <14099566+frankii91@users.noreply.github.com>
+ *
+ * Copyright (c) 2026 Krzysztof Wielgosz
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacyidea_authenticator/l10n/app_localizations.dart';
+import 'package:privacyidea_authenticator/widgets/app_wrappers/immediate_update_gate.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('shows only the required update title and update action', (
+    tester,
+  ) async {
+    final client = _FakeImmediateUpdateClient(
+      availability: ImmediateUpdateAvailability.available,
+    );
+
+    await _pumpGate(tester, client);
+
+    expect(find.text('Update required'), findsOneWidget);
+    expect(find.text('Update'), findsOneWidget);
+    expect(find.byType(AlertDialog), findsOneWidget);
+    expect(find.byType(TextButton), findsNothing);
+    expect(find.byType(FilledButton), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byType(AlertDialog),
+        matching: find.byType(Text),
+      ),
+      findsNWidgets(2),
+    );
+  });
+
+  testWidgets('system back cannot dismiss the required update prompt', (
+    tester,
+  ) async {
+    final client = _FakeImmediateUpdateClient(
+      availability: ImmediateUpdateAvailability.available,
+    );
+
+    await _pumpGate(tester, client);
+    await tester.binding.handlePopRoute();
+    await tester.pump();
+
+    expect(find.byType(AlertDialog), findsOneWidget);
+    expect(client.performCount, 0);
+  });
+
+  testWidgets('update action starts the immediate update and keeps the gate', (
+    tester,
+  ) async {
+    final client = _FakeImmediateUpdateClient(
+      availability: ImmediateUpdateAvailability.available,
+    );
+
+    await _pumpGate(tester, client);
+    await tester.tap(find.byKey(ImmediateUpdateGate.updateButtonKey));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AlertDialog), findsOneWidget);
+    expect(client.performCount, 1);
+  });
+
+  testWidgets('failed update keeps the required update prompt visible', (
+    tester,
+  ) async {
+    final client = _FakeImmediateUpdateClient(
+      availability: ImmediateUpdateAvailability.available,
+      failUpdate: true,
+    );
+
+    await _pumpGate(tester, client);
+    await tester.tap(find.byKey(ImmediateUpdateGate.updateButtonKey));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AlertDialog), findsOneWidget);
+    expect(client.performCount, 1);
+  });
+
+  testWidgets('resumes an immediate update already in progress', (
+    tester,
+  ) async {
+    final client = _FakeImmediateUpdateClient(
+      availability: ImmediateUpdateAvailability.inProgress,
+    );
+
+    await _pumpGate(tester, client);
+
+    expect(find.byType(AlertDialog), findsNothing);
+    expect(client.performCount, 1);
+  });
+
+  testWidgets('does nothing when an update is unavailable', (tester) async {
+    final client = _FakeImmediateUpdateClient(
+      availability: ImmediateUpdateAvailability.unavailable,
+    );
+
+    await _pumpGate(tester, client);
+
+    expect(find.byType(AlertDialog), findsNothing);
+    expect(client.performCount, 0);
+  });
+}
+
+Future<void> _pumpGate(
+  WidgetTester tester,
+  ImmediateUpdateClient client,
+) async {
+  final navigatorKey = GlobalKey<NavigatorState>();
+
+  await tester.pumpWidget(
+    MaterialApp(
+      navigatorKey: navigatorKey,
+      locale: const Locale('en'),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: ImmediateUpdateGate(
+        client: client,
+        navigatorKey: navigatorKey,
+        child: const Scaffold(body: SizedBox()),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+class _FakeImmediateUpdateClient implements ImmediateUpdateClient {
+  final ImmediateUpdateAvailability availability;
+  final bool failUpdate;
+  int performCount = 0;
+
+  _FakeImmediateUpdateClient({
+    required this.availability,
+    this.failUpdate = false,
+  });
+
+  @override
+  Future<ImmediateUpdateAvailability> checkAvailability() async => availability;
+
+  @override
+  Future<void> performImmediateUpdate() async {
+    performCount++;
+    if (failUpdate) throw StateError('Update failed');
+  }
+}


### PR DESCRIPTION
## Summary

- add Google Play immediate in-app update support to both official app entry points
- check for updates at startup and whenever the app resumes
- show a localized, non-dismissible update gate when Google Play reports that an immediate update is available
- resume a developer-triggered immediate update that is already in progress

## Motivation

Google Play background updates are optional and are not guaranteed to run promptly. Without an in-app update check, an authenticator can continue running an obsolete client even when a newer Play release contains important security, protocol-compatibility, or reliability fixes.

The application previously had no active update path. This change asks the Google Play runtime for the authoritative update state and blocks access only when Play reports both that an update is available and that the immediate flow is allowed.

Once the gate is shown, it cannot be dismissed by tapping outside it or using the system back action. If starting the Play flow fails or the user returns from it without updating, the gate remains visible and the update can be retried.

## Unchanged behavior

- non-Android platforms continue without an update check
- Android installations for which Google Play does not offer an immediate update continue normally
- update-check failures do not block application startup
- Google Play remains responsible for download, signature verification, installation, and restart
- there is no background timer or custom update server

## Validation

- focused widget tests: 6 passed
- full Flutter test suite: passed
- Android `netknights` debug APK build: passed
- `git diff --check`: passed
- static analysis reports no diagnostics in the new gate or its tests

The current upstream analyzer baseline remains non-zero with 58 existing diagnostics (57 info diagnostics and one `invalid_annotation_target` warning in `lib/model/token_folder.dart`). None are introduced by this change.
