### PR TITLE
Show the newest pending push request first

### DIFF
--- a/lib/widgets/push_request_listener.dart
+++ b/lib/widgets/push_request_listener.dart
@@ -52,7 +52,7 @@ class _PushRequestListenerState extends ConsumerState<PushRequestListener> {
 
     final pushRequest = ref
         .watch(pushRequestProvider)
-        .whenOrNull(data: (data) => data.pushRequests.firstOrNull);
+        .whenOrNull(data: (data) => data.pushRequests.lastOrNull);
 
     if (pushRequest == null) return widget.child;
 

--- a/test/unit_test/widgets/push_request_listener_test.dart
+++ b/test/unit_test/widgets/push_request_listener_test.dart
@@ -20,9 +20,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
+import 'package:privacyidea_authenticator/model/push_request/push_default_request.dart';
 import 'package:privacyidea_authenticator/model/riverpod_states/push_request_state.dart';
 import 'package:privacyidea_authenticator/model/riverpod_states/token_state.dart';
 import 'package:privacyidea_authenticator/model/tokens/push_token.dart';
+import 'package:privacyidea_authenticator/utils/custom_int_buffer.dart';
 import 'package:privacyidea_authenticator/utils/push_provider.dart';
 import 'package:privacyidea_authenticator/utils/riverpod/riverpod_providers/generated_providers/push_request_provider.dart';
 import 'package:privacyidea_authenticator/utils/riverpod/riverpod_providers/generated_providers/token_notifier.dart';
@@ -112,6 +114,63 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Main Content'), findsOneWidget);
+    });
+
+    testWidgets('shows the newest request when multiple requests are pending', (
+      tester,
+    ) async {
+      final pushToken = PushToken(
+        serial: 'PUSH001',
+        id: 'push-id-1',
+        label: 'Push Token',
+        issuer: 'Test Issuer',
+        isRolledOut: true,
+      );
+      final now = DateTime.now();
+      final olderRequest = PushDefaultRequest(
+        title: 'Older request',
+        question: 'OLDER_PUSH',
+        uri: Uri.parse('https://example.com/older'),
+        nonce: 'older-nonce',
+        sslVerify: true,
+        expirationDate: now.add(const Duration(minutes: 1)),
+        signature: 'older-signature',
+        serial: pushToken.serial,
+      );
+      final newestRequest = PushDefaultRequest(
+        title: 'Newest request',
+        question: 'NEWEST_PUSH',
+        uri: Uri.parse('https://example.com/newest'),
+        nonce: 'newest-nonce',
+        sslVerify: true,
+        expirationDate: now.add(const Duration(minutes: 2)),
+        signature: 'newest-signature',
+        serial: pushToken.serial,
+      );
+      final restoredState = PushRequestState(
+        pushRequests: [olderRequest, newestRequest],
+        knownPushRequests: CustomIntBuffer(
+          list: [olderRequest.id, newestRequest.id],
+        ),
+      );
+
+      await tester.pumpWidget(
+        TestsAppWrapper(
+          overrides: [
+            tokenProvider.overrideWith(
+              () => FakeTokenNotifierForPush(TokenState(tokens: [pushToken])),
+            ),
+            pushRequestProvider.overrideWith(
+              () => FakePushRequestNotifier(restoredState),
+            ),
+          ],
+          child: const PushRequestListener(child: Text('Main Content')),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('NEWEST_PUSH'), findsOneWidget);
+      expect(find.text('OLDER_PUSH'), findsNothing);
     });
   });
 }


### PR DESCRIPTION
## Summary

- show the newest pending push request first when several requests are queued
- add a widget regression test for restoring multiple pending requests after the app is reopened

## Current behavior and impact

Incoming push requests are appended to `PushRequestState.pushRequests`, but `PushRequestListener` displays `firstOrNull`. As a result, when several requests are pending, the oldest request is shown while the newest and usually most relevant request remains underneath it.

The problem is especially disruptive when **Close app after accepting a push request** is enabled. After the user accepts the oldest request, the app closes. The user then has to reopen the app, accept another old request, and repeat this cycle for every queued request before finally reaching the newest one. Besides being confusing, this makes it easier to act on a stale authentication request instead of the request that just prompted the user to open the app.

## Root cause and fix

The queue preserves arrival order by appending new requests at the end. The listener selected the first element, effectively giving the oldest request the highest display priority.

This PR selects `lastOrNull` instead, so the newest pending request is displayed first. It does not change request persistence, acceptance/decline handling, expiration, or behavior when only one request is pending.

## Regression coverage

The new widget test restores a state containing an older and a newer request and verifies that:

- the newer request is visible;
- the older request is not displayed on top of it.

Validation:

- focused push listener/notifier/repository tests: 14 passed
- complete Flutter test suite: 1068 passed
- scoped Dart analysis for the changed files: no issues
- full Flutter analysis still reports 58 pre-existing diagnostics outside the changed files

## Possible follow-up (not implemented here)

Consider automatically removing older pending requests when a newer request arrives for the same push token/serial. This could prevent stale requests from resurfacing after the newest request is handled, particularly with automatic app closing enabled. It should be designed separately because it changes queue retention semantics and may require agreement on whether every challenge must remain individually actionable or auditable.
