### PR TITLE
reject urls without scheme or host before requesting them

### DIFF
--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -847,6 +847,9 @@
       }
     }
   },
+  "@invalidHttpUrl": {
+    "description": "Error message when a url can not be requested via http or https."
+  },
   "@invalidLink": {
     "description": "Error message when the link is invalid.",
     "placeholders": {
@@ -1956,6 +1959,7 @@
   "introTokenSwipe": "Přejetím po tokenech doleva zobrazíte dostupné akce.",
   "invalidBackupFile": "Vybraný soubor není platnou zálohou {appName}.",
   "invalidHostForScheme": "Neplatný hostitel: {host} pro schéma: {scheme}",
+  "invalidHttpUrl": "Adresa URL není platná pro http/https.",
   "invalidLink": "Zadaný odkaz není platným tokenem {appName} nebo není podporován.",
   "invalidQrBackup": "Naskenovaný QR kód není platnou zálohou {appName}.",
   "invalidQrFile": "Vybraný soubor neobsahuje platný QR kód z {appName}.",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -868,6 +868,9 @@
       }
     }
   },
+  "@invalidHttpUrl": {
+    "description": "Error message when a url can not be requested via http or https."
+  },
   "@invalidLink": {
     "description": "Error message when the link is invalid.",
     "placeholders": {
@@ -1983,6 +1986,7 @@
   "introTokenSwipe": "Wischen Sie Token nach links, um die verfügbaren Aktionen zu sehen.",
   "invalidBackupFile": "Die ausgewählte Datei ist kein gültiges Backup von {appName}.",
   "invalidHostForScheme": "Ungültiger Host: {host} für Schema: {scheme}",
+  "invalidHttpUrl": "URL ungültig für http/https.",
   "invalidLink": "Der eingegebene Link ist kein gültiger Token von {appName}, oder er wird nicht unterstützt.",
   "invalidQrBackup": "Der gescannte QR-Code ist kein gültiges Backup von {appName}.",
   "invalidQrFile": "Die ausgewählte Datei enthällt kein gültigen QR-Code von {appName}.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -871,6 +871,9 @@
       }
     }
   },
+  "@invalidHttpUrl": {
+    "description": "Error message when a url can not be requested via http or https."
+  },
   "@invalidLink": {
     "description": "Error message when the link is invalid.",
     "placeholders": {
@@ -1991,6 +1994,7 @@
   "invalidQrFile": "The selected file does not contain a valid QR code from {appName}.",
   "invalidQrScan": "The QR code that was scanned did not contain valid data",
   "invalidUrl": "Invalid URL",
+  "invalidHttpUrl": "URL not valid for http/https.",
   "invalidValue": "The {type} “{value}“ is not valid for “{parameter}“",
   "invalidValueIn": "The {type} “{value}“ is not valid for “{parameter}“ in “{map}“",
   "isExpotableQuestion": "Is exportable?",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -847,6 +847,9 @@
       }
     }
   },
+  "@invalidHttpUrl": {
+    "description": "Error message when a url can not be requested via http or https."
+  },
   "@invalidLink": {
     "description": "Error message when the link is invalid.",
     "placeholders": {
@@ -1956,6 +1959,7 @@
   "introTokenSwipe": "Desliza los tokens hacia la izquierda para ver las acciones disponibles",
   "invalidBackupFile": "El archivo seleccionado no es una copia de seguridad válida de {appName}",
   "invalidHostForScheme": "Host inválido: {host} para esquema: {scheme}",
+  "invalidHttpUrl": "URL no válida para http/https.",
   "invalidLink": "El enlace introducido no es un token válido de {appName}, o no es compatible",
   "invalidQrBackup": "El código QR escaneado no es una copia de seguridad válida de {appName}",
   "invalidQrFile": "El archivo seleccionado no contiene un código QR válido de {appName}",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -847,6 +847,9 @@
       }
     }
   },
+  "@invalidHttpUrl": {
+    "description": "Error message when a url can not be requested via http or https."
+  },
   "@invalidLink": {
     "description": "Error message when the link is invalid.",
     "placeholders": {
@@ -1956,6 +1959,7 @@
   "introTokenSwipe": "Balayez les jetons vers la gauche pour voir les actions disponibles",
   "invalidBackupFile": "Le fichier sélectionné n'est pas une sauvegarde valide de {appName}",
   "invalidHostForScheme": "Hôte non valide : {host} pour le schéma : {scheme}",
+  "invalidHttpUrl": "URL non valide pour http/https.",
   "invalidLink": "Le lien saisi n'est pas un jeton valide de {appName}, ou il n'est pas pris en charge",
   "invalidQrBackup": "Le code QR scanné n'est pas une sauvegarde valide de {appName}",
   "invalidQrFile": "Le fichier sélectionné ne contient pas de code QR valide de {appName}",

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -847,6 +847,9 @@
       }
     }
   },
