### PR TITLE
Await screen security during settings initialization

### DIFF
--- a/lib/utils/riverpod/riverpod_providers/generated_providers/allow_screenshot_notifier.dart
+++ b/lib/utils/riverpod/riverpod_providers/generated_providers/allow_screenshot_notifier.dart
@@ -49,9 +49,11 @@ class AllowScreenshotNotifier extends _$AllowScreenshotNotifier {
     final allowScreenshot = await ref.watch(
       settingsProvider.selectAsync((settings) => settings.allowScreenshots),
     );
-    allowScreenshot
-        ? this.screenshotUtils.allowScreenshots()
-        : this.screenshotUtils.disallowScreenshots();
+    if (allowScreenshot) {
+      await this.screenshotUtils.allowScreenshots();
+    } else {
+      await this.screenshotUtils.disallowScreenshots();
+    }
     return allowScreenshot;
   }
 

--- a/test/unit_test/state_notifiers/allow_screenshot_notifier_test.dart
+++ b/test/unit_test/state_notifiers/allow_screenshot_notifier_test.dart
@@ -18,6 +18,8 @@
  * limitations under the License.
  */
 
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
@@ -81,6 +83,46 @@ void _testAllowScreenshotNotifier() {
 
     verify(mockSettingsRepository.loadSettings()).called(1);
     expect(result, false);
+  });
+
+  test('Initial state waits until screen security is applied', () async {
+    final initialScreenshotUtils = MockAllowScreenshotUtils();
+    final initialSettingsRepository = MockSettingsRepository();
+    final platformOperation = Completer<bool>();
+    when(
+      initialScreenshotUtils.allowScreenshots(),
+    ).thenAnswer((_) => platformOperation.future);
+    when(
+      initialSettingsRepository.loadSettings(),
+    ).thenAnswer((_) async => SettingsState(allowScreenshots: true));
+    final initialContainer = ProviderContainer(
+      overrides: [
+        allowScreenshotProvider.overrideWith(
+          () => AllowScreenshotNotifier(
+            screenshotUtilsOverride: initialScreenshotUtils,
+          ),
+        ),
+        settingsProvider.overrideWith(
+          () => SettingsNotifier(repoOverride: initialSettingsRepository),
+        ),
+      ],
+    );
+    addTearDown(initialContainer.dispose);
+
+    var buildCompleted = false;
+    final buildFuture = initialContainer
+        .read(allowScreenshotProvider.future)
+        .then((value) {
+          buildCompleted = true;
+          return value;
+        });
+
+    await Future<void>.delayed(Duration.zero);
+    expect(buildCompleted, isFalse);
+
+    platformOperation.complete(true);
+    expect(await buildFuture, isTrue);
+    verify(initialScreenshotUtils.allowScreenshots()).called(1);
   });
 
   test('allowScreenshots enables screenshots and updates settings', () async {


### PR DESCRIPTION
## Problem

The screenshot setting provider completed initialization before the platform screen-security operation finished. On app startup, consumers could therefore continue while screenshots were still enabled or disabled according to the previous platform state.

## Root cause

`AllowScreenshotNotifier.build` called `allowScreenshots()` or `disallowScreenshots()` without awaiting the returned future, then immediately returned the persisted setting.

## Fix

- Await the selected platform screen-security operation before completing provider initialization.
- Add a regression test with a controlled platform future and verify that the provider remains pending until the operation completes.

The persisted setting, user-facing behavior, and later toggle/update flow are unchanged; only startup ordering is made deterministic.

## Validation

- Focused notifier suite: 8 tests passed.
- Full Flutter suite on current `upstream/master`: 1068 tests passed.
- `git diff --check`: passed.
- `flutter analyze`: current upstream baseline reports 58 unrelated diagnostics (one `invalid_annotation_target` warning plus informational lints); this change adds no analyzer diagnostic.
