### PR TITLE
Persist push auto-close setting across restarts

### DIFF
--- a/lib/repo/preference_settings_repository.dart
+++ b/lib/repo/preference_settings_repository.dart
@@ -40,6 +40,8 @@ class PreferenceSettingsRepository extends SettingsRepository {
   static const String _showBackgroundImageKey = 'KEY_HIDE_BACKGROUND_IMAGE';
   static const String _allowScreenshotKey = 'KEY_ALLOW_SCREENSHOTS';
   static const String _appAuthMethodKey = 'KEY_APP_AUTH_METHOD';
+  static const String _autoCloseAppAfterAcceptingPushRequestKey =
+      'KEY_AUTO_CLOSE_APP_AFTER_ACCEPTING_PUSH_REQUEST';
 
   static final Future<SharedPreferences> _preferences =
       SharedPreferences.getInstance();
@@ -72,6 +74,9 @@ class PreferenceSettingsRepository extends SettingsRepository {
           : null,
       showBackgroundImage: prefs.getBool(_showBackgroundImageKey),
       allowScreenshots: prefs.getBool(_allowScreenshotKey),
+      autoCloseAppAfterAcceptingPushRequest: prefs.getBool(
+        _autoCloseAppAfterAcceptingPushRequestKey,
+      ),
       appAuthMethod: ForceBiometricOptionX.fromString(
         prefs.getString(_appAuthMethodKey),
       ),
@@ -119,6 +124,12 @@ class PreferenceSettingsRepository extends SettingsRepository {
         prefs.setBool(_showBackgroundImageKey, settings.showBackgroundImage),
       if (_lastState?.allowScreenshots != settings.allowScreenshots)
         prefs.setBool(_allowScreenshotKey, settings.allowScreenshots),
+      if (_lastState?.autoCloseAppAfterAcceptingPushRequest !=
+          settings.autoCloseAppAfterAcceptingPushRequest)
+        prefs.setBool(
+          _autoCloseAppAfterAcceptingPushRequestKey,
+          settings.autoCloseAppAfterAcceptingPushRequest,
+        ),
       if (_lastState?.appAuthMethod != settings.appAuthMethod)
         prefs.setString(_appAuthMethodKey, settings.appAuthMethod.name),
     ];

--- a/test/unit_test/repo/preference_settings_repository_test.dart
+++ b/test/unit_test/repo/preference_settings_repository_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacyidea_authenticator/repo/preference_settings_repository.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('persists auto-close after accepting a push request', () async {
+    SharedPreferences.setMockInitialValues({});
+    final repository = PreferenceSettingsRepository();
+
+    final initialSettings = await repository.loadSettings();
+    expect(initialSettings.autoCloseAppAfterAcceptingPushRequest, isFalse);
+
+    final saved = await repository.saveSettings(
+      initialSettings.copyWith(autoCloseAppAfterAcceptingPushRequest: true),
+    );
+    expect(saved, isTrue);
+
+    final reloadedSettings = await PreferenceSettingsRepository()
+        .loadSettings();
+    expect(reloadedSettings.autoCloseAppAfterAcceptingPushRequest, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary

Persist the Android setting that closes the app after a push request is accepted.

## Problem

Enabling **Close app after accepting push request** updated the in-memory settings state, so the switch appeared enabled and the app could close during the current process. After the app was restarted, the switch returned to disabled.

`PreferenceSettingsRepository` did not define a SharedPreferences key for `autoCloseAppAfterAcceptingPushRequest` and omitted the field from both `loadSettings()` and `saveSettings()`.

## Fix

- add a dedicated boolean SharedPreferences key;
- load the stored value into `SettingsState`;
- save the value when it changes;
- add a regression test covering load, enable, save, and reload.

The default remains `false` for users who have never enabled the option. Push request acceptance and app-closing behavior are otherwise unchanged.

## Validation

- Regression test before the fix: failed with `Expected: true`, `Actual: false`.
- Focused repository and settings notifier tests: 16 passed.
- Full Flutter test suite: 1068 passed.
- Analyzer on both changed files: no issues.
- Full-project analyzer: 58 pre-existing diagnostics in unrelated files (1 warning, 57 info); this change adds none.
- `git diff --check`: passed.