+  "@invalidHttpUrl": {
+    "description": "Error message when a url can not be requested via http or https."
+  },
   "@invalidLink": {
     "description": "Error message when the link is invalid.Error message when the link is invalid.",
     "placeholders": {
@@ -1956,6 +1959,7 @@
   "introTokenSwipe": "Geser token ke kiri untuk melihat tindakan yang tersedia.",
   "invalidBackupFile": "File yang dipilih bukan merupakan cadangan yang valid dari {appName}.",
   "invalidHostForScheme": "Host tidak valid: {host} untuk skema: {scheme}",
+  "invalidHttpUrl": "URL tidak valid untuk http/https.",
   "invalidLink": "Tautan yang dimasukkan bukan merupakan token yang valid dari {appName}, atau tidak didukung.",
   "invalidQrBackup": "Kode QR yang dipindai bukan merupakan cadangan yang valid dari {appName}.",
   "invalidQrFile": "File yang dipilih tidak berisi kode QR yang valid dari {appName}.",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -847,6 +847,9 @@
       }
     }
   },
+  "@invalidHttpUrl": {
+    "description": "Error message when a url can not be requested via http or https."
+  },
   "@invalidLink": {
     "description": "Error message when the link is invalid.",
     "placeholders": {
@@ -1956,6 +1959,7 @@
   "introTokenSwipe": "Veeg tokens naar links om beschikbare acties te zien.",
   "invalidBackupFile": "Het geselecteerde bestand is geen geldige backup van {appName}.",
   "invalidHostForScheme": "Ongeldige host: {host} voor schema: {scheme}",
+  "invalidHttpUrl": "URL niet geldig voor http/https.",
   "invalidLink": "De ingevoerde link is geen geldig token van {appName}, of wordt niet ondersteund.",
   "invalidQrBackup": "De gescande QR code is geen geldige backup van {appName}.",
   "invalidQrFile": "Het geselecteerde bestand bevat geen geldige QR code van {appName}.",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -847,6 +847,9 @@
       }
     }
   },
+  "@invalidHttpUrl": {
+    "description": "Error message when a url can not be requested via http or https."
+  },
   "@invalidLink": {
     "description": "Error message when the link is invalid.",
     "placeholders": {
@@ -1956,6 +1959,7 @@
   "introTokenSwipe": "Przesuń tokeny w lewo, aby zobaczyć dostępne akcje.",
   "invalidBackupFile": "Wybrany plik nie jest prawidłową kopią zapasową {appName}.",
   "invalidHostForScheme": "Nieprawidłowy host: {host} dla schematu: {scheme}",
+  "invalidHttpUrl": "Adres URL nieprawidłowy dla http/https.",
   "invalidLink": "Wprowadzony link nie jest prawidłowym tokenem {appName} lub nie jest obsługiwany.",
   "invalidQrBackup": "Zeskanowany kod QR nie jest prawidłową kopią zapasową {appName}.",
   "invalidQrFile": "Wybrany plik nie zawiera prawidłowego kodu QR z {appName}.",

--- a/lib/model/extensions/uri_extension.dart
+++ b/lib/model/extensions/uri_extension.dart
@@ -1,0 +1,25 @@
+/*
+ * privacyIDEA Authenticator
+ *
+ * Author: Frank Merkel <frank.merkel@netknights.it>
+ *
+ * Copyright (c) 2026 NetKnights GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+extension UriX on Uri {
+  /// Whether this uri can be used as the target of a http request.
+  bool get isValidEndpoint =>
+      (scheme == 'http' || scheme == 'https') && host.isNotEmpty;
+}

--- a/lib/model/token_container.dart
+++ b/lib/model/token_container.dart
@@ -141,7 +141,7 @@ sealed class TokenContainer with _$TokenContainer {
           ),
           NONCE: Validators.string,
           TIMESTAMP: DateTimeX.validator,
-          FINALIZATION_URL: Validators.uri,
+          FINALIZATION_URL: Validators.httpUri,
           SERIAL: Validators.string,
           EC_KEY_ALGORITHM: EcKeyAlgorithmX.validator,
           HASH_ALGORITHM: Validators.algorithms,

--- a/lib/model/tokens/push_token.dart
+++ b/lib/model/tokens/push_token.dart
@@ -69,7 +69,7 @@ class PushToken extends Token {
       const Duration(minutes: 3),
     ),
     ENROLLMENT_CREDENTIAL: Validators.stringOptional,
-    ROLLOUT_URL: Validators.uri,
+    ROLLOUT_URL: Validators.httpUri,
     VERSION: Validators.string,
   };
 

--- a/lib/processors/scheme_processors/token_import_scheme_processors/otp_auth_processor.dart
+++ b/lib/processors/scheme_processors/token_import_scheme_processors/otp_auth_processor.dart
@@ -22,6 +22,7 @@ import 'dart:typed_data';
 import '../../../model/enums/encodings.dart';
 import '../../../model/enums/token_origin_source_type.dart';
 import '../../../model/enums/token_types.dart';
+import '../../../model/exception_errors/localized_exception.dart';
 import '../../../model/extensions/enums/encodings_extension.dart';
 import '../../../model/extensions/enums/token_origin_source_type.dart';
 import '../../../model/processor_result.dart';
@@ -105,7 +106,9 @@ class OtpAuthProcessor extends TokenImportSchemeProcessor {
       );
       return [
         ProcessorResultFailed(
-          (l) => l.unableToCreateToken,
+          e is LocalizedException
+              ? e.localizedMessage
+              : (l) => l.unableToCreateToken,
           error: e,
           resultHandlerType: resultHandlerType,
         ),

--- a/lib/utils/object_validator/base_validator.dart
+++ b/lib/utils/object_validator/base_validator.dart
@@ -20,11 +20,32 @@
 
 part of 'object_validators.dart';
 
+/// Builds a message for the user from the invalid [value] of the field [name].
+typedef ValidatorMessage =
+    String Function(
+      AppLocalizations localizations,
+      String value,
+      String name,
+    );
+
 abstract class BaseValidator<T extends Object?> {
   final T Function(Object? value)? transformer;
   final bool Function(T)? allowedValues;
 
-  const BaseValidator({this.transformer, this.allowedValues});
+  /// Shown to the user when the value could not be transformed,
+  /// instead of the generic “invalid value“ text.
+  final ValidatorMessage? invalidMessage;
+
+  /// Shown to the user when [allowedValues] rejected the transformed value,
+  /// instead of the generic “invalid value“ text.
+  final ValidatorMessage? unallowedMessage;
+
+  const BaseValidator({
+    this.transformer,
+    this.allowedValues,
+    this.invalidMessage,
+    this.unallowedMessage,
+  });
 
   // Rückgabetyp auf T (bzw. die Non-Nullable Variante) angepasst
   BaseValidator<Object?> optional();
@@ -39,16 +60,21 @@ abstract class BaseValidator<T extends Object?> {
       return transformer!(value);
     }
     if (value is T) return value;
-    throw _error(value, name);
+    throw _invalidError(value, name);
   }
 
-  Exception _error(Object? value, String name) {
+  Exception _invalidError(Object? value, String name) =>
+      _error(value, name, invalidMessage);
+
+  Exception _unallowedError(Object? value, String name) =>
+      _error(value, name, unallowedMessage);
+
+  Exception _error(Object? value, String name, ValidatorMessage? message) {
     final error = LocalizedArgumentError(
-      localizedMessage: (localizations, v, name) => localizations.invalidValue(
-        v.runtimeType.toString(),
-        v.toString(),
-        name,
-      ),
+      localizedMessage:
+          message ??
+          (localizations, v, name) =>
+              localizations.invalidValue(name, value.runtimeType.toString(), v),
       unlocalizedMessage:
           'The ${value.runtimeType} “$value“ is not valid for “$name“',
       invalidValue: value.toString(),

--- a/lib/utils/object_validator/default_object_validator.dart
+++ b/lib/utils/object_validator/default_object_validator.dart
@@ -27,6 +27,8 @@ class DefaultObjectValidator<T extends Object> extends BaseValidator<T> {
     required this.defaultValue,
     super.transformer,
     super.allowedValues,
+    super.invalidMessage,
+    super.unallowedMessage,
   });
 
   @override
@@ -43,6 +45,8 @@ class DefaultObjectValidator<T extends Object> extends BaseValidator<T> {
   OptionalObjectValidator<T> optional() => OptionalObjectValidator<T>(
     transformer: transformer,
     allowedValues: (v) => v == null ? true : (allowedValues?.call(v) ?? true),
+    invalidMessage: invalidMessage,
+    unallowedMessage: unallowedMessage,
   );
 
   @override
@@ -51,6 +55,8 @@ class DefaultObjectValidator<T extends Object> extends BaseValidator<T> {
         defaultValue: defaultValue,
         transformer: transformer,
         allowedValues: allowedValues,
+        invalidMessage: invalidMessage,
+        unallowedMessage: unallowedMessage,
       );
 
   @override

--- a/lib/utils/object_validator/object_validators.dart
+++ b/lib/utils/object_validator/object_validators.dart
@@ -21,9 +21,11 @@
 import 'dart:typed_data' show Uint8List;
 
 import '../../../../../model/extensions/enums/encodings_extension.dart';
+import '../../l10n/app_localizations.dart';
 import '../../model/enums/algorithms.dart';
 import '../../model/enums/encodings.dart';
 import '../../model/exception_errors/localized_argument_error.dart';
+import '../../model/extensions/uri_extension.dart';
 import '../logger.dart';
 
 part 'base_validator.dart';
@@ -140,10 +142,16 @@ abstract class Validators {
   );
   static final minutesDurationOptional = minutesDuration.optional();
 
-  static final uri = RequiredObjectValidator<Uri>(
-    transformer: (v) => v is String ? Uri.parse(v) : (v as Uri),
+  static final httpUri = RequiredObjectValidator<Uri>(
+    transformer: (v) {
+      if (v is Uri) return v;
+      final parsed = Uri.tryParse(v as String);
+      if (parsed == null) throw ArgumentError('Invalid url: $v');
+      return parsed;
+    },
+    allowedValues: (v) => v.isValidEndpoint,
+    unallowedMessage: (localizations, _, _) => localizations.invalidHttpUrl,
   );
-  static final uriOptional = uri.optional();
 }
 
 T validate<T extends Object?>({
@@ -153,7 +161,7 @@ T validate<T extends Object?>({
 }) {
   final result = validator.transform(value, name);
   if (!validator.valueIsAllowed(value, name)) {
-    throw (validator as dynamic)._error(value, name);
+    throw validator._unallowedError(value, name);
   }
   return result;
 }

--- a/lib/utils/object_validator/optional_object_validator.dart
+++ b/lib/utils/object_validator/optional_object_validator.dart
@@ -20,7 +20,12 @@
 part of 'object_validators.dart';
 
 class OptionalObjectValidator<T extends Object> extends BaseValidator<T?> {
-  OptionalObjectValidator({super.transformer, super.allowedValues});
+  OptionalObjectValidator({
+    super.transformer,
+    super.allowedValues,
+    super.invalidMessage,
+    super.unallowedMessage,
+  });
 
   @override
   T? transform(value, name) {
@@ -44,6 +49,8 @@ class OptionalObjectValidator<T extends Object> extends BaseValidator<T?> {
             ? null
             : (v) => transformer!(v) ?? defaultValue,
         allowedValues: allowedValues,
+        invalidMessage: invalidMessage,
+        unallowedMessage: unallowedMessage,
       );
 
   @override

--- a/lib/utils/object_validator/required_object_validator.dart
+++ b/lib/utils/object_validator/required_object_validator.dart
@@ -21,11 +21,16 @@
 part of 'object_validators.dart';
 
 class RequiredObjectValidator<T extends Object> extends BaseValidator<T> {
-  RequiredObjectValidator({super.transformer, super.allowedValues});
+  RequiredObjectValidator({
+    super.transformer,
+    super.allowedValues,
+    super.invalidMessage,
+    super.unallowedMessage,
+  });
 
   @override
   T transform(value, name) {
-    if (value == null) throw _error(value, name);
+    if (value == null) throw _invalidError(value, name);
     return _executeTransform(value, name);
   }
 
@@ -36,6 +41,8 @@ class RequiredObjectValidator<T extends Object> extends BaseValidator<T> {
       if (v == null) return true;
       return allowedValues?.call(v) ?? true;
     },
+    invalidMessage: invalidMessage,
+    unallowedMessage: unallowedMessage,
   );
 
   @override
@@ -44,6 +51,8 @@ class RequiredObjectValidator<T extends Object> extends BaseValidator<T> {
         defaultValue: defaultValue,
         transformer: transformer,
         allowedValues: allowedValues,
+        invalidMessage: invalidMessage,
+        unallowedMessage: unallowedMessage,
       );
 
   @override

--- a/lib/utils/privacyidea_io_client.dart
+++ b/lib/utils/privacyidea_io_client.dart
@@ -256,18 +256,16 @@ class PrivacyideaIOClient {
 
     IOClient ioClient = IOClient(httpClient);
 
-    StringBuffer buffer = StringBuffer(url);
-
-    if (parameters.isNotEmpty) {
-      buffer.write('?');
-      buffer.writeAll(
-        parameters.entries.map((e) => '${e.key}=${e.value}'),
-        '&',
-      );
-    }
+    final uri = parameters.isEmpty
+        ? url
+        : url.replace(
+            queryParameters: {
+              ...url.queryParametersAll,
+              for (final entry in parameters.entries) entry.key: entry.value!,
+            },
+          );
 
     Response response;
-    Uri uri = Uri.parse(buffer.toString());
     try {
       response = await ioClient.get(uri).timeout(const Duration(seconds: 15));
     } on HandshakeException catch (e, _) {

--- a/lib/utils/riverpod/riverpod_providers/generated_providers/token_notifier.dart
+++ b/lib/utils/riverpod/riverpod_providers/generated_providers/token_notifier.dart
@@ -25,9 +25,9 @@ import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart';
-import 'package:privacyidea_authenticator/utils/helpers/mutex.dart';
 import 'package:pointycastle/asymmetric/api.dart';
 import 'package:privacyidea_authenticator/model/extensions/token_list_extension.dart';
+import 'package:privacyidea_authenticator/utils/helpers/mutex.dart';
 import 'package:privacyidea_authenticator/utils/riverpod/riverpod_providers/generated_providers/localization_notifier.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -592,8 +592,9 @@ class TokenNotifier extends _$TokenNotifier with ResultHandler {
       ref
           .read(statusProvider.notifier)
           .show(
-            (loc) => loc.errorRollOutNotPossibleAnymore,
-            details: (loc) => loc.errorTokenExpired(token.label),
+            (localization) => localization.errorRollOutNotPossibleAnymore,
+            details: (localization) =>
+                localization.errorTokenExpired(token.label),
           );
       await _removeToken(token);
       return false;
@@ -713,7 +714,10 @@ class TokenNotifier extends _$TokenNotifier with ResultHandler {
       Logger.error('Roll out failed.', error: e, stackTrace: s);
       ref
           .read(statusProvider.notifier)
-          .show((loc) => loc.errorRollOutUnknownError(token.label));
+          .show(
+            (localization) =>
+                localization.errorRollOutUnknownError(token.label),
+          );
       await _updateStatus(token, PushTokenRollOutState.sendRSAPublicKeyFailed);
       return false;
     }

--- a/lib/views/main_view/main_view_widgets/token_widgets/push_token_widgets/actions/edit_push_token_action.dart
+++ b/lib/views/main_view/main_view_widgets/token_widgets/push_token_widgets/actions/edit_push_token_action.dart
@@ -24,6 +24,7 @@ import 'package:privacyidea_authenticator/utils/view_utils.dart';
 
 import '../../../../../../l10n/app_localizations.dart';
 import '../../../../../../model/enums/introduction.dart';
+import '../../../../../../model/extensions/uri_extension.dart';
 import '../../../../../../model/tokens/push_token.dart';
 import '../../../../../../utils/customization/theme_extentions/action_theme.dart';
 import '../../../../../../utils/globals.dart';
@@ -96,10 +97,7 @@ class EditPushTokenAction extends ConsumerSlideableAction {
       )!.mustNotBeEmpty(AppLocalizations.of(context)!.pushEndpointUrl);
     }
     final uri = Uri.tryParse(value);
-    if (uri == null ||
-        uri.host.isEmpty ||
-        uri.scheme.isEmpty ||
-        uri.path.isEmpty) {
+    if (uri == null || !uri.isValidEndpoint) {
       return AppLocalizations.of(context)!.exampleUrl;
     }
     return null;
@@ -112,13 +110,21 @@ class EditPushTokenAction extends ConsumerSlideableAction {
       return DefaultEditActionDialog(
         token: token,
         onSaveButtonPressed: ({required newLabel, newImageUrl}) async {
+          final newUrl = Uri.tryParse(pushUrl.text);
+          if (newUrl == null || !newUrl.isValidEndpoint) {
+            showErrorStatusMessage(
+              message: (localization) => localization.invalidUrl,
+              details: (localization) => localization.exampleUrl,
+            );
+            return;
+          }
           globalRef
               ?.read(tokenProvider.notifier)
               .updateToken(
                 token,
                 (p0) => p0.copyWith(
                   label: newLabel,
-                  url: Uri.parse(pushUrl.text),
+                  url: newUrl,
                   tokenImage: newImageUrl,
                 ),
               );

--- a/lib/widgets/dialog_widgets/default_dialog.dart
+++ b/lib/widgets/dialog_widgets/default_dialog.dart
@@ -97,9 +97,9 @@ class DefaultDialog extends ConsumerWidget {
       ),
       titlePadding: EdgeInsets.all(dimensions.spacingMedium),
       contentPadding: EdgeInsets.fromLTRB(
-        dimensions.spacingMedium,
+        dimensions.spacingSmall,
         0,
-        dimensions.spacingMedium,
+        dimensions.spacingSmall,
         dimensions.spacingSmall,
       ),
       elevation: 2,

--- a/lib/widgets/enable_text_edit_after_many_taps.dart
+++ b/lib/widgets/enable_text_edit_after_many_taps.dart
@@ -77,10 +77,9 @@ class _EnableTextEditAfterManyTapsState
       timer = null;
       if (widget.lockedHint != null) {
         setState(() => counter = 0);
-        ref.read(statusProvider.notifier).show(
-          widget.lockedHint!,
-          type: StatusMessageType.neutral,
-        );
+        ref
+            .read(statusProvider.notifier)
+            .show(widget.lockedHint!, type: StatusMessageType.neutral);
       } else {
         setState(() {
           counter = newCounter;
@@ -98,7 +97,10 @@ class _EnableTextEditAfterManyTapsState
       return TextFormField(
         key: Key('enabled_${widget.controller.hashCode}'),
         controller: widget.controller,
-        decoration: InputDecoration(labelText: widget.labelText),
+        decoration: InputDecoration(
+          labelText: widget.labelText,
+          errorMaxLines: 2,
+        ),
         autovalidateMode: widget.autovalidateMode,
         validator: widget.validator,
       );

--- a/lib/widgets/status_bar.dart
+++ b/lib/widgets/status_bar.dart
@@ -65,8 +65,7 @@ class StatusBarOverlayEntry extends StatefulWidget {
   State<StatusBarOverlayEntry> createState() => _StatusBarOverlayEntryState();
 }
 
-class _StatusBarOverlayEntryState extends State<StatusBarOverlayEntry>
-    with SingleTickerProviderStateMixin {
+class _StatusBarOverlayEntryState extends State<StatusBarOverlayEntry> {
   bool isFirstFrame = true;
   bool isPaused = false;
   static const double margin = 10;
@@ -107,6 +106,12 @@ class _StatusBarOverlayEntryState extends State<StatusBarOverlayEntry>
     };
 
     super.initState();
+  }
+
+  @override
+  void dispose() {
+    controller.dispose();
+    super.dispose();
   }
 
   @override

--- a/lib/widgets/status_bar.dart
+++ b/lib/widgets/status_bar.dart
@@ -68,12 +68,17 @@ class StatusBarOverlayEntry extends StatefulWidget {
 class _StatusBarOverlayEntryState extends State<StatusBarOverlayEntry>
     with SingleTickerProviderStateMixin {
   bool isFirstFrame = true;
+  bool isPaused = false;
   static const double margin = 10;
   static const double padding = 10;
+  static const int collapsedSubTextMaxLines = 2;
   static const Duration showDuration = Duration(seconds: 5);
   late UnscaledAnimationController controller;
   late Animation autoDismissAnimation;
   late Function(DismissDirection) onDismissed;
+
+  /// Line limit of the sub text: unlimited while the auto dismiss is paused.
+  int? get subTextMaxLines => isPaused ? null : collapsedSubTextMaxLines;
 
   @override
   void initState() {
@@ -130,7 +135,6 @@ class _StatusBarOverlayEntryState extends State<StatusBarOverlayEntry>
       style: statusTextStyle,
       maxWidth: maxWidth,
       textScaler: MediaQuery.of(context).textScaler,
-      maxLines: 1,
     ).height;
     final statusSubTextHeight = widget.statusSubText != null
         ? textSizeOf(
@@ -138,7 +142,7 @@ class _StatusBarOverlayEntryState extends State<StatusBarOverlayEntry>
             style: statusSubTextStyle,
             maxWidth: maxWidth,
             textScaler: MediaQuery.of(context).textScaler,
-            maxLines: 1,
+            maxLines: subTextMaxLines,
           ).height
         : 0;
     return AnimatedPositioned(
@@ -159,11 +163,15 @@ class _StatusBarOverlayEntryState extends State<StatusBarOverlayEntry>
         child: GestureDetector(
           onTap: () {
             if (mounted) {
-              if (controller.isAnimating) {
-                controller.stop();
-              } else {
-                controller.forward();
-              }
+              setState(() {
+                if (controller.isAnimating) {
+                  controller.stop();
+                  isPaused = true;
+                } else {
+                  controller.forward();
+                  isPaused = false;
+                }
+              });
             }
           },
           child: Dismissible(
@@ -199,7 +207,7 @@ class _StatusBarOverlayEntryState extends State<StatusBarOverlayEntry>
                             widget.statusSubText!,
                             style: statusSubTextStyle,
                             textAlign: TextAlign.center,
-                            maxLines: 1,
+                            maxLines: subTextMaxLines,
                             overflow: TextOverflow.ellipsis,
                           ),
                       ],

--- a/test/unit_test/model/extensions/enums/patch_note_type_extension_test.dart
+++ b/test/unit_test/model/extensions/enums/patch_note_type_extension_test.dart
@@ -6,16 +6,20 @@ import 'package:privacyidea_authenticator/model/extensions/enums/patch_note_type
 void main() {
   group('PatchNoteType extension', () {
     test('localizedName returns non-empty string for all types', () {
-      final loc = AppLocalizationsEn();
+      final localization = AppLocalizationsEn();
       for (final type in PatchNoteType.values) {
-        expect(type.localizedName(loc).isNotEmpty, isTrue, reason: '$type');
+        expect(
+          type.localizedName(localization).isNotEmpty,
+          isTrue,
+          reason: '$type',
+        );
       }
     });
 
     test('all types produce distinct localized names', () {
-      final loc = AppLocalizationsEn();
+      final localization = AppLocalizationsEn();
       final names = PatchNoteType.values
-          .map((t) => t.localizedName(loc))
+          .map((t) => t.localizedName(localization))
           .toSet();
       expect(names.length, PatchNoteType.values.length);
     });

--- a/test/unit_test/model/extensions/enums/sync_state_extension_test.dart
+++ b/test/unit_test/model/extensions/enums/sync_state_extension_test.dart
@@ -13,9 +13,13 @@ void main() {
     });
 
     test('localizedName returns non-empty string for all states', () {
-      final loc = AppLocalizationsEn();
+      final localization = AppLocalizationsEn();
       for (final state in SyncState.values) {
-        expect(state.localizedName(loc).isNotEmpty, isTrue, reason: '$state');
+        expect(
+          state.localizedName(localization).isNotEmpty,
+          isTrue,
+          reason: '$state',
+        );
       }
     });
   });

--- a/test/unit_test/utils/lock_auth_test.dart
+++ b/test/unit_test/utils/lock_auth_test.dart
@@ -33,7 +33,7 @@ void main() {
       ).thenAnswer((_) async => true);
 
       final result = await lockAuth(
-        reason: (loc) => 'reason',
+        reason: (localization) => 'reason',
         localization: AppLocalizationsEn(),
       );
 
@@ -53,7 +53,7 @@ void main() {
         ).thenAnswer((_) async => false);
 
         final result = await lockAuth(
-          reason: (loc) => 'reason',
+          reason: (localization) => 'reason',
           localization: AppLocalizationsEn(),
         );
 
@@ -76,7 +76,7 @@ void main() {
         ).thenAnswer((_) async => true);
 
         final result = await lockAuth(
-          reason: (loc) => 'reason',
+          reason: (localization) => 'reason',
           localization: AppLocalizationsEn(),
           autoAuthIfUnsupported: true,
         );
@@ -99,7 +99,7 @@ void main() {
         when(mockLocalAuth.canCheckBiometrics).thenAnswer((_) async => false);
 
         final result = await lockAuth(
-          reason: (loc) => 'reason',
+          reason: (localization) => 'reason',
           localization: AppLocalizationsEn(),
           forceBiometricOption: ForceBiometricOption.biometric,
         );
@@ -118,7 +118,7 @@ void main() {
         ).thenAnswer((_) async => []);
 
         final result = await lockAuth(
-          reason: (loc) => 'reason',
+          reason: (localization) => 'reason',
           localization: AppLocalizationsEn(),
           forceBiometricOption: ForceBiometricOption.biometric,
         );
@@ -144,7 +144,7 @@ void main() {
         ).thenAnswer((_) async => true);
 
         final result = await lockAuth(
-          reason: (loc) => 'reason',
+          reason: (localization) => 'reason',
           localization: AppLocalizationsEn(),
           forceBiometricOption: ForceBiometricOption.biometric,
         );
@@ -173,7 +173,7 @@ void main() {
         ).thenAnswer((_) async => false);
 
         final result = await lockAuth(
-          reason: (loc) => 'reason',
+          reason: (localization) => 'reason',
           localization: AppLocalizationsEn(),
           autoAuthIfUnsupported: true,
         );
@@ -197,7 +197,7 @@ void main() {
         when(mockLocalAuth.isDeviceSupported()).thenAnswer((_) async => false);
 
         final result = await lockAuth(
-          reason: (loc) => 'reason',
+          reason: (localization) => 'reason',
           localization: AppLocalizationsEn(),
         );
 
@@ -223,7 +223,7 @@ void main() {
       );
 
       final result = await lockAuth(
-        reason: (loc) => 'reason',
+        reason: (localization) => 'reason',
         localization: AppLocalizationsEn(),
       );
 
@@ -241,7 +241,7 @@ void main() {
       ).thenThrow(Exception('Unknown auth error'));
 
       final result = await lockAuth(
-        reason: (loc) => 'reason',
+        reason: (localization) => 'reason',
         localization: AppLocalizationsEn(),
       );
 
@@ -267,7 +267,7 @@ void main() {
 
         final result = await lockAuthWithSettingsRef(
           ref: ref,
-          reason: (loc) => 'reason',
+          reason: (localization) => 'reason',
           localization: AppLocalizationsEn(),
           // Token says "any"; app setting (biometric) should win.
         );
@@ -298,7 +298,7 @@ void main() {
 
         final result = await lockAuthWithSettingsRef(
           ref: ref,
-          reason: (loc) => 'reason',
+          reason: (localization) => 'reason',
           localization: AppLocalizationsEn(),
         );
 
@@ -331,7 +331,7 @@ void main() {
 
         final result = await lockAuthWithSettingsRef(
           ref: ref,
-          reason: (loc) => 'reason',
+          reason: (localization) => 'reason',
           localization: AppLocalizationsEn(),
           forceBiometricOption: ForceBiometricOption.biometric,
         );
@@ -361,11 +361,11 @@ void main() {
       });
 
       final firstCall = lockAuth(
-        reason: (loc) => 'first',
+        reason: (localization) => 'first',
         localization: AppLocalizationsEn(),
       );
       final secondCall = lockAuth(
-        reason: (loc) => 'second',
+        reason: (localization) => 'second',
         localization: AppLocalizationsEn(),
       );
 

--- a/test/unit_test/utils/object_validators_test.dart
+++ b/test/unit_test/utils/object_validators_test.dart
@@ -20,7 +20,9 @@
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:privacyidea_authenticator/l10n/app_localizations_en.dart';
 import 'package:privacyidea_authenticator/model/enums/algorithms.dart';
+import 'package:privacyidea_authenticator/model/exception_errors/localized_argument_error.dart';
 import 'package:privacyidea_authenticator/utils/object_validator/object_validators.dart'
     as ov;
 import 'package:privacyidea_authenticator/utils/object_validator/object_validators.dart';
@@ -295,22 +297,68 @@ void main() {
     });
   });
 
-  group('uri validator', () {
-    test('transforms string to Uri', () {
-      final result = ov.Validators.uri.transform(
-        'https://example.com',
-        'field',
+  group('httpUri validator', () {
+    test('transforms absolute url', () {
+      expect(
+        validate(
+          value: 'https://example.com/ttype/push',
+          validator: ov.Validators.httpUri,
+          name: 'url',
+        ),
+        Uri.parse('https://example.com/ttype/push'),
       );
-      expect(result, Uri.parse('https://example.com'));
     });
 
     test('passes through Uri', () {
-      final input = Uri.parse('https://example.com');
-      expect(ov.Validators.uri.transform(input, 'field'), input);
+      final input = Uri.parse('https://example.com/ttype/push');
+      expect(
+        validate(value: input, validator: ov.Validators.httpUri, name: 'url'),
+        input,
+      );
     });
 
-    test('uriOptional returns null for null', () {
-      expect(ov.Validators.uriOptional.transform(null, 'field'), isNull);
+    test('throws on url without scheme', () {
+      expect(
+        () => validate(
+          value: 'example.com/ttype/push',
+          validator: ov.Validators.httpUri,
+          name: 'url',
+        ),
+        throwsA(anything),
+      );
+    });
+
+    test('throws on url without host', () {
+      expect(
+        () => validate(
+          value: '/ttype/push',
+          validator: ov.Validators.httpUri,
+          name: 'url',
+        ),
+        throwsA(anything),
+      );
+    });
+
+    test('throws on non http scheme', () {
+      expect(
+        () => validate(
+          value: 'ftp://example.com/ttype/push',
+          validator: ov.Validators.httpUri,
+          name: 'url',
+        ),
+        throwsA(anything),
+      );
+    });
+
+    test('throws on null', () {
+      expect(
+        () => validate(
+          value: null,
+          validator: ov.Validators.httpUri,
+          name: 'url',
+        ),
+        throwsA(anything),
+      );
     });
   });
 
@@ -343,6 +391,53 @@ void main() {
       );
       expect(result, '');
     });
+
+    test('error names the invalid value and the parameter', () {
+      final error = _errorOf(value: 42, validator: ov.Validators.string);
+      expect(
+        error.localizedMessage(AppLocalizationsEn()),
+        'The int “42“ is not valid for “url“',
+      );
+      expect(error.unlocalizedMessage, 'The int “42“ is not valid for “url“');
+    });
+
+    test('unallowed value uses the message of the validator if it has one', () {
+      final error = _errorOf(
+        value: '192.168.178.139/ttype/push',
+        validator: ov.Validators.httpUri,
+      );
+      expect(
+        error.localizedMessage(AppLocalizationsEn()),
+        'URL not valid for http/https.',
+      );
+      expect(
+        error.unlocalizedMessage,
+        'The String “192.168.178.139/ttype/push“ is not valid for “url“',
+      );
+    });
+
+    test('invalid value falls back to the generic message', () {
+      final error = _errorOf(value: null, validator: ov.Validators.httpUri);
+      expect(
+        error.localizedMessage(AppLocalizationsEn()),
+        'The Null “null“ is not valid for “url“',
+      );
+    });
+
+    test('the messages of the validator survive optional and withDefault', () {
+      final optional = ov.Validators.httpUri.optional();
+      expect(optional.invalidMessage, ov.Validators.httpUri.invalidMessage);
+      expect(optional.unallowedMessage, ov.Validators.httpUri.unallowedMessage);
+
+      final withDefault = ov.Validators.httpUri.withDefault(
+        Uri.parse('https://example.com'),
+      );
+      expect(withDefault.invalidMessage, ov.Validators.httpUri.invalidMessage);
+      expect(
+        withDefault.unallowedMessage,
+        ov.Validators.httpUri.unallowedMessage,
+      );
+    });
   });
 
   group('validateMap function', () {
@@ -372,4 +467,17 @@ void main() {
       expect(result.containsKey('email'), isFalse);
     });
   });
+}
+
+/// Validates [value] and returns the error it throws.
+LocalizedArgumentError _errorOf({
+  required Object? value,
+  required BaseValidator validator,
+}) {
+  try {
+    validate(value: value, validator: validator, name: 'url');
+  } on LocalizedArgumentError catch (e) {
+    return e;
+  }
+  fail('Expected a LocalizedArgumentError for "$value"');
 }


### PR DESCRIPTION
Validation now happens while parsing, with a readable message for the user.
