### PR TITLE
Protect Push keys with enrollment-bound biometrics

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -15,6 +15,10 @@ dependencies {
     // plugin. Gradle otherwise silently resolves to the higher version; matching it
     // explicitly keeps the RescheduleReceiver keep-alive (see PiApplication) predictable.
     implementation "androidx.work:work-runtime-ktx:2.11.2"
+    // The Push private-key channel uses crypto-bound BiometricPrompt directly.
+    // Keep this aligned with local_auth_android until that plugin moves.
+    implementation "androidx.biometric:biometric:1.1.0"
+    testImplementation "junit:junit:4.13.2"
 }
 
 def localProperties = new Properties()

--- a/android/app/src/main/kotlin/app/piauthenticator/BaseMainActivity.kt
+++ b/android/app/src/main/kotlin/app/piauthenticator/BaseMainActivity.kt
@@ -9,6 +9,7 @@ import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugins.GeneratedPluginRegistrant
 import app.piauthenticator.channels.MailerChannel
 import app.piauthenticator.channels.SettingsChannel
+import app.piauthenticator.channels.BiometricPushKeyChannel
 
 /**
  * Shared behavior for all product flavors. Flavor-specific `MainActivity`
@@ -27,5 +28,6 @@ abstract class BaseMainActivity : FlutterFragmentActivity() {
 
         SettingsChannel.register(this, flutterEngine)
         MailerChannel.register(this, flutterEngine)
+        BiometricPushKeyChannel.register(this, flutterEngine)
     }
 }

--- a/android/app/src/main/kotlin/app/piauthenticator/channels/BiometricPushKeyChannel.kt
+++ b/android/app/src/main/kotlin/app/piauthenticator/channels/BiometricPushKeyChannel.kt
@@ -1,0 +1,543 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package app.piauthenticator.channels
+
+import android.content.Context
+import android.os.Build
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyPermanentlyInvalidatedException
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import androidx.biometric.BiometricManager
+import androidx.biometric.BiometricPrompt
+import androidx.fragment.app.FragmentActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import java.security.KeyStore
+import java.security.MessageDigest
+import java.security.Signature
+import java.util.concurrent.Executor
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+
+/**
+ * Protects privacyIDEA Push private keys with an Android Keystore AES key.
+ *
+ * The wrapping key requires BIOMETRIC_STRONG for every operation and is
+ * invalidated when biometric enrollment changes if the token policy requests
+ * it. Device PIN, pattern and password are deliberately not accepted.
+ */
+object BiometricPushKeyChannel {
+    private const val CHANNEL_NAME = "biometric_push_key"
+    private const val KEYSTORE = "AndroidKeyStore"
+    private const val KEY_ALIAS_PREFIX = "pi_push_biometric_v1_"
+    private const val PREFERENCES = "pi_push_biometric_keys_v1"
+    private const val INVALIDATED = "invalidated_"
+    private const val WRAPPED_KEY = "wrapped_"
+    private const val IV = "iv_"
+
+    private const val ERROR_INVALIDATED = "BIOMETRIC_KEY_INVALIDATED"
+    private const val ERROR_MISSING = "BIOMETRIC_KEY_MISSING"
+    private const val ERROR_UNSUPPORTED = "BIOMETRIC_KEY_UNSUPPORTED"
+    private const val ERROR_STRONG_UNAVAILABLE = "BIOMETRIC_STRONG_UNAVAILABLE"
+    private const val ERROR_CANCELED = "BIOMETRIC_AUTH_CANCELED"
+    private const val ERROR_FAILED = "BIOMETRIC_AUTH_FAILED"
+
+    fun register(activity: FragmentActivity, flutterEngine: FlutterEngine) {
+        val channel = MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            CHANNEL_NAME,
+        )
+        channel.setMethodCallHandler { call, result ->
+            try {
+                when (call.method) {
+                    "status" -> result.success(status(activity, tokenId(call)))
+                    "delete" -> {
+                        delete(activity, tokenId(call))
+                        result.success(null)
+                    }
+                    "protect" -> protect(activity, call, result)
+                    "sign" -> sign(activity, call, result)
+                    else -> result.notImplemented()
+                }
+            } catch (exception: BiometricKeyException) {
+                result.error(exception.code, exception.message, null)
+            } catch (exception: Exception) {
+                result.error(ERROR_FAILED, "Biometric Push key operation failed", null)
+            }
+        }
+    }
+
+    private fun status(activity: FragmentActivity, tokenId: String): String {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) return "unsupported"
+        val key = storageKey(tokenId)
+        val preferences = preferences(activity)
+        if (preferences.getBoolean(INVALIDATED + key, false)) return "invalidated"
+        val wrapped = preferences.getString(WRAPPED_KEY + key, null)
+            ?: return "unprotected"
+        val iv = preferences.getString(IV + key, null)
+            ?: return markInvalidated(activity, key)
+
+        return try {
+            val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+            cipher.init(
+                Cipher.DECRYPT_MODE,
+                loadSecretKey(key),
+                GCMParameterSpec(128, Base64.decode(iv, Base64.NO_WRAP)),
+            )
+            // Merely initializing the operation proves that the auth-bound key
+            // still exists and was not invalidated. No plaintext is released.
+            if (wrapped.isEmpty()) markInvalidated(activity, key) else "protected"
+        } catch (_: KeyPermanentlyInvalidatedException) {
+            markInvalidated(activity, key)
+        } catch (_: BiometricKeyException) {
+            markInvalidated(activity, key)
+        }
+    }
+
+    private fun protect(
+        activity: FragmentActivity,
+        call: MethodCall,
+        result: MethodChannel.Result,
+    ) {
+        ensureSupported(activity)
+        val tokenId = tokenId(call)
+        val privateKey = requiredString(call, "privateKey")
+        authenticateAndProtect(
+            activity = activity,
+            tokenId = tokenId,
+            privateKeyBase64 = privateKey,
+            reason = requiredString(call, "reason"),
+            cancelLabel = requiredString(call, "cancelLabel"),
+            invalidateOnBiometricChange = requiredBoolean(
+                call,
+                "invalidateOnBiometricChange",
+            ),
+            message = null,
+            result = result,
+        )
+    }
+
+    private fun sign(
+        activity: FragmentActivity,
+        call: MethodCall,
+        result: MethodChannel.Result,
+    ) {
+        val tokenId = tokenId(call)
+        // Validate all required call data before starting BiometricPrompt. An
+        // exception thrown later from its asynchronous callback would otherwise
+        // leave the Dart MethodChannel call without a completion.
+        val message = requiredString(call, "message")
+        val reason = requiredString(call, "reason")
+        val cancelLabel = requiredString(call, "cancelLabel")
+        val invalidateOnBiometricChange = requiredBoolean(
+            call,
+            "invalidateOnBiometricChange",
+        )
+        val key = storageKey(tokenId)
+        val preferences = preferences(activity)
+        if (preferences.getBoolean(INVALIDATED + key, false)) {
+            throw BiometricKeyException(ERROR_INVALIDATED)
+        }
+
+        val wrapped = preferences.getString(WRAPPED_KEY + key, null)
+        val iv = preferences.getString(IV + key, null)
+        if (wrapped == null || iv == null) {
+            // There is no existing enrollment-bound operation to inspect. The
+            // legacy key may be migrated only while strong biometrics are
+            // currently available.
+            ensureSupported(activity)
+            val privateKey = call.argument<String>("privateKey")
+                ?: throw BiometricKeyException(ERROR_MISSING)
+            authenticateAndProtect(
+                activity = activity,
+                tokenId = tokenId,
+                privateKeyBase64 = privateKey,
+                reason = reason,
+                cancelLabel = cancelLabel,
+                invalidateOnBiometricChange = invalidateOnBiometricChange,
+                message = message,
+                result = result,
+            )
+            return
+        }
+
+        // Initialize the already-enrolled key before checking whether a strong
+        // biometric is currently available. Removing all enrolled biometrics
+        // makes canAuthenticate() report NONE_ENROLLED; checking it first would
+        // mask KeyPermanentlyInvalidatedException (or a deleted Keystore alias)
+        // as the non-terminal STRONG_UNAVAILABLE error.
+        val cipher = try {
+            Cipher.getInstance("AES/GCM/NoPadding").apply {
+                init(
+                    Cipher.DECRYPT_MODE,
+                    loadSecretKey(key),
+                    GCMParameterSpec(128, Base64.decode(iv, Base64.NO_WRAP)),
+                )
+            }
+        } catch (_: KeyPermanentlyInvalidatedException) {
+            markInvalidated(activity, key)
+            throw BiometricKeyException(ERROR_INVALIDATED)
+        } catch (_: BiometricKeyException) {
+            markInvalidated(activity, key)
+            throw BiometricKeyException(ERROR_MISSING)
+        } catch (_: Exception) {
+            throw BiometricKeyException(ERROR_FAILED)
+        }
+
+        ensureSupported(
+            activity,
+            enrollmentBoundKey = key.takeIf { invalidateOnBiometricChange },
+        )
+
+        authenticate(
+            activity = activity,
+            cipher = cipher,
+            reason = reason,
+            cancelLabel = cancelLabel,
+            onSuccess = { authenticatedCipher ->
+                var privateKeyBytes: ByteArray? = null
+                try {
+                    privateKeyBytes = authenticatedCipher.doFinal(
+                        Base64.decode(wrapped, Base64.NO_WRAP),
+                    )
+                    result.success(
+                        mapOf(
+                            "signature" to signMessage(
+                                privateKeyBytes,
+                                message,
+                            ),
+                            "protectedNow" to false,
+                        ),
+                    )
+                } catch (_: KeyPermanentlyInvalidatedException) {
+                    completeInvalidated(activity, key, result)
+                } catch (_: Exception) {
+                    result.error(
+                        ERROR_FAILED,
+                        "Could not sign the Push response",
+                        null,
+                    )
+                } finally {
+                    privateKeyBytes?.fill(0)
+                }
+            },
+            onError = result,
+        )
+    }
+
+    /** Protects a legacy key and optionally signs in the same authenticated operation. */
+    private fun authenticateAndProtect(
+        activity: FragmentActivity,
+        tokenId: String,
+        privateKeyBase64: String,
+        reason: String,
+        cancelLabel: String,
+        invalidateOnBiometricChange: Boolean,
+        message: String?,
+        result: MethodChannel.Result,
+    ) {
+        val key = storageKey(tokenId)
+        deleteNativeKey(key)
+        val cleared = preferences(activity).edit()
+            .remove(WRAPPED_KEY + key)
+            .remove(IV + key)
+            .remove(INVALIDATED + key)
+            .commit()
+        if (!cleared) {
+            throw BiometricKeyException(ERROR_FAILED, "Could not reset Push key state")
+        }
+
+        val secretKey = createSecretKey(key, invalidateOnBiometricChange)
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding").apply {
+            init(Cipher.ENCRYPT_MODE, secretKey)
+        }
+        authenticate(
+            activity = activity,
+            cipher = cipher,
+            reason = reason,
+            cancelLabel = cancelLabel,
+            onSuccess = { authenticatedCipher ->
+                var privateKeyBytes: ByteArray? = null
+                try {
+                    // Decoding belongs inside the callback's guarded section:
+                    // malformed legacy data must complete the MethodChannel
+                    // call with an error instead of escaping on the main thread.
+                    privateKeyBytes = Base64.decode(privateKeyBase64, Base64.DEFAULT)
+                    PushPrivateKeyCodec.decode(privateKeyBytes)
+                    val wrapped = authenticatedCipher.doFinal(privateKeyBytes)
+                    val stored = preferences(activity).edit()
+                        .putString(
+                            WRAPPED_KEY + key,
+                            Base64.encodeToString(wrapped, Base64.NO_WRAP),
+                        )
+                        .putString(
+                            IV + key,
+                            Base64.encodeToString(authenticatedCipher.iv, Base64.NO_WRAP),
+                        )
+                        .putBoolean(INVALIDATED + key, false)
+                        .commit()
+                    if (!stored) {
+                        throw BiometricKeyException(
+                            ERROR_FAILED,
+                            "Could not persist protected Push key state",
+                        )
+                    }
+                    if (message == null) {
+                        result.success(null)
+                    } else {
+                        result.success(
+                            mapOf(
+                                "signature" to signMessage(privateKeyBytes, message),
+                                "protectedNow" to true,
+                            ),
+                        )
+                    }
+                } catch (_: Exception) {
+                    val cleanupSucceeded = try {
+                        delete(activity, tokenId)
+                        true
+                    } catch (_: Exception) {
+                        false
+                    }
+                    val details = if (cleanupSucceeded) {
+                        "Could not protect the Push key"
+                    } else {
+                        "Could not protect or clean up the Push key"
+                    }
+                    result.error(ERROR_FAILED, details, null)
+                } finally {
+                    privateKeyBytes?.fill(0)
+                }
+            },
+            onError = result,
+            deleteKeyOnError = key,
+        )
+    }
+
+    private fun authenticate(
+        activity: FragmentActivity,
+        cipher: Cipher,
+        reason: String,
+        cancelLabel: String,
+        onSuccess: (Cipher) -> Unit,
+        onError: MethodChannel.Result,
+        deleteKeyOnError: String? = null,
+    ) {
+        val executor: Executor = activity.mainExecutor
+        val prompt = BiometricPrompt(
+            activity,
+            executor,
+            object : BiometricPrompt.AuthenticationCallback() {
+                override fun onAuthenticationSucceeded(
+                    authenticationResult: BiometricPrompt.AuthenticationResult,
+                ) {
+                    if (authenticationResult.authenticationType ==
+                        BiometricPrompt.AUTHENTICATION_RESULT_TYPE_DEVICE_CREDENTIAL
+                    ) {
+                        deleteKeyOnError?.let { runCatching { deleteNativeKey(it) } }
+                        onError.error(
+                            ERROR_FAILED,
+                            "Device credentials cannot authorize this Push key",
+                            null,
+                        )
+                        return
+                    }
+                    val authenticatedCipher = authenticationResult.cryptoObject?.cipher
+                    if (authenticatedCipher == null) {
+                        val cleanupFailed = deleteKeyOnError
+                            ?.let { runCatching { deleteNativeKey(it) }.isFailure }
+                            ?: false
+                        val details = if (cleanupFailed) {
+                            "Missing authenticated cipher; key cleanup also failed"
+                        } else {
+                            "Missing authenticated cipher"
+                        }
+                        onError.error(ERROR_FAILED, details, null)
+                        return
+                    }
+                    onSuccess(authenticatedCipher)
+                }
+
+                override fun onAuthenticationError(code: Int, message: CharSequence) {
+                    val cleanupFailed = deleteKeyOnError
+                        ?.let { runCatching { deleteNativeKey(it) }.isFailure }
+                        ?: false
+                    val errorCode = when (code) {
+                        BiometricPrompt.ERROR_CANCELED,
+                        BiometricPrompt.ERROR_NEGATIVE_BUTTON,
+                        BiometricPrompt.ERROR_USER_CANCELED -> ERROR_CANCELED
+                        else -> ERROR_FAILED
+                    }
+                    val details = if (cleanupFailed) {
+                        "$message (Push key cleanup failed)"
+                    } else {
+                        message.toString()
+                    }
+                    onError.error(errorCode, details, null)
+                }
+
+                override fun onAuthenticationFailed() {
+                    // The system prompt remains open and permits another attempt.
+                }
+            },
+        )
+        val promptInfo = BiometricPrompt.PromptInfo.Builder()
+            .setTitle(reason)
+            .setNegativeButtonText(cancelLabel)
+            .setAllowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_STRONG)
+            .setConfirmationRequired(true)
+            .build()
+        prompt.authenticate(promptInfo, BiometricPrompt.CryptoObject(cipher))
+    }
+
+    private fun createSecretKey(
+        key: String,
+        invalidateOnBiometricChange: Boolean,
+    ): SecretKey {
+        val builder = KeyGenParameterSpec.Builder(
+            alias(key),
+            KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT,
+        )
+            .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+            .setRandomizedEncryptionRequired(true)
+            .setUserAuthenticationRequired(true)
+            .setInvalidatedByBiometricEnrollment(invalidateOnBiometricChange)
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            builder.setUserAuthenticationParameters(
+                0,
+                KeyProperties.AUTH_BIOMETRIC_STRONG,
+            )
+        } else {
+            @Suppress("DEPRECATION")
+            builder.setUserAuthenticationValidityDurationSeconds(-1)
+        }
+        // Android 12-14 have documented unlocked-device-required key bugs.
+        // The auth-per-use requirement already protects earlier releases.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+            builder.setUnlockedDeviceRequired(true)
+        }
+
+        return KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, KEYSTORE)
+            .apply { init(builder.build()) }
+            .generateKey()
+    }
+
+    private fun loadSecretKey(key: String): SecretKey {
+        val keyStore = KeyStore.getInstance(KEYSTORE).apply { load(null) }
+        return keyStore.getKey(alias(key), null) as? SecretKey
+            ?: throw BiometricKeyException(ERROR_MISSING)
+    }
+
+    private fun signMessage(privateKeyPkcs1: ByteArray, message: String): String {
+        val privateKey = PushPrivateKeyCodec.decode(privateKeyPkcs1).privateKey
+        val signature = Signature.getInstance("SHA256withRSA")
+        signature.initSign(privateKey)
+        signature.update(message.toByteArray(Charsets.UTF_8))
+        return Base64.encodeToString(signature.sign(), Base64.NO_WRAP)
+    }
+
+    private fun ensureSupported(
+        activity: FragmentActivity,
+        enrollmentBoundKey: String? = null,
+    ) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+            throw BiometricKeyException(ERROR_UNSUPPORTED)
+        }
+        val status = BiometricManager.from(activity).canAuthenticate(
+            BiometricManager.Authenticators.BIOMETRIC_STRONG,
+        )
+        if (status == BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED &&
+            enrollmentBoundKey != null
+        ) {
+            markInvalidated(activity, enrollmentBoundKey)
+            throw BiometricKeyException(ERROR_INVALIDATED)
+        }
+        if (status != BiometricManager.BIOMETRIC_SUCCESS) {
+            throw BiometricKeyException(ERROR_STRONG_UNAVAILABLE)
+        }
+    }
+
+    private fun delete(activity: FragmentActivity, tokenId: String) {
+        val key = storageKey(tokenId)
+        deleteNativeKey(key)
+        val cleared = preferences(activity).edit()
+            .remove(WRAPPED_KEY + key)
+            .remove(IV + key)
+            .remove(INVALIDATED + key)
+            .commit()
+        if (!cleared) {
+            throw BiometricKeyException(
+                ERROR_FAILED,
+                "Could not remove persisted Push key state",
+            )
+        }
+    }
+
+    private fun deleteNativeKey(key: String) {
+        val keyStore = KeyStore.getInstance(KEYSTORE).apply { load(null) }
+        if (keyStore.containsAlias(alias(key))) keyStore.deleteEntry(alias(key))
+    }
+
+    private fun markInvalidated(activity: FragmentActivity, key: String): String {
+        val stored = preferences(activity).edit()
+            .putBoolean(INVALIDATED + key, true)
+            .commit()
+        if (!stored) {
+            // Keep the semantic error as INVALIDATED. The Keystore operation
+            // already proved that this key must never be used again, even if
+            // persisting the convenience marker failed.
+            throw BiometricKeyException(
+                ERROR_INVALIDATED,
+                "Biometric Push key is invalid and its marker could not be persisted",
+            )
+        }
+        return "invalidated"
+    }
+
+    private fun completeInvalidated(
+        activity: FragmentActivity,
+        key: String,
+        result: MethodChannel.Result,
+    ) {
+        val details = try {
+            markInvalidated(activity, key)
+            "Biometric Push key is invalid"
+        } catch (_: Exception) {
+            // The authenticated operation already failed. Always complete the
+            // asynchronous MethodChannel call and remain fail-closed even if
+            // the invalidation marker could not be written.
+            "Biometric Push key is invalid and its marker could not be persisted"
+        }
+        result.error(ERROR_INVALIDATED, details, null)
+    }
+
+    private fun preferences(activity: FragmentActivity) =
+        activity.getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE)
+
+    private fun tokenId(call: MethodCall): String = requiredString(call, "tokenId")
+
+    private fun requiredString(call: MethodCall, name: String): String =
+        call.argument<String>(name)?.takeIf { it.isNotBlank() }
+            ?: throw BiometricKeyException(ERROR_FAILED, "Missing $name")
+
+    private fun requiredBoolean(call: MethodCall, name: String): Boolean =
+        call.argument<Boolean>(name)
+            ?: throw BiometricKeyException(ERROR_FAILED, "Missing $name")
+
+    private fun storageKey(tokenId: String): String = MessageDigest.getInstance("SHA-256")
+        .digest(tokenId.toByteArray(Charsets.UTF_8))
+        .joinToString("") { "%02x".format(it) }
+
+    private fun alias(key: String) = KEY_ALIAS_PREFIX + key
+
+    private class BiometricKeyException(
+        val code: String,
+        override val message: String = code,
+    ) : Exception(message)
+}

--- a/android/app/src/main/kotlin/app/piauthenticator/channels/PushPrivateKeyCodec.kt
+++ b/android/app/src/main/kotlin/app/piauthenticator/channels/PushPrivateKeyCodec.kt
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package app.piauthenticator.channels
+
+import java.math.BigInteger
+import java.security.GeneralSecurityException
+import java.security.InvalidKeyException
+import java.security.KeyFactory
+import java.security.PrivateKey
+import java.security.spec.PKCS8EncodedKeySpec
+import java.security.spec.RSAPrivateCrtKeySpec
+
+/** Decodes standards-compliant PKCS#1 RSA keys and a validated legacy encoding. */
+internal object PushPrivateKeyCodec {
+    private val RSA_PUBLIC_EXPONENT = BigInteger.valueOf(65537L)
+    private val ONE = BigInteger.ONE
+    private val ZERO = BigInteger.ZERO
+
+    internal data class DecodedKey(
+        val privateKey: PrivateKey,
+        val repairedLegacyEncoding: Boolean,
+    )
+
+    private data class RsaComponents(
+        val version: BigInteger,
+        val modulus: BigInteger,
+        val storedPublicExponent: BigInteger,
+        val privateExponent: BigInteger,
+        val primeP: BigInteger,
+        val primeQ: BigInteger,
+        val exponentP: BigInteger,
+        val exponentQ: BigInteger,
+        val crtCoefficient: BigInteger,
+    )
+
+    fun decode(pkcs1: ByteArray): DecodedKey {
+        val parsed = try {
+            parsePkcs1(pkcs1)
+        } catch (_: IllegalArgumentException) {
+            null
+        }
+        if (parsed != null && parsed.storedPublicExponent == parsed.privateExponent) {
+            return try {
+                DecodedKey(decodeLegacyDuplicateExponent(parsed), true)
+            } catch (error: Exception) {
+                throw InvalidKeyException("Invalid legacy RSA Push private key", error)
+            }
+        }
+
+        try {
+            return DecodedKey(
+                KeyFactory.getInstance("RSA").generatePrivate(
+                    PKCS8EncodedKeySpec(wrapPkcs1InPkcs8(pkcs1)),
+                ),
+                false,
+            )
+        } catch (error: GeneralSecurityException) {
+            throw InvalidKeyException("Invalid RSA Push private key", error)
+        }
+    }
+
+    private fun parsePkcs1(pkcs1: ByteArray): RsaComponents {
+        val outer = DerReader(pkcs1)
+        val sequence = outer.readSequence()
+        outer.requireAtEnd()
+        val result = RsaComponents(
+            sequence.readPositiveInteger(),
+            sequence.readPositiveInteger(),
+            sequence.readPositiveInteger(),
+            sequence.readPositiveInteger(),
+            sequence.readPositiveInteger(),
+            sequence.readPositiveInteger(),
+            sequence.readPositiveInteger(),
+            sequence.readPositiveInteger(),
+            sequence.readPositiveInteger(),
+        )
+        sequence.requireAtEnd()
+        return result
+    }
+
+    private fun decodeLegacyDuplicateExponent(key: RsaComponents): PrivateKey {
+        require(key.version == ZERO) { "Only two-prime RSA keys are supported" }
+        require(key.storedPublicExponent == key.privateExponent)
+        require(key.modulus.bitLength() in 2048..8192) { "Unexpected RSA modulus" }
+        require(key.primeP > ONE && key.primeQ > ONE && key.primeP != key.primeQ)
+        require(key.modulus == key.primeP.multiply(key.primeQ))
+        val pMinusOne = key.primeP.subtract(ONE)
+        val qMinusOne = key.primeQ.subtract(ONE)
+        require(key.exponentP == key.privateExponent.mod(pMinusOne))
+        require(key.exponentQ == key.privateExponent.mod(qMinusOne))
+        require(key.crtCoefficient == key.primeQ.modInverse(key.primeP))
+        val lambda = pMinusOne.divide(pMinusOne.gcd(qMinusOne)).multiply(qMinusOne)
+        val recoveredPublicExponent = key.privateExponent.modInverse(lambda)
+        require(recoveredPublicExponent == RSA_PUBLIC_EXPONENT)
+        return KeyFactory.getInstance("RSA").generatePrivate(
+            RSAPrivateCrtKeySpec(
+                key.modulus,
+                recoveredPublicExponent,
+                key.privateExponent,
+                key.primeP,
+                key.primeQ,
+                key.exponentP,
+                key.exponentQ,
+                key.crtCoefficient,
+            ),
+        )
+    }
+
+    private fun wrapPkcs1InPkcs8(pkcs1: ByteArray): ByteArray {
+        val version = byteArrayOf(0x02, 0x01, 0x00)
+        val rsaAlgorithm = byteArrayOf(
+            0x30, 0x0d, 0x06, 0x09, 0x2a, 0x86.toByte(), 0x48, 0x86.toByte(),
+            0xf7.toByte(), 0x0d, 0x01, 0x01, 0x01, 0x05, 0x00,
+        )
+        val privateKey = byteArrayOf(0x04) + derLength(pkcs1.size) + pkcs1
+        val body = version + rsaAlgorithm + privateKey
+        return byteArrayOf(0x30) + derLength(body.size) + body
+    }
+
+    private fun derLength(length: Int): ByteArray {
+        require(length >= 0)
+        if (length < 128) return byteArrayOf(length.toByte())
+        val bytes = ByteArray(4)
+        var value = length
+        var index = bytes.lastIndex
+        while (value != 0) {
+            bytes[index--] = (value and 0xff).toByte()
+            value = value ushr 8
+        }
+        val encoded = bytes.copyOfRange(index + 1, bytes.size)
+        return byteArrayOf((0x80 or encoded.size).toByte()) + encoded
+    }
+
+    private class DerReader(
+        private val data: ByteArray,
+        start: Int = 0,
+        private val end: Int = data.size,
+    ) {
+        private var offset = start
+
+        fun readSequence(): DerReader {
+            require(readByte() == 0x30) { "Expected DER sequence" }
+            val length = readLength()
+            require(length <= end - offset) { "Truncated DER sequence" }
+            val contentStart = offset
+            offset += length
+            return DerReader(data, contentStart, contentStart + length)
+        }
+
+        fun readPositiveInteger(): BigInteger {
+            require(readByte() == 0x02) { "Expected DER integer" }
+            val length = readLength()
+            require(length > 0 && length <= end - offset) { "Invalid DER integer" }
+            val first = data[offset].toInt() and 0xff
+            require(first and 0x80 == 0) { "Negative DER integer" }
+            if (length > 1 && first == 0) {
+                require(data[offset + 1].toInt() and 0x80 != 0) {
+                    "Non-minimal DER integer"
+                }
+            }
+            val bytes = data.copyOfRange(offset, offset + length)
+            offset += length
+            return try {
+                BigInteger(bytes)
+            } finally {
+                bytes.fill(0)
+            }
+        }
+
+        fun requireAtEnd() {
+            require(offset == end) { "Trailing DER data" }
+        }
+
+        private fun readLength(): Int {
+            val first = readByte()
+            if (first and 0x80 == 0) return first
+            val count = first and 0x7f
+            require(count in 1..4 && count <= end - offset) { "Invalid DER length" }
+            require(data[offset].toInt() and 0xff != 0) { "Non-minimal DER length" }
+            var length = 0
+            repeat(count) { length = (length shl 8) or readByte() }
+            require(length >= 128) { "Non-minimal DER length" }
+            return length
+        }
+
+        private fun readByte(): Int {
+            require(offset < end) { "Truncated DER data" }
+            return data[offset++].toInt() and 0xff
+        }
+    }
+}

--- a/android/app/src/test/kotlin/app/piauthenticator/channels/PushPrivateKeyCodecTest.kt
+++ b/android/app/src/test/kotlin/app/piauthenticator/channels/PushPrivateKeyCodecTest.kt
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package app.piauthenticator.channels
+
+import java.math.BigInteger
+import java.security.InvalidKeyException
+import java.security.KeyPairGenerator
+import java.security.Signature
+import java.security.interfaces.RSAPrivateCrtKey
+import java.security.interfaces.RSAPublicKey
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PushPrivateKeyCodecTest {
+    @Test
+    fun decodesStandardPkcs1AndSigns() {
+        val (privateKey, publicKey) = keyPair()
+        val decoded = PushPrivateKeyCodec.decode(pkcs1(privateKey))
+
+        assertFalse(decoded.repairedLegacyEncoding)
+        assertTrue(signAndVerify(decoded.privateKey, publicKey))
+    }
+
+    @Test
+    fun repairsExactDuplicateExponentEncodingAndSigns() {
+        val (privateKey, publicKey) = keyPair()
+        val decoded = PushPrivateKeyCodec.decode(
+            pkcs1(privateKey, storedPublicExponent = privateKey.privateExponent),
+        )
+
+        assertTrue(decoded.repairedLegacyEncoding)
+        assertTrue(signAndVerify(decoded.privateKey, publicKey))
+    }
+
+    @Test
+    fun rejectsLegacyShapeWithInconsistentCrtParameters() {
+        val (privateKey, _) = keyPair()
+        val malformed = pkcs1(
+            privateKey,
+            storedPublicExponent = privateKey.privateExponent,
+            exponentP = privateKey.primeExponentP.add(BigInteger.ONE),
+        )
+
+        assertThrows(InvalidKeyException::class.java) {
+            PushPrivateKeyCodec.decode(malformed)
+        }
+    }
+
+    private fun keyPair(): Pair<RSAPrivateCrtKey, RSAPublicKey> {
+        val pair = KeyPairGenerator.getInstance("RSA").apply {
+            initialize(2048)
+        }.generateKeyPair()
+        return Pair(pair.private as RSAPrivateCrtKey, pair.public as RSAPublicKey)
+    }
+
+    private fun signAndVerify(
+        privateKey: java.security.PrivateKey,
+        publicKey: RSAPublicKey,
+    ): Boolean {
+        val message = "Push PKCS#1 interoperability".toByteArray()
+        val signature = Signature.getInstance("SHA256withRSA").run {
+            initSign(privateKey)
+            update(message)
+            sign()
+        }
+        return Signature.getInstance("SHA256withRSA").run {
+            initVerify(publicKey)
+            update(message)
+            verify(signature)
+        }
+    }
+
+    private fun pkcs1(
+        key: RSAPrivateCrtKey,
+        storedPublicExponent: BigInteger = key.publicExponent,
+        exponentP: BigInteger = key.primeExponentP,
+    ): ByteArray = sequence(
+        integer(BigInteger.ZERO),
+        integer(key.modulus),
+        integer(storedPublicExponent),
+        integer(key.privateExponent),
+        integer(key.primeP),
+        integer(key.primeQ),
+        integer(exponentP),
+        integer(key.primeExponentQ),
+        integer(key.crtCoefficient),
+    )
+
+    private fun sequence(vararg values: ByteArray): ByteArray {
+        val body = values.fold(ByteArray(0)) { result, value -> result + value }
+        return byteArrayOf(0x30) + length(body.size) + body
+    }
+
+    private fun integer(value: BigInteger): ByteArray {
+        val encoded = value.toByteArray()
+        return byteArrayOf(0x02) + length(encoded.size) + encoded
+    }
+
+    private fun length(value: Int): ByteArray {
+        if (value < 128) return byteArrayOf(value.toByte())
+        val raw = BigInteger.valueOf(value.toLong()).toByteArray()
+            .dropWhile { it == 0.toByte() }
+            .toByteArray()
+        return byteArrayOf((0x80 or raw.size).toByte()) + raw
+    }
+}

--- a/docs/BIOMETRIC_PUSH_KEY_PROTECTION.md
+++ b/docs/BIOMETRIC_PUSH_KEY_PROTECTION.md
@@ -1,0 +1,126 @@
+# Biometric protection for Push keys
+
+This design separates three independent Push enrollment requirements:
+
+```text
+app_force_unlock=biometric
+app_biometric_level=strong
+app_invalidate_on_biometric_change=true
+```
+
+The existing privacyIDEA policy action is `push_app_force_unlock`. The two new
+server actions proposed by this design are `push_app_biometric_level` and
+`push_app_invalidate_on_biometric_change`. The enrollment URL should use the
+short `app_*` parameter names, consistent with the existing
+`app_force_unlock` parameter. For compatibility with an initial server
+implementation, the app also accepts the `push_app_*` names for the two new
+parameters. If both forms are present, the more specific `push_app_*` value
+wins.
+
+## Defaults and policy combinations
+
+When `app_force_unlock=biometric` is present and either new parameter is
+missing, the app defaults to `strong` and `true`. This makes existing biometric
+Push policies fail closed without requiring a simultaneous server upgrade.
+
+| Biometric level | Invalidate on change | Client behavior |
+| --- | --- | --- |
+| `strong` | `true` | Strong biometric for every signature; key invalidated after enrollment change |
+| `strong` | `false` | Strong biometric for every signature; key survives enrollment change |
+| `any` | `true` | Treated as strong because enrollment-bound cryptographic access cannot safely use weak Android biometrics |
+| `any` | `false` | Android `BIOMETRIC_WEAK` (which also accepts strong biometrics) before every use; widest device compatibility, but the private key cannot be bound to weak enrollment in Android Keystore and remains in encrypted app storage |
+
+Device PIN, pattern, and password are never fallback authenticators when
+`app_force_unlock=biometric`, including the `any` + `false` compatibility
+mode.
+
+The recommended policy set is:
+
+```text
+push_app_force_unlock=biometric
+push_app_biometric_level=strong
+push_app_invalidate_on_biometric_change=true
+```
+
+It requires class-3 biometrics on Android, never falls back to device
+credentials, and makes a biometric enrollment change invalidate the existing
+Push key.
+
+## Key lifecycle
+
+On Android, the app wraps the Push RSA private key with an Android Keystore AES
+key. The key permits only `BIOMETRIC_STRONG`, requires authentication for every
+cryptographic operation, and uses
+`setInvalidatedByBiometricEnrollment(true)` when requested. Adding a biometric
+or removing all biometrics invalidates an enrollment-bound key. Android does
+not guarantee invalidation when only one of several enrolled biometrics is
+removed.
+
+On iOS, the app stores the Push RSA private key in a non-synchronizing Keychain
+item protected by biometric-only access. `biometryCurrentSet` binds it to the
+current Face ID/Touch ID enrollment when invalidation is requested;
+`biometryAny` provides per-use biometric access without that binding. iOS does
+not expose Android-style weak and strong biometric classes, so Face ID/Touch ID
+is the platform equivalent used for `strong`.
+
+New Push tokens are protected before their public key is sent to privacyIDEA.
+An already deployed biometric Push token that has no native enrollment binding
+is invalidated and must be enrolled again. Transparently binding such a legacy
+token on first use would trust any biometric added after its original
+enrollment, which cannot satisfy change detection. An interrupted enrollment
+may be repaired only when the native protected key already exists. After
+protection, the Dart token record contains no private key. Native protected
+material is removed when the local token is deleted.
+
+Migration state must be written to secure token storage before a signature is
+sent over the network. If that write fails, rollout, polling, approval, or FCM
+token update stops without sending the signed request. Startup reconciliation
+repairs an interrupted migration before the token can be used.
+
+Native operations are serialized per token. Periodic automatic polling skips
+auth-per-use tokens so it cannot open a biometric prompt every few seconds;
+the user can still poll those tokens manually, while normal FCM delivery does
+not require use of the private key. Manual polling processes tokens
+sequentially so multiple protected tokens cannot open competing biometric
+prompts.
+
+If the platform reports an enrollment-bound key as invalid, the token is
+persisted as invalidated, Push approval is blocked, and the UI asks the user to
+remove and enroll the token again. A temporary authentication failure or user
+cancellation does not invalidate the token.
+
+Once a key is protected natively, relaxing the policy does not export it back
+to Dart. Any transition from `invalidate_on_biometric_change=false` to `true`
+invalidates the local token. This also covers a policy response racing with
+initial native protection: a key created without enrollment binding cannot be
+retroactively bound to the earlier biometric set, so a new enrollment is
+required.
+
+Container synchronization rebases server-owned template fields onto the latest
+local token under the token-state lock. It preserves native key state, rollout
+state, Firebase registration, and UI placement; a response that arrives after
+local deletion cannot recreate the token. Tightening the biometric enrollment
+binding during container synchronization follows the same fail-closed
+invalidation rule.
+
+## Server notification
+
+The currently supported Push protocol has no client-authenticated endpoint for
+a token to revoke or disable itself. The administrative `/token/revoke` and
+`/token/disable` operations must not be called from the app: embedding an admin
+credential would be unsafe, and an unauthenticated variant would permit remote
+denial of service.
+
+If privacyIDEA later adds a signed token self-invalidation operation, the app
+can report biometric key invalidation before removing any remaining native
+material. The server must authenticate the request with the enrolled token,
+make it idempotent, and define recovery when the signing key is already
+unavailable.
+
+## Validation before upstream submission
+
+Test at least one supported Android device and one iOS device for enrollment,
+approval, rejection, cancellation, app restart, token deletion, adding a new
+biometric, and removing all biometrics. Also verify that devices without the
+required biometric cannot activate a `strong` token. iOS changes require a
+separate Xcode build and device test before an upstream pull request.

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		6EBCAFBA0FB19CEC0ABC560B /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B0A948E39FB9ADC655A3B274 /* Pods_Runner.framework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
+		A96C101931DCAF5100B10A11 /* BiometricPushKeyChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A96C101831DCAF5100B10A11 /* BiometricPushKeyChannel.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
@@ -59,6 +60,7 @@
 		5997B4F6647F087D6C528CEB /* Pods-Runner.release-netknights_debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release-netknights_debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release-netknights_debug.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		A96C101831DCAF5100B10A11 /* BiometricPushKeyChannel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BiometricPushKeyChannel.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
@@ -171,6 +173,7 @@
 				1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */,
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
+				A96C101831DCAF5100B10A11 /* BiometricPushKeyChannel.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
 			);
 			path = Runner;
@@ -436,6 +439,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A96C101931DCAF5100B10A11 /* BiometricPushKeyChannel.swift in Sources */,
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
 			);

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -11,6 +11,9 @@ import Flutter
       UNUserNotificationCenter.current().delegate = self as? UNUserNotificationCenterDelegate
     }
     GeneratedPluginRegistrant.register(with: self)
+    if let registrar = registrar(forPlugin: "BiometricPushKeyChannel") {
+      BiometricPushKeyChannel.register(with: registrar.messenger())
+    }
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 }

--- a/ios/Runner/BiometricPushKeyChannel.swift
+++ b/ios/Runner/BiometricPushKeyChannel.swift
@@ -1,0 +1,316 @@
+import Flutter
+import Foundation
+import LocalAuthentication
+import Security
+
+/// Stores each biometric-only Push private key as a non-migrating Keychain
+/// item. `biometryCurrentSet` binds the item to the enrolled Face ID/Touch ID
+/// set; `biometryAny` keeps per-use biometric authentication without binding.
+final class BiometricPushKeyChannel {
+  private static let channelName = "biometric_push_key"
+  private static let service = "it.netknights.piauthenticator.push-biometric-key.v1"
+  private static let protectedPrefix = "biometric_push_key_protected_"
+
+  private static let invalidatedError = "BIOMETRIC_KEY_INVALIDATED"
+  private static let missingError = "BIOMETRIC_KEY_MISSING"
+  private static let unsupportedError = "BIOMETRIC_KEY_UNSUPPORTED"
+  private static let unavailableError = "BIOMETRIC_STRONG_UNAVAILABLE"
+  private static let canceledError = "BIOMETRIC_AUTH_CANCELED"
+  private static let failedError = "BIOMETRIC_AUTH_FAILED"
+
+  static func register(with messenger: FlutterBinaryMessenger) {
+    let channel = FlutterMethodChannel(name: channelName, binaryMessenger: messenger)
+    channel.setMethodCallHandler { call, result in
+      guard let arguments = call.arguments as? [String: Any],
+            let tokenId = nonEmptyString(arguments["tokenId"]) else {
+        result(error(failedError, "Missing tokenId"))
+        return
+      }
+
+      switch call.method {
+      case "status":
+        result(status(tokenId: tokenId))
+      case "delete":
+        delete(tokenId: tokenId)
+        result(nil)
+      case "protect":
+        protect(arguments: arguments, tokenId: tokenId, result: result)
+      case "sign":
+        sign(arguments: arguments, tokenId: tokenId, result: result)
+      default:
+        result(FlutterMethodNotImplemented)
+      }
+    }
+  }
+
+  private static func status(tokenId: String) -> String {
+    let query: [String: Any] = baseQuery(tokenId: tokenId).merging([
+      kSecReturnAttributes as String: true,
+      kSecMatchLimit as String: kSecMatchLimitOne,
+      kSecUseAuthenticationUI as String: kSecUseAuthenticationUIFail,
+    ]) { _, new in new }
+    let status = SecItemCopyMatching(query as CFDictionary, nil)
+    if status == errSecSuccess { return "protected" }
+    if wasProtected(tokenId: tokenId) {
+      // Attribute-only queries for an access-controlled item can return
+      // interaction-not-allowed while the device is locked. The durable marker
+      // lets startup reconciliation distinguish that from a never-migrated key.
+      return status == errSecItemNotFound ? "invalidated" : "protected"
+    }
+    return status == errSecItemNotFound ? "unprotected" : "unsupported"
+  }
+
+  private static func protect(
+    arguments: [String: Any],
+    tokenId: String,
+    result: @escaping FlutterResult
+  ) {
+    guard let privateKey = nonEmptyString(arguments["privateKey"]),
+          let reason = nonEmptyString(arguments["reason"]),
+          let cancelLabel = nonEmptyString(arguments["cancelLabel"]),
+          let invalidate = arguments["invalidateOnBiometricChange"] as? Bool else {
+      result(error(failedError, "Missing biometric Push key arguments"))
+      return
+    }
+    authenticate(reason: reason, cancelLabel: cancelLabel) { context, authenticationError in
+      guard let context = context else {
+        result(mapAuthenticationError(authenticationError))
+        return
+      }
+      do {
+        try store(
+          Data(base64Encoded: privateKey) ?? Data(),
+          tokenId: tokenId,
+          invalidateOnChange: invalidate,
+          context: context
+        )
+        result(nil)
+      } catch let keyError as KeyError {
+        result(error(keyError.code, keyError.message))
+      } catch {
+        result(self.error(failedError, "Could not protect the Push key"))
+      }
+    }
+  }
+
+  private static func sign(
+    arguments: [String: Any],
+    tokenId: String,
+    result: @escaping FlutterResult
+  ) {
+    guard let message = nonEmptyString(arguments["message"]),
+          let reason = nonEmptyString(arguments["reason"]),
+          let cancelLabel = nonEmptyString(arguments["cancelLabel"]),
+          let invalidate = arguments["invalidateOnBiometricChange"] as? Bool else {
+      result(error(failedError, "Missing biometric Push signing arguments"))
+      return
+    }
+
+    if status(tokenId: tokenId) == "invalidated" {
+      result(error(invalidatedError, "Biometric Push key is invalid"))
+      return
+    }
+
+    if let legacyKey = nonEmptyString(arguments["privateKey"]),
+       status(tokenId: tokenId) == "unprotected" {
+      authenticate(reason: reason, cancelLabel: cancelLabel) { context, authenticationError in
+        guard let context = context else {
+          result(mapAuthenticationError(authenticationError))
+          return
+        }
+        guard let keyData = Data(base64Encoded: legacyKey) else {
+          result(error(failedError, "Invalid Push private key"))
+          return
+        }
+        do {
+          try store(
+            keyData,
+            tokenId: tokenId,
+            invalidateOnChange: invalidate,
+            context: context
+          )
+          result([
+            "signature": try signMessage(keyData, message: message),
+            "protectedNow": true,
+          ])
+        } catch let keyError as KeyError {
+          delete(tokenId: tokenId)
+          result(error(keyError.code, keyError.message))
+        } catch {
+          delete(tokenId: tokenId)
+          result(self.error(failedError, "Could not protect the Push key"))
+        }
+      }
+      return
+    }
+
+    let context = LAContext()
+    context.localizedFallbackTitle = ""
+    context.localizedCancelTitle = cancelLabel
+    context.localizedReason = reason
+    context.touchIDAuthenticationAllowableReuseDuration = 0
+    let query: [String: Any] = baseQuery(tokenId: tokenId).merging([
+      kSecReturnData as String: true,
+      kSecMatchLimit as String: kSecMatchLimitOne,
+      kSecUseAuthenticationContext as String: context,
+    ]) { _, new in new }
+    var item: CFTypeRef?
+    let keychainStatus = SecItemCopyMatching(query as CFDictionary, &item)
+    guard keychainStatus == errSecSuccess, let keyData = item as? Data else {
+      if keychainStatus == errSecItemNotFound && wasProtected(tokenId: tokenId) {
+        result(error(invalidatedError, "Biometric Push key is invalid"))
+      } else if keychainStatus == errSecItemNotFound {
+        result(error(missingError, "Biometric Push key is missing"))
+      } else if keychainStatus == errSecUserCanceled {
+        result(error(canceledError, "Biometric authentication was canceled"))
+      } else {
+        result(error(failedError, "Biometric authentication failed"))
+      }
+      return
+    }
+    do {
+      result([
+        "signature": try signMessage(keyData, message: message),
+        "protectedNow": false,
+      ])
+    } catch let keyError as KeyError {
+      result(error(keyError.code, keyError.message))
+    } catch {
+      result(self.error(failedError, "Could not sign the Push response"))
+    }
+  }
+
+  private static func authenticate(
+    reason: String,
+    cancelLabel: String,
+    completion: @escaping (LAContext?, Error?) -> Void
+  ) {
+    let context = LAContext()
+    context.localizedFallbackTitle = ""
+    context.localizedCancelTitle = cancelLabel
+    context.touchIDAuthenticationAllowableReuseDuration = 0
+    var evaluationError: NSError?
+    guard context.canEvaluatePolicy(
+      .deviceOwnerAuthenticationWithBiometrics,
+      error: &evaluationError
+    ) else {
+      completion(nil, evaluationError)
+      return
+    }
+    context.evaluatePolicy(
+      .deviceOwnerAuthenticationWithBiometrics,
+      localizedReason: reason
+    ) { success, authenticationError in
+      DispatchQueue.main.async {
+        completion(success ? context : nil, authenticationError)
+      }
+    }
+  }
+
+  private static func store(
+    _ keyData: Data,
+    tokenId: String,
+    invalidateOnChange: Bool,
+    context: LAContext
+  ) throws {
+    guard !keyData.isEmpty else { throw KeyError(failedError, "Invalid Push private key") }
+    delete(tokenId: tokenId)
+    let flags: SecAccessControlCreateFlags = invalidateOnChange
+      ? .biometryCurrentSet
+      : .biometryAny
+    var accessError: Unmanaged<CFError>?
+    guard let access = SecAccessControlCreateWithFlags(
+      nil,
+      kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
+      flags,
+      &accessError
+    ) else {
+      throw KeyError(unsupportedError, "Could not create biometric access control")
+    }
+    let query: [String: Any] = baseQuery(tokenId: tokenId).merging([
+      kSecValueData as String: keyData,
+      kSecAttrAccessControl as String: access,
+      kSecUseAuthenticationContext as String: context,
+    ]) { _, new in new }
+    let status = SecItemAdd(query as CFDictionary, nil)
+    guard status == errSecSuccess else {
+      throw KeyError(failedError, "Could not store biometric Push key")
+    }
+    UserDefaults.standard.set(true, forKey: protectedPrefix + tokenId)
+  }
+
+  private static func signMessage(_ keyData: Data, message: String) throws -> String {
+    let attributes: [String: Any] = [
+      kSecAttrKeyType as String: kSecAttrKeyTypeRSA,
+      kSecAttrKeyClass as String: kSecAttrKeyClassPrivate,
+    ]
+    var createError: Unmanaged<CFError>?
+    guard let privateKey = SecKeyCreateWithData(
+      keyData as CFData,
+      attributes as CFDictionary,
+      &createError
+    ) else {
+      throw KeyError(failedError, "Invalid Push private key")
+    }
+    var signatureError: Unmanaged<CFError>?
+    guard let signature = SecKeyCreateSignature(
+      privateKey,
+      .rsaSignatureMessagePKCS1v15SHA256,
+      Data(message.utf8) as CFData,
+      &signatureError
+    ) else {
+      throw KeyError(failedError, "Could not sign the Push response")
+    }
+    return (signature as Data).base64EncodedString()
+  }
+
+  private static func delete(tokenId: String) {
+    SecItemDelete(baseQuery(tokenId: tokenId) as CFDictionary)
+    UserDefaults.standard.removeObject(forKey: protectedPrefix + tokenId)
+  }
+
+  private static func baseQuery(tokenId: String) -> [String: Any] {
+    [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: service,
+      kSecAttrAccount as String: tokenId,
+      kSecAttrSynchronizable as String: false,
+    ]
+  }
+
+  private static func wasProtected(tokenId: String) -> Bool {
+    UserDefaults.standard.bool(forKey: protectedPrefix + tokenId)
+  }
+
+  private static func mapAuthenticationError(_ source: Error?) -> FlutterError {
+    let code = (source as? LAError)?.code
+    if code == .userCancel || code == .systemCancel || code == .appCancel {
+      return error(canceledError, "Biometric authentication was canceled")
+    }
+    if code == .biometryNotAvailable ||
+       code == .biometryNotEnrolled ||
+       code == .passcodeNotSet {
+      return error(unavailableError, "Strong biometrics are unavailable")
+    }
+    return error(failedError, "Biometric authentication failed")
+  }
+
+  private static func nonEmptyString(_ value: Any?) -> String? {
+    guard let value = value as? String, !value.isEmpty else { return nil }
+    return value
+  }
+
+  private static func error(_ code: String, _ message: String) -> FlutterError {
+    FlutterError(code: code, message: message, details: nil)
+  }
+
+  private struct KeyError: Error {
+    let code: String
+    let message: String
+
+    init(_ code: String, _ message: String) {
+      self.code = code
+      self.message = message
+    }
+  }
+}

--- a/lib/api/impl/privacy_idea_container_api.dart
+++ b/lib/api/impl/privacy_idea_container_api.dart
@@ -177,7 +177,13 @@ class PiContainerApi implements TokenContainerApi {
       ...mergedTemplatesWithOtps,
       ...mergedTemplatesWithSerial,
     ]) {
-      final token = container.addOriginToToken(token: mergedTemplate.toToken());
+      final snapshotToken = tokenState.tokens.firstWhereOrNull(
+        (token) => token.id == mergedTemplate.additionalData[Token.ID],
+      );
+      final synchronizedToken = snapshotToken == null
+          ? mergedTemplate.toToken()
+          : snapshotToken.copyUpdateByTemplate(mergedTemplate);
+      final token = container.addOriginToToken(token: synchronizedToken);
       updatedTokens.add(token);
     }
 

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -1491,6 +1491,9 @@
   "@sendPushRequestResponseFailed": {
     "description": "Error message when the response to a push request could not be sent."
   },
+  "@pushRequestResponseRejected": {
+    "description": "Error shown when privacyIDEA did not positively accept a Push response."
+  },
   "@serverNotReachable": {
     "description": "Tells the user that the server could not be reached."
   },
@@ -2166,6 +2169,7 @@
   "sendErrorDialogBody": "V aplikaci se vyskytla neznámá chyba. Informace uvedené níže mohou být odeslány vývojářům e-mailem pro vyřešení chyby v budoucnu.",
   "sendErrorLogDescription": "Vytvoří se připravený e-mail.\nObsahuje informace o aplikaci, chybě a zařízení.\nPřed odesláním můžete e-mail upravit.\nZde se můžete podívat, jak informace používáme:",
   "sendPushRequestResponseFailed": "Odpověď se nepodařilo odeslat.",
+  "pushRequestResponseRejected": "Aplikace nemohla potvrdit, že server přijal odpověď Push. Platnost požadavku mohla vypršet nebo může být token neplatný.",
   "serverNotReachable": "Na server se nepodařilo dovolat.",
   "setUpButton": "Nastavení",
   "settings": "Nastavení",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1518,6 +1518,9 @@
   "@sendPushRequestResponseFailed": {
     "description": "Error message when the response to a push request could not be sent."
   },
+  "@pushRequestResponseRejected": {
+    "description": "Error shown when privacyIDEA did not positively accept a Push response."
+  },
   "@serverNotReachable": {
     "description": "Tells the user that the server could not be reached."
   },
@@ -2195,6 +2198,7 @@
   "sendErrorDialogBody": "Ein unbekannter Fehler ist aufgetreten. Die unten gezeigten Informationen können den Entwicklern per E-Mail zugesendet werden, um zu helfen, diesen Fehler in Zukunft zu vermeiden.",
   "sendErrorLogDescription": "Es wird eine vorgefertigte E-Mail erstellt.\nSie enthält Informationen über die App, den Fehler und das Gerät.\nSie können die E-Mail vor dem Senden bearbeiten.\nWie wir die Informationen verwenden, sehen Sie hier:",
   "sendPushRequestResponseFailed": "Senden der Antwort fehlgeschlagen.",
+  "pushRequestResponseRejected": "Die App konnte nicht bestätigen, dass der Server die Push-Antwort akzeptiert hat. Die Anfrage ist möglicherweise abgelaufen oder das Token ist ungültig.",
   "serverNotReachable": "Der Server konnte nicht erreicht werden.",
   "setUpButton": "Einrichten",
   "settings": "Einstellungen",
@@ -2257,5 +2261,13 @@
   "verboseLogging": "Ausführliche Protokollierung",
   "versionTitle": "Version",
   "wrongPassword": "Falsches Passwort",
-  "yes": "Ja"
+  "yes": "Ja",
+  "biometricPushKeyAuthReason": "Authentifizieren Sie sich, um dieses Push-Token zu verwenden",
+  "biometricPushKeyProtectReason": "Dieses Push-Token mit starker Biometrie schützen",
+  "biometricPushTokenInvalid": "Push-Token ungültig — biometrische Registrierung wurde geändert",
+  "biometricPushTokenInvalidTitle": "Push-Token ist nicht mehr gültig",
+  "biometricPushTokenInvalidBody": "Der biometrische Schlüssel dieses Push-Tokens ist nicht mehr gültig. Dies kann nach Änderungen der biometrischen Registrierung oder der Sicherheitsrichtlinie auftreten. Aus Sicherheitsgründen kann das Token keine Anfragen mehr signieren. Entfernen Sie es und registrieren Sie ein neues Push-Token.",
+  "biometricStrongRequired": "Dieses Push-Token erfordert starke Biometrie. Geräte-PIN, Muster, Passwort und schwache Biometrie können nicht verwendet werden.",
+  "biometricPushKeyPersistenceFailedTitle": "Push-Schlüsselschutz wurde nicht gespeichert",
+  "biometricPushKeyPersistenceFailed": "Der Status des geschützten Push-Schlüssels konnte nicht sicher gespeichert werden. Es wurden keine Daten an den Server gesendet. Versuchen Sie es erneut."
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1521,6 +1521,9 @@
   "@sendPushRequestResponseFailed": {
     "description": "Error message when the response to a push request could not be sent."
   },
+  "@pushRequestResponseRejected": {
+    "description": "Error shown when privacyIDEA did not positively accept a Push response."
+  },
   "@serverNotReachable": {
     "description": "Tells the user that the server could not be reached."
   },
@@ -2198,6 +2201,7 @@
   "sendErrorDialogBody": "An unexpected error occurred in the application. The information below can be sent to the developers by email to help prevent this error in the future.",
   "sendErrorLogDescription": "A predefined email is created.\nIt contains information about the app, the error and the device.\nYou can edit the email before sending it.\nYou can see here how we use the information:",
   "sendPushRequestResponseFailed": "Failed to send the response.",
+  "pushRequestResponseRejected": "The app could not confirm that the server accepted the Push response. The request may have expired or the token may be invalid.",
   "serverNotReachable": "The server could not be reached.",
   "setUpButton": "Set up",
   "settings": "Settings",
@@ -2260,5 +2264,13 @@
   "verboseLogging": "Verbose logging",
   "versionTitle": "Version",
   "wrongPassword": "Incorrect password",
-  "yes": "Yes"
+  "yes": "Yes",
+  "biometricPushKeyAuthReason": "Authenticate to use this Push token",
+  "biometricPushKeyProtectReason": "Protect this Push token with strong biometrics",
+  "biometricPushTokenInvalid": "Push token invalid — biometric enrollment changed",
+  "biometricPushTokenInvalidTitle": "Push token is no longer valid",
+  "biometricPushTokenInvalidBody": "The biometric key for this Push token is no longer valid. This can happen after biometric enrollment or security policy changes. For security, the token can no longer sign requests. Remove it and enroll a new Push token.",
+  "biometricStrongRequired": "This Push token requires strong biometrics. Device PIN, pattern, password, and weak biometrics cannot be used.",
+  "biometricPushKeyPersistenceFailedTitle": "Push key protection was not saved",
+  "biometricPushKeyPersistenceFailed": "The protected Push key state could not be saved securely. No data was sent to the server. Try again."
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1491,6 +1491,9 @@
   "@sendPushRequestResponseFailed": {
     "description": "Error message when the response to a push request could not be sent."
   },
+  "@pushRequestResponseRejected": {
+    "description": "Error shown when privacyIDEA did not positively accept a Push response."
+  },
   "@serverNotReachable": {
     "description": "Tells the user that the server could not be reached."
   },
@@ -2166,6 +2169,7 @@
   "sendErrorDialogBody": "Se ha producido un error inesperado en la aplicación. La siguiente información puede ser enviada a los desarrolladores por correo electrónico para ayudar a prevenir este error en el futuro.",
   "sendErrorLogDescription": "Se crea un correo electrónico listo.\nContiene información sobre la app, el error y el dispositivo.\nPuedes editar el correo antes de enviarlo.\nAquí puede ver cómo utilizamos la información:",
   "sendPushRequestResponseFailed": "No se ha podido enviar la respuesta.",
+  "pushRequestResponseRejected": "La aplicación no pudo confirmar que el servidor aceptara la respuesta Push. Es posible que la solicitud haya caducado o que el token no sea válido.",
   "serverNotReachable": "No se ha podido acceder al servidor.",
   "setUpButton": "Configuración",
   "settings": "Configuración",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1491,6 +1491,9 @@
   "@sendPushRequestResponseFailed": {
     "description": "Error message when the response to a push request could not be sent."
   },
+  "@pushRequestResponseRejected": {
+    "description": "Error shown when privacyIDEA did not positively accept a Push response."
+  },
   "@serverNotReachable": {
     "description": "Tells the user that the server could not be reached."
   },
@@ -2166,6 +2169,7 @@
   "sendErrorDialogBody": "Une erreur inattendue est survenue dans l'application. L'information suivante peut être transmise aux développeurs par email afin d'aider à corriger cette erreur dans le futur.",
   "sendErrorLogDescription": "Un e-mail pré-rempli est créé.\nIl contient des informations sur l'application, l'erreur et le périphérique.\nVous pouvez modifier l'e-mail avant de l'envoyer.\nVous pouvez voir ici comment nous utilisons les informations:",
   "sendPushRequestResponseFailed": "Échec de l'envoi de la réponse.",
+  "pushRequestResponseRejected": "L’application n’a pas pu confirmer que le serveur a accepté la réponse Push. La demande a peut-être expiré ou le jeton est peut-être invalide.",
   "serverNotReachable": "Le serveur n'a pas pu être atteint.",
   "setUpButton": "Configuration",
   "settings": "Paramètres",
@@ -2228,5 +2232,13 @@
   "verboseLogging": "Journalisation verbeuse",
   "versionTitle": "Version",
   "wrongPassword": "Mot de passe incorrect",
-  "yes": "Oui"
+  "yes": "Oui",
+  "biometricPushKeyAuthReason": "Authentifiez-vous pour utiliser ce jeton Push",
+  "biometricPushKeyProtectReason": "Protéger ce jeton Push avec une biométrie forte",
+  "biometricPushTokenInvalid": "Jeton Push non valide — l’enrôlement biométrique a changé",
+  "biometricPushTokenInvalidTitle": "Le jeton Push n’est plus valide",
+  "biometricPushTokenInvalidBody": "La clé biométrique de ce jeton Push n’est plus valide. Cela peut se produire après une modification de l’enrôlement biométrique ou de la politique de sécurité. Pour des raisons de sécurité, le jeton ne peut plus signer de demandes. Supprimez-le et enrôlez un nouveau jeton Push.",
+  "biometricStrongRequired": "Ce jeton Push exige une biométrie forte. Le code PIN, le schéma, le mot de passe de l’appareil et la biométrie faible ne peuvent pas être utilisés.",
+  "biometricPushKeyPersistenceFailedTitle": "La protection de la clé Push n’a pas été enregistrée",
+  "biometricPushKeyPersistenceFailed": "L’état de la clé Push protégée n’a pas pu être enregistré de manière sécurisée. Aucune donnée n’a été envoyée au serveur. Réessayez."
 }

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -1491,6 +1491,9 @@
   "@sendPushRequestResponseFailed": {
     "description": "Error message when the response to a push request could not be sent."
   },
+  "@pushRequestResponseRejected": {
+    "description": "Error shown when privacyIDEA did not positively accept a Push response."
+  },
   "@serverNotReachable": {
     "description": "Tells the user that the server could not be reached."
   },
@@ -2166,6 +2169,7 @@
   "sendErrorDialogBody": "Terjadi kesalahan yang tidak terduga dalam aplikasi. Informasi di bawah ini dapat dikirimkan ke pengembang melalui email untuk membantu mencegah kesalahan ini di masa mendatang.",
   "sendErrorLogDescription": "Email yang telah ditentukan sebelumnya akan dibuat.\nEmail ini berisi informasi tentang aplikasi, kesalahan, dan perangkat.\nAnda dapat mengedit email sebelum mengirimnya.\nAnda dapat melihat di sini bagaimana kami menggunakan informasi tersebut:",
   "sendPushRequestResponseFailed": "Gagal mengirim tanggapan.",
+  "pushRequestResponseRejected": "Aplikasi tidak dapat memastikan bahwa server menerima respons Push. Permintaan mungkin telah kedaluwarsa atau token mungkin tidak valid.",
   "serverNotReachable": "Server tidak dapat dihubungi.",
   "setUpButton": "Pengaturan",
   "settings": "Pengaturan",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -1491,6 +1491,9 @@
   "@sendPushRequestResponseFailed": {
     "description": "Error message when the response to a push request could not be sent."
   },
+  "@pushRequestResponseRejected": {
+    "description": "Error shown when privacyIDEA did not positively accept a Push response."
+  },
   "@serverNotReachable": {
     "description": "Tells the user that the server could not be reached."
   },
@@ -2166,6 +2169,7 @@
   "sendErrorDialogBody": "Een onverwachte fout heeft plaatsgevonden in de applicatie. De onderstaande informatie kan worden verstuurd naar de ontwikkelaars via e-mail om het probleem in de toekomst te voorkomen.",
   "sendErrorLogDescription": "Er wordt een kant-en-klare e-mail gemaakt die informatie bevat over de app, de fout en het apparaat.\nJe kunt de e-mail bewerken voordat je hem verstuurt.\nJe kunt hier zien hoe we de informatie gebruiken:",
   "sendPushRequestResponseFailed": "Het verzenden van het antwoord is mislukt. ",
+  "pushRequestResponseRejected": "De app kon niet bevestigen dat de server het Push-antwoord heeft geaccepteerd. Het verzoek is mogelijk verlopen of het token is mogelijk ongeldig.",
   "serverNotReachable": "De server kon niet worden bereikt.",
   "setUpButton": "Inrichten",
   "settings": "Instellingen",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -1491,6 +1491,9 @@
   "@sendPushRequestResponseFailed": {
     "description": "Error message when the response to a push request could not be sent."
   },
+  "@pushRequestResponseRejected": {
+    "description": "Error shown when privacyIDEA did not positively accept a Push response."
+  },
   "@serverNotReachable": {
     "description": "Tells the user that the server could not be reached."
   },
@@ -2166,6 +2169,7 @@
   "sendErrorDialogBody": "Napotkano nieoczekiwany błąd w aplikacji. Poniższa wiadomość może zostać wysłana do deweloperów poprzez email, żeby pomóc uniknąć tego problemu w przyszłości.",
   "sendErrorLogDescription": "Tworzona jest gotowa wiadomość e-mail zawierająca informacje o aplikacji, błędzie i urządzeniu.\nMożesz edytować wiadomość e-mail przed jej wysłaniem.\nTutaj można zobaczyć, w jaki sposób wykorzystujemy te informacje:",
   "sendPushRequestResponseFailed": "Nie udało się wysłać odpowiedzi.",
+  "pushRequestResponseRejected": "Aplikacja nie mogła potwierdzić, że serwer zaakceptował odpowiedź Push. Żądanie mogło wygasnąć albo token może być nieważny.",
   "serverNotReachable": "Nie można uzyskać połączenia z serwerem.",
   "setUpButton": "Konfiguracja",
   "settings": "Ustawienia",
@@ -2228,5 +2232,13 @@
   "verboseLogging": "Wyczerpujące rejestrowanie",
   "versionTitle": "Wersja",
   "wrongPassword": "Nieprawidłowe hasło",
-  "yes": "Tak"
+  "yes": "Tak",
+  "biometricPushKeyAuthReason": "Uwierzytelnij się, aby użyć tego tokenu Push",
+  "biometricPushKeyProtectReason": "Zabezpiecz ten token Push silną biometrią",
+  "biometricPushTokenInvalid": "Token Push nieważny — zmieniono biometrię",
+  "biometricPushTokenInvalidTitle": "Token Push nie jest już ważny",
+  "biometricPushTokenInvalidBody": "Klucz biometryczny tego tokenu Push nie jest już ważny. Może się tak zdarzyć po zmianie zestawu biometrii lub polityki bezpieczeństwa. Ze względów bezpieczeństwa token nie może już podpisywać żądań. Usuń go i zarejestruj nowy token Push.",
+  "biometricStrongRequired": "Ten token Push wymaga silnej biometrii. Nie można użyć kodu PIN, wzoru, hasła urządzenia ani słabej biometrii.",
+  "biometricPushKeyPersistenceFailedTitle": "Nie zapisano ochrony klucza Push",
+  "biometricPushKeyPersistenceFailed": "Nie udało się bezpiecznie zapisać stanu chronionego klucza Push. Żadne dane nie zostały wysłane do serwera. Spróbuj ponownie."
 }

--- a/lib/model/enums/biometric_push_key_status.dart
+++ b/lib/model/enums/biometric_push_key_status.dart
@@ -1,0 +1,20 @@
+// Modified by KW Krzysztof Wielgosz, 2026.
+/*
+ * privacyIDEA Authenticator
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+/// Durable client-side state of an Android Keystore protected Push key.
+enum BiometricPushKeyStatus {
+  /// The legacy private key still needs to be moved behind Android Keystore.
+  unprotected,
+
+  /// The private key is wrapped by an auth-per-use BIOMETRIC_STRONG key.
+  protected,
+
+  /// The Keystore key can no longer be used, e.g. after biometric enrollment
+  /// changed. This state is terminal and the Push token must be re-enrolled.
+  invalidated,
+}

--- a/lib/model/enums/push_app_biometric_level.dart
+++ b/lib/model/enums/push_app_biometric_level.dart
@@ -1,0 +1,30 @@
+/*
+ * privacyIDEA Authenticator
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+import '../../utils/logger.dart';
+import '../../utils/object_validator/object_validators.dart';
+
+/// Biometric class requested by a privacyIDEA Push enrollment policy.
+enum PushAppBiometricLevel { any, strong }
+
+extension PushAppBiometricLevelX on PushAppBiometricLevel {
+  static final validator = DefaultObjectValidator<PushAppBiometricLevel>(
+    defaultValue: PushAppBiometricLevel.any,
+    transformer: (value) {
+      if (value is PushAppBiometricLevel) return value;
+      final name = value.toString().split('.').last.toLowerCase();
+      final level = PushAppBiometricLevel.values
+          .where((candidate) => candidate.name == name)
+          .firstOrNull;
+      if (level == null) {
+        Logger.warning('Unknown Push biometric level: $value');
+        throw ArgumentError.value(value, 'push_app_biometric_level');
+      }
+      return level;
+    },
+  );
+}

--- a/lib/model/tokens/push_token.dart
+++ b/lib/model/tokens/push_token.dart
@@ -26,6 +26,8 @@ import '../../../../../../../model/token_template.dart';
 import '../../utils/object_validator/object_validators.dart';
 import '../../utils/rsa_utils.dart';
 import '../enums/force_biometric_option.dart';
+import '../enums/biometric_push_key_status.dart';
+import '../enums/push_app_biometric_level.dart';
 import '../enums/push_token_rollout_state.dart';
 import '../enums/token_types.dart';
 import '../exception_errors/localized_argument_error.dart';
@@ -56,6 +58,13 @@ class PushToken extends Token {
   static const String PUBLIC_SERVER_KEY = 'publicServerKey';
   static const String PRIVATE_TOKEN_KEY = 'privateTokenKey';
   static const String PUBLIC_TOKEN_KEY = 'publicTokenKey';
+  static const String BIOMETRIC_KEY_STATUS = 'biometricKeyStatus';
+  static const String APP_BIOMETRIC_LEVEL = 'app_biometric_level';
+  static const String PUSH_APP_BIOMETRIC_LEVEL = 'push_app_biometric_level';
+  static const String APP_INVALIDATE_ON_BIOMETRIC_CHANGE =
+      'app_invalidate_on_biometric_change';
+  static const String PUSH_APP_INVALIDATE_ON_BIOMETRIC_CHANGE =
+      'push_app_invalidate_on_biometric_change';
 
   // --- Static Accessors & Validators ---
   static String get tokenType => TokenTypes.PIPUSH.name;
@@ -71,6 +80,10 @@ class PushToken extends Token {
     ENROLLMENT_CREDENTIAL: Validators.stringOptional,
     ROLLOUT_URL: Validators.httpUri,
     VERSION: Validators.string,
+    APP_BIOMETRIC_LEVEL: PushAppBiometricLevelX.validator.optional(),
+    PUSH_APP_BIOMETRIC_LEVEL: PushAppBiometricLevelX.validator.optional(),
+    APP_INVALIDATE_ON_BIOMETRIC_CHANGE: Validators.boolOptional,
+    PUSH_APP_INVALIDATE_ON_BIOMETRIC_CHANGE: Validators.boolOptional,
   };
 
   static final Map<String, BaseValidator> additionalDataValidators = {
@@ -83,6 +96,12 @@ class PushToken extends Token {
     PUBLIC_SERVER_KEY: Validators.stringOptional,
     PUBLIC_TOKEN_KEY: Validators.stringOptional,
     PRIVATE_TOKEN_KEY: Validators.stringOptional,
+    BIOMETRIC_KEY_STATUS: DefaultObjectValidator<BiometricPushKeyStatus>(
+      defaultValue: BiometricPushKeyStatus.unprotected,
+      transformer: (value) => value is BiometricPushKeyStatus
+          ? value
+          : BiometricPushKeyStatus.values.byName(value.toString()),
+    ),
   };
 
   // --- Static Validation Methods ---
@@ -118,6 +137,25 @@ class PushToken extends Token {
   final String? publicServerKey;
   final String? privateTokenKey;
   final String? publicTokenKey;
+  final BiometricPushKeyStatus biometricKeyStatus;
+  final PushAppBiometricLevel biometricLevel;
+  final bool invalidateOnBiometricChange;
+
+  bool get requiresStrongBiometric =>
+      forceBiometricOption == ForceBiometricOption.biometric &&
+      (biometricLevel == PushAppBiometricLevel.strong ||
+          invalidateOnBiometricChange);
+  // Once a key has moved to native biometric storage, keep using it even if a
+  // later server policy is relaxed. There is no safe way to export it back to
+  // Dart without weakening the original protection.
+  bool get requiresBiometricKeyProtection =>
+      requiresStrongBiometric ||
+      biometricKeyStatus != BiometricPushKeyStatus.unprotected;
+  bool get requiresBiometricPromptBeforeDartKeyUse =>
+      forceBiometricOption == ForceBiometricOption.biometric &&
+      !requiresBiometricKeyProtection;
+  bool get isBiometricKeyInvalidated =>
+      biometricKeyStatus == BiometricPushKeyStatus.invalidated;
 
   @override
   String get serial => super.serial!;
@@ -141,8 +179,9 @@ class PushToken extends Token {
       copyWith(publicServerKey: rsaParser.serializeRSAPublicKeyPKCS1(key));
   PushToken withPublicTokenKey(RSAPublicKey key) =>
       copyWith(publicTokenKey: rsaParser.serializeRSAPublicKeyPKCS1(key));
-  PushToken withPrivateTokenKey(RSAPrivateKey key) =>
-      copyWith(privateTokenKey: rsaParser.serializeRSAPrivateKeyPKCS1(key));
+  PushToken withPrivateTokenKey(RSAPrivateKey key) => copyWith(
+    privateTokenKey: () => rsaParser.serializeRSAPrivateKeyPKCS1(key),
+  );
 
   // --- Constructor ---
   PushToken({
@@ -159,6 +198,9 @@ class PushToken extends Token {
     this.publicServerKey,
     this.publicTokenKey,
     this.privateTokenKey,
+    this.biometricKeyStatus = BiometricPushKeyStatus.unprotected,
+    PushAppBiometricLevel? biometricLevel,
+    bool? invalidateOnBiometricChange,
     this.isPollOnly,
     bool? isRolledOut,
     bool? sslVerify,
@@ -173,7 +215,15 @@ class PushToken extends Token {
     super.origin,
     super.isOffline,
     super.forceBiometricOption,
-  }) : isRolledOut = isRolledOut ?? false,
+  }) : biometricLevel =
+           biometricLevel ??
+           (forceBiometricOption == ForceBiometricOption.biometric
+               ? PushAppBiometricLevel.strong
+               : PushAppBiometricLevel.any),
+       invalidateOnBiometricChange =
+           invalidateOnBiometricChange ??
+           forceBiometricOption == ForceBiometricOption.biometric,
+       isRolledOut = isRolledOut ?? false,
        sslVerify = sslVerify ?? false,
        rolloutState = rolloutState ?? PushTokenRollOutState.rolloutNotStarted,
        super(type: type ?? TokenTypes.PIPUSH.name, serial: serial);
@@ -240,6 +290,14 @@ class PushToken extends Token {
       isOffline: validatedMap[Token.OFFLINE] as bool,
       forceBiometricOption:
           validatedMap[Token.FORCE_BIOMETRIC_OPTION] as ForceBiometricOption,
+      biometricLevel:
+          (validatedMap[PUSH_APP_BIOMETRIC_LEVEL] ??
+                  validatedMap[APP_BIOMETRIC_LEVEL])
+              as PushAppBiometricLevel?,
+      invalidateOnBiometricChange:
+          (validatedMap[PUSH_APP_INVALIDATE_ON_BIOMETRIC_CHANGE] ??
+                  validatedMap[APP_INVALIDATE_ON_BIOMETRIC_CHANGE])
+              as bool?,
       id: validatedAdditionalData[Token.ID] as String? ?? uuidV4(),
       containerSerial:
           validatedAdditionalData[Token.CONTAINER_SERIAL] as String?,
@@ -251,6 +309,9 @@ class PushToken extends Token {
       publicServerKey: validatedAdditionalData[PUBLIC_SERVER_KEY] as String?,
       publicTokenKey: validatedAdditionalData[PUBLIC_TOKEN_KEY] as String?,
       privateTokenKey: validatedAdditionalData[PRIVATE_TOKEN_KEY] as String?,
+      biometricKeyStatus:
+          validatedAdditionalData[BIOMETRIC_KEY_STATUS]
+              as BiometricPushKeyStatus,
     );
   }
 
@@ -268,7 +329,10 @@ class PushToken extends Token {
       other.rolloutState == rolloutState &&
       other.publicServerKey == publicServerKey &&
       other.publicTokenKey == publicTokenKey &&
-      other.privateTokenKey == privateTokenKey;
+      other.privateTokenKey == privateTokenKey &&
+      other.biometricKeyStatus == biometricKeyStatus &&
+      other.biometricLevel == biometricLevel &&
+      other.invalidateOnBiometricChange == invalidateOnBiometricChange;
 
   @override
   bool isSameTokenAs(Token other) {
@@ -303,7 +367,10 @@ class PushToken extends Token {
     Uri? url,
     String? publicServerKey,
     String? publicTokenKey,
-    String? privateTokenKey,
+    String? Function()? privateTokenKey,
+    BiometricPushKeyStatus? biometricKeyStatus,
+    PushAppBiometricLevel? biometricLevel,
+    bool? invalidateOnBiometricChange,
     DateTime? expirationDate,
     bool? isRolledOut,
     PushTokenRollOutState? rolloutState,
@@ -314,6 +381,9 @@ class PushToken extends Token {
     ForceBiometricOption? forceBiometricOption,
   }) {
     final String? newSerial = serial?.call();
+    final enablesBiometricProtection =
+        forceBiometricOption == ForceBiometricOption.biometric &&
+        this.forceBiometricOption != ForceBiometricOption.biometric;
     return PushToken(
       label: label ?? this.label,
       serial: newSerial ?? this.serial,
@@ -335,7 +405,20 @@ class PushToken extends Token {
       url: url ?? this.url,
       publicServerKey: publicServerKey ?? this.publicServerKey,
       publicTokenKey: publicTokenKey ?? this.publicTokenKey,
-      privateTokenKey: privateTokenKey ?? this.privateTokenKey,
+      privateTokenKey: privateTokenKey != null
+          ? privateTokenKey()
+          : this.privateTokenKey,
+      biometricKeyStatus: biometricKeyStatus ?? this.biometricKeyStatus,
+      biometricLevel:
+          biometricLevel ??
+          (enablesBiometricProtection
+              ? PushAppBiometricLevel.strong
+              : this.biometricLevel),
+      invalidateOnBiometricChange:
+          invalidateOnBiometricChange ??
+          (enablesBiometricProtection
+              ? true
+              : this.invalidateOnBiometricChange),
       expirationDate: expirationDate ?? this.expirationDate,
       isRolledOut: isRolledOut ?? this.isRolledOut,
       rolloutState: rolloutState ?? this.rolloutState,
@@ -347,10 +430,112 @@ class PushToken extends Token {
     );
   }
 
+  /// Applies new token data without allowing a stale writer to weaken native
+  /// biometric key protection already recorded for [current].
+  ///
+  /// This is intentionally monotonic: `invalidated` is terminal, `protected`
+  /// never returns to plaintext storage, and tightening enrollment binding for
+  /// an existing unbound native key invalidates that key.
+  PushToken withMonotonicBiometricStateFrom(PushToken current) {
+    final tightenedEnrollmentBindingForNativeKey =
+        current.biometricKeyStatus == BiometricPushKeyStatus.protected &&
+        !current.invalidateOnBiometricChange &&
+        invalidateOnBiometricChange;
+    final newlyRequiresNativeProtection =
+        !current.requiresBiometricKeyProtection &&
+        requiresBiometricKeyProtection;
+    final deployedPlaintextCannotBeRetrofitted =
+        current.isRolledOut &&
+        current.biometricKeyStatus == BiometricPushKeyStatus.unprotected &&
+        newlyRequiresNativeProtection;
+    var mergedStatus = switch ((
+      current.biometricKeyStatus,
+      biometricKeyStatus,
+    )) {
+      (BiometricPushKeyStatus.invalidated, _) ||
+      (
+        _,
+        BiometricPushKeyStatus.invalidated,
+      ) => BiometricPushKeyStatus.invalidated,
+      _
+          when tightenedEnrollmentBindingForNativeKey ||
+              deployedPlaintextCannotBeRetrofitted =>
+        BiometricPushKeyStatus.invalidated,
+      (BiometricPushKeyStatus.protected, _) ||
+      (_, BiometricPushKeyStatus.protected) => BiometricPushKeyStatus.protected,
+      _ => BiometricPushKeyStatus.unprotected,
+    };
+    final currentNativePublicKey =
+        current.biometricKeyStatus == BiometricPushKeyStatus.protected
+        ? current.publicTokenKey
+        : null;
+    final incomingNativePublicKey =
+        biometricKeyStatus == BiometricPushKeyStatus.protected
+        ? publicTokenKey
+        : null;
+    final nativePublicKeyConflict =
+        currentNativePublicKey != null &&
+        incomingNativePublicKey != null &&
+        currentNativePublicKey != incomingNativePublicKey;
+    if (nativePublicKeyConflict) {
+      mergedStatus = BiometricPushKeyStatus.invalidated;
+    }
+    final mergedPublicTokenKey = switch (mergedStatus) {
+      BiometricPushKeyStatus.protected =>
+        currentNativePublicKey ?? incomingNativePublicKey,
+      _ => publicTokenKey,
+    };
+    return copyWith(
+      publicTokenKey: mergedPublicTokenKey,
+      biometricKeyStatus: mergedStatus,
+      privateTokenKey: () => mergedStatus == BiometricPushKeyStatus.unprotected
+          ? privateTokenKey ?? current.privateTokenKey
+          : null,
+    ).withFailClosedBiometricLifecycle();
+  }
+
+  /// Enforces the storage invariant for a deployed Push token even when there
+  /// is no earlier local record to merge (for example, a container import).
+  PushToken withFailClosedBiometricLifecycle() {
+    if (isBiometricKeyInvalidated) {
+      return privateTokenKey == null
+          ? this
+          : copyWith(privateTokenKey: () => null);
+    }
+    if (isRolledOut &&
+        requiresBiometricKeyProtection &&
+        biometricKeyStatus == BiometricPushKeyStatus.unprotected) {
+      return copyWith(
+        privateTokenKey: () => null,
+        biometricKeyStatus: BiometricPushKeyStatus.invalidated,
+      );
+    }
+    return this;
+  }
+
   @override
   Token copyUpdateByTemplate(TokenTemplate template) {
     final uriMap = validateOtpAuthMap(template.otpAuthMap);
-    return copyWith(
+    final forceUnlock =
+        uriMap[Token.FORCE_BIOMETRIC_OPTION] as ForceBiometricOption;
+    final policyLevel =
+        (uriMap[PUSH_APP_BIOMETRIC_LEVEL] ?? uriMap[APP_BIOMETRIC_LEVEL])
+            as PushAppBiometricLevel?;
+    final policyInvalidation =
+        (uriMap[PUSH_APP_INVALIDATE_ON_BIOMETRIC_CHANGE] ??
+                uriMap[APP_INVALIDATE_ON_BIOMETRIC_CHANGE])
+            as bool?;
+    final nextBiometricLevel =
+        policyLevel ??
+        (forceUnlock == ForceBiometricOption.biometric
+            ? PushAppBiometricLevel.strong
+            : biometricLevel);
+    final nextInvalidation =
+        policyInvalidation ??
+        (forceUnlock == ForceBiometricOption.biometric
+            ? true
+            : invalidateOnBiometricChange);
+    final updated = copyWith(
       label: uriMap[Token.LABEL] as String?,
       issuer: uriMap[Token.ISSUER] as String?,
       serial: () => uriMap[Token.SERIAL] as String?,
@@ -363,7 +548,15 @@ class PushToken extends Token {
       tokenImage: uriMap[Token.IMAGE] as String?,
       pin: uriMap[Token.PIN] as bool?,
       isLocked: uriMap[Token.PIN] as bool?,
+      forceBiometricOption: forceUnlock,
+      biometricLevel: nextBiometricLevel,
+      invalidateOnBiometricChange: nextInvalidation,
+      biometricKeyStatus: biometricKeyStatus,
+      privateTokenKey: biometricKeyStatus == BiometricPushKeyStatus.invalidated
+          ? () => null
+          : null,
     );
+    return updated.withMonotonicBiometricStateFrom(this);
   }
 
   @override
@@ -376,6 +569,10 @@ class PushToken extends Token {
             : IS_POLL_ONLY_VALUE_FALSE,
       ENROLLMENT_CREDENTIAL: enrollmentCredentials,
       if (url != null) ROLLOUT_URL: url.toString(),
+      if (forceBiometricOption == ForceBiometricOption.biometric)
+        APP_BIOMETRIC_LEVEL: biometricLevel.name,
+      if (forceBiometricOption == ForceBiometricOption.biometric)
+        APP_INVALIDATE_ON_BIOMETRIC_CHANGE: invalidateOnBiometricChange,
       VERSION: '1',
     });
 
@@ -388,6 +585,7 @@ class PushToken extends Token {
       PUBLIC_SERVER_KEY: publicServerKey,
       PUBLIC_TOKEN_KEY: publicTokenKey,
       PRIVATE_TOKEN_KEY: privateTokenKey,
+      BIOMETRIC_KEY_STATUS: biometricKeyStatus,
     });
 
   @override

--- a/lib/model/tokens/push_token.g.dart
+++ b/lib/model/tokens/push_token.g.dart
@@ -26,6 +26,17 @@ PushToken _$PushTokenFromJson(Map<String, dynamic> json) => PushToken(
   publicServerKey: json['publicServerKey'] as String?,
   publicTokenKey: json['publicTokenKey'] as String?,
   privateTokenKey: json['privateTokenKey'] as String?,
+  biometricKeyStatus:
+      $enumDecodeNullable(
+        _$BiometricPushKeyStatusEnumMap,
+        json['biometricKeyStatus'],
+      ) ??
+      BiometricPushKeyStatus.unprotected,
+  biometricLevel: $enumDecodeNullable(
+    _$PushAppBiometricLevelEnumMap,
+    json['biometricLevel'],
+  ),
+  invalidateOnBiometricChange: json['invalidateOnBiometricChange'] as bool?,
   isPollOnly: json['isPollOnly'] as bool?,
   isRolledOut: json['isRolledOut'] as bool?,
   sslVerify: json['sslVerify'] as bool?,
@@ -79,8 +90,23 @@ Map<String, dynamic> _$PushTokenToJson(PushToken instance) => <String, dynamic>{
   'publicServerKey': instance.publicServerKey,
   'privateTokenKey': instance.privateTokenKey,
   'publicTokenKey': instance.publicTokenKey,
+  'biometricKeyStatus':
+      _$BiometricPushKeyStatusEnumMap[instance.biometricKeyStatus]!,
+  'biometricLevel': _$PushAppBiometricLevelEnumMap[instance.biometricLevel]!,
+  'invalidateOnBiometricChange': instance.invalidateOnBiometricChange,
   'serial': instance.serial,
   'isHidden': instance.isHidden,
+};
+
+const _$BiometricPushKeyStatusEnumMap = {
+  BiometricPushKeyStatus.unprotected: 'unprotected',
+  BiometricPushKeyStatus.protected: 'protected',
+  BiometricPushKeyStatus.invalidated: 'invalidated',
+};
+
+const _$PushAppBiometricLevelEnumMap = {
+  PushAppBiometricLevel.any: 'any',
+  PushAppBiometricLevel.strong: 'strong',
 };
 
 const _$PushTokenRollOutStateEnumMap = {

--- a/lib/model/tokens/token.dart
+++ b/lib/model/tokens/token.dart
@@ -88,6 +88,7 @@ abstract class Token with SortableMixin {
     'isHidden',
     'isOffline',
     'forceBiometricOption',
+    'biometricKeyStatus',
     'viewMode',
     'sortIndex',
     'folderId',

--- a/lib/repo/secure_token_repository.dart
+++ b/lib/repo/secure_token_repository.dart
@@ -27,6 +27,8 @@ import 'package:privacyidea_authenticator/views/main_view/main_view_widgets/load
 
 import '../interfaces/repo/token_repository.dart';
 import '../l10n/app_localizations.dart';
+import '../model/enums/biometric_push_key_status.dart';
+import '../model/tokens/push_token.dart';
 import '../model/tokens/token.dart';
 import '../utils/globals.dart';
 import '../utils/helpers/log_redaction_helper.dart';
@@ -152,7 +154,17 @@ class SecureTokenRepository implements TokenRepository {
         Logger.info(
           'Legacy entry that meets token criteria: ${entry.key} will be migrated to new secure storage',
         );
-        await _storage.write(key: entry.key, value: entry.value);
+        final currentValue = await _storage.read(key: entry.key);
+        if (currentValue == null) {
+          await _storage.write(
+            key: entry.key,
+            value: _sanitizeLegacyTokenBeforeMigration(valueJson, entry.value),
+          );
+        } else {
+          Logger.info(
+            'Keeping the existing token ${valueJson['id']} in new secure storage',
+          );
+        }
         await _storageLegacy.delete(key: entry.key);
         Logger.info('Migrated token ${valueJson['id']} to new secure storage');
       } catch (e, s) {
@@ -164,6 +176,38 @@ class SecureTokenRepository implements TokenRepository {
       }
     }
     Logger.info('Migration of legacy tokens to new secure storage completed');
+  }
+
+  String _sanitizeLegacyTokenBeforeMigration(
+    Map<String, dynamic> valueJson,
+    String originalValue,
+  ) {
+    try {
+      final token = Token.fromJson(valueJson);
+      final isUnsafeRolledOutBiometricPush =
+          token is PushToken &&
+          token.isRolledOut &&
+          token.requiresBiometricKeyProtection &&
+          (token.privateTokenKey != null ||
+              token.biometricKeyStatus == BiometricPushKeyStatus.unprotected);
+      if (!isUnsafeRolledOutBiometricPush) return originalValue;
+
+      Logger.warning(
+        'Invalidating an unsafe legacy biometric Push key during migration.',
+      );
+      return jsonEncode(
+        token
+            .copyWith(
+              privateTokenKey: () => null,
+              biometricKeyStatus: BiometricPushKeyStatus.invalidated,
+            )
+            .toJson(),
+      );
+    } catch (_) {
+      // Preserve the previous migration behavior for entries that only meet
+      // the legacy shape check but cannot be parsed as a current Token.
+      return originalValue;
+    }
   }
 
   /// Returns a list of all tokens that are saved in the secure storage of

--- a/lib/utils/biometric_push_key_manager.dart
+++ b/lib/utils/biometric_push_key_manager.dart
@@ -1,0 +1,158 @@
+/*
+ * privacyIDEA Authenticator
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+
+import 'helpers/mutex.dart';
+
+enum BiometricPushKeyNativeStatus {
+  unprotected,
+  protected,
+  invalidated,
+  unsupported,
+}
+
+class BiometricPushKeyResult {
+  final String signature;
+  final bool protectedNow;
+
+  const BiometricPushKeyResult({
+    required this.signature,
+    required this.protectedNow,
+  });
+}
+
+class BiometricPushKeyException implements Exception {
+  final String code;
+
+  const BiometricPushKeyException(this.code);
+
+  bool get isInvalidated =>
+      code == BiometricPushKeyManager.invalidatedCode ||
+      code == BiometricPushKeyManager.keyMissingCode;
+  bool get isStateNotPersisted =>
+      code == BiometricPushKeyManager.stateNotPersistedCode;
+
+  @override
+  String toString() => 'BiometricPushKeyException($code)';
+}
+
+/// Bridges biometric-only Push signing to Android Keystore or iOS Keychain.
+///
+/// * requires BIOMETRIC_STRONG for every use;
+/// * never permits a device-credential fallback;
+/// * can be invalidated when biometric enrollment changes.
+///
+/// The native side stores only the wrapped private key and its IV. Dart keeps
+/// no private key after a successful migration.
+class BiometricPushKeyManager {
+  static const channelName = 'biometric_push_key';
+  static const invalidatedCode = 'BIOMETRIC_KEY_INVALIDATED';
+  static const keyMissingCode = 'BIOMETRIC_KEY_MISSING';
+  static const unsupportedCode = 'BIOMETRIC_KEY_UNSUPPORTED';
+  static const canceledCode = 'BIOMETRIC_AUTH_CANCELED';
+  static const stateNotPersistedCode = 'BIOMETRIC_KEY_STATE_NOT_PERSISTED';
+
+  /// Native biometric operations for one token must never overlap. In
+  /// particular, a periodic poll must not replace a Keystore key while an
+  /// approval or a legacy-key migration is still authenticating.
+  static final Map<String, Mutex> _tokenMutexes = {};
+
+  final MethodChannel channel;
+  final bool? supportedPlatformOverride;
+
+  const BiometricPushKeyManager({
+    this.channel = const MethodChannel(channelName),
+    this.supportedPlatformOverride,
+  });
+
+  bool get isSupportedPlatform =>
+      supportedPlatformOverride ?? (Platform.isAndroid || Platform.isIOS);
+
+  Mutex _mutexFor(String tokenId) =>
+      _tokenMutexes.putIfAbsent(tokenId, Mutex.new);
+
+  Future<BiometricPushKeyNativeStatus> status(String tokenId) async {
+    if (!isSupportedPlatform) {
+      return BiometricPushKeyNativeStatus.unsupported;
+    }
+    return _mutexFor(tokenId).protect(() async {
+      final value = await _invoke<String>('status', {'tokenId': tokenId});
+      return switch (value) {
+        'protected' => BiometricPushKeyNativeStatus.protected,
+        'invalidated' => BiometricPushKeyNativeStatus.invalidated,
+        'unsupported' => BiometricPushKeyNativeStatus.unsupported,
+        _ => BiometricPushKeyNativeStatus.unprotected,
+      };
+    });
+  }
+
+  Future<void> protect({
+    required String tokenId,
+    required String privateKey,
+    required String reason,
+    required String cancelLabel,
+    required bool invalidateOnBiometricChange,
+  }) => _mutexFor(tokenId).protect(
+    () => _invoke<void>('protect', {
+      'tokenId': tokenId,
+      'privateKey': privateKey,
+      'reason': reason,
+      'cancelLabel': cancelLabel,
+      'invalidateOnBiometricChange': invalidateOnBiometricChange,
+    }),
+  );
+
+  Future<BiometricPushKeyResult> sign({
+    required String tokenId,
+    required String message,
+    required String reason,
+    required String cancelLabel,
+    required bool invalidateOnBiometricChange,
+    String? privateKey,
+  }) async {
+    return _mutexFor(tokenId).protect(() async {
+      final value = await _invoke<Map<Object?, Object?>>('sign', {
+        'tokenId': tokenId,
+        'message': message,
+        'reason': reason,
+        'cancelLabel': cancelLabel,
+        'invalidateOnBiometricChange': invalidateOnBiometricChange,
+        'privateKey': ?privateKey,
+      });
+      final signature = value['signature'];
+      if (signature is! String) {
+        throw const BiometricPushKeyException('INVALID_NATIVE_RESPONSE');
+      }
+      return BiometricPushKeyResult(
+        signature: base64.normalize(signature),
+        protectedNow: value['protectedNow'] == true,
+      );
+    });
+  }
+
+  Future<void> delete(String tokenId) async {
+    if (!isSupportedPlatform) return;
+    await _mutexFor(
+      tokenId,
+    ).protect(() => _invoke<void>('delete', {'tokenId': tokenId}));
+  }
+
+  Future<T> _invoke<T>(String method, Map<String, Object> arguments) async {
+    try {
+      final result = await channel.invokeMethod<T>(method, arguments);
+      return result as T;
+    } on PlatformException catch (error) {
+      throw BiometricPushKeyException(error.code);
+    } on MissingPluginException {
+      throw const BiometricPushKeyException(unsupportedCode);
+    }
+  }
+}

--- a/lib/utils/push_provider.dart
+++ b/lib/utils/push_provider.dart
@@ -25,8 +25,10 @@ import 'dart:io';
 import 'package:collection/collection.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter/foundation.dart';
 import 'package:http/http.dart';
 import 'package:privacyidea_authenticator/l10n/app_localizations_en.dart';
+import 'package:privacyidea_authenticator/model/enums/force_biometric_option.dart';
 import 'package:privacyidea_authenticator/utils/view_utils.dart';
 
 import '../../../../../../../repo/secure_push_request_repository.dart';
@@ -38,12 +40,47 @@ import '../repo/secure_token_repository.dart';
 import 'firebase_utils.dart';
 import 'globals.dart';
 import 'helpers/json_canonicalizer.dart';
+import 'lock_auth.dart';
 import 'logger.dart';
 import 'privacyidea_io_client.dart';
+import 'riverpod/riverpod_providers/generated_providers/localization_notifier.dart';
 import 'riverpod/riverpod_providers/generated_providers/settings_notifier.dart';
 import 'riverpod/riverpod_providers/generated_providers/token_notifier.dart';
 import 'rsa_utils.dart';
+import 'biometric_push_key_manager.dart';
 import 'utils.dart';
+
+@visibleForTesting
+Future<void> runPushPollingRequests<T>(
+  Iterable<T> targets, {
+  required bool sequential,
+  required Future<void> Function(T target) request,
+}) async {
+  if (sequential) {
+    for (final target in targets) {
+      await request(target);
+    }
+    return;
+  }
+  await Future.wait(targets.map(request));
+}
+
+/// Authorizes access to a weak-biometric Push private key kept in Dart.
+///
+/// Automatic polling must never use such a key because it cannot safely open
+/// an interactive biometric prompt. Manual polling must authenticate for each
+/// use. Native protected keys are authorized by their crypto-bound prompt and
+/// therefore bypass this compatibility gate.
+@visibleForTesting
+Future<bool> authorizePushDartKeyUseForPolling(
+  PushToken token, {
+  required bool isManually,
+  required Future<bool> Function() authenticate,
+}) async {
+  if (!token.requiresBiometricPromptBeforeDartKeyUse) return true;
+  if (!isManually) return false;
+  return authenticate();
+}
 
 /// This class bundles all logic that is needed to handle incomig PushRequests, e.g.,
 /// firebase, polling, notifications.
@@ -56,6 +93,7 @@ class PushProvider {
 
   bool pollingIsEnabled = false;
   Timer? _pollTimer;
+  bool _pollInProgress = false;
   final List<Function(PushRequest)> _subscribers = [];
 
   FirebaseUtils _firebaseUtils;
@@ -339,6 +377,19 @@ class PushProvider {
   }
 
   Future<void> pollForChallenges({required bool isManually}) async {
+    if (_pollInProgress) {
+      Logger.info('Skipping overlapping Push polling request.');
+      return;
+    }
+    _pollInProgress = true;
+    try {
+      await _pollForChallenges(isManually: isManually);
+    } finally {
+      _pollInProgress = false;
+    }
+  }
+
+  Future<void> _pollForChallenges({required bool isManually}) async {
     // Get all push tokens
     final rolledOutPushTokens =
         await globalRef?.read(
@@ -357,6 +408,25 @@ class PushProvider {
       return;
     }
 
+    // An auth-per-use key would otherwise open a biometric prompt every three
+    // seconds. Such tokens can still be polled explicitly; FCM delivery remains
+    // available without using the private key.
+    final tokensToPoll = isManually
+        ? rolledOutPushTokens
+        : rolledOutPushTokens
+              .where(
+                (token) =>
+                    token.forceBiometricOption !=
+                    ForceBiometricOption.biometric,
+              )
+              .toList();
+    if (tokensToPoll.isEmpty) {
+      Logger.info(
+        'Automatic polling skipped because all Push keys require per-use biometrics.',
+      );
+      return;
+    }
+
     final connectivityResult = await (Connectivity().checkConnectivity());
     if (connectivityResult.contains(ConnectivityResult.none)) {
       if (isManually) {
@@ -370,13 +440,16 @@ class PushProvider {
     }
 
     // Start request for each token
-    Logger.info('Polling for challenges: ${rolledOutPushTokens.length} Tokens');
-    final List<Future<void>> futures = [];
-    for (PushToken p in rolledOutPushTokens) {
-      futures.add(pollForChallenge(p, isManually: isManually));
-    }
-    await Future.wait(futures);
-    return;
+    Logger.info('Polling for challenges: ${tokensToPoll.length} Tokens');
+    // Manual polling can include several auth-per-use keys. Run those requests
+    // one after another so Android/iOS never receive competing biometric
+    // prompts. Automatic polling contains only non-protected keys and can stay
+    // parallel.
+    await runPushPollingRequests(
+      tokensToPoll,
+      sequential: isManually,
+      request: (token) => pollForChallenge(token, isManually: isManually),
+    );
   }
 
   Future<void> pollForChallenge(
@@ -389,108 +462,175 @@ class PushProvider {
       );
       return;
     }
-    String timestamp = DateTime.now().toUtc().toIso8601String();
-
-    String message = '${token.serial}|$timestamp';
-
-    RsaUtils rsaUtils = instance!._rsaUtils;
-    Logger.info(rsaUtils.runtimeType.toString());
-    String? signature = await rsaUtils.trySignWithToken(token, message);
-    if (signature == null) {
-      showErrorStatusMessage(
-        message: (localization) => localization.pollingFailedFor(token.serial),
-        details: (localization) => localization.couldNotSignMessage,
-      );
-      Logger.warning(
-        'Polling push tokens failed because signing the message failed.',
-      );
+    final ref = globalRef;
+    if (ref == null) {
+      Logger.warning('Polling requires the current token state.');
       return;
     }
-    Map<String, String> parameters = {
-      'serial': token.serial,
-      'timestamp': timestamp,
-      'signature': signature,
-      // Keeps the set the server stored at enrollment current after an app
-      // update. Not part of the signed message, because a server that does not
-      // know it rebuilds '{serial}|{timestamp}' and would reject the request.
-      'capabilities': canonicalizeJson(appPushCapabilities.names),
-    };
-
-    final Response response;
-
-    try {
-      response = instance != null
-          ? await instance!._ioClient.doGet(
-              url: token.url!,
-              parameters: parameters,
-              sslVerify: token.sslVerify,
-            )
-          : await const PrivacyideaIOClient().doGet(
-              url: token.url!,
-              parameters: parameters,
-              sslVerify: token.sslVerify,
-            );
-    } catch (_) {
-      if (isManually) {
-        showErrorStatusMessage(
-          message: (localization) =>
-              localization.errorWhenPullingChallenges(token.serial),
-          details: (localization) => localization.couldNotConnectToServer,
-        );
-      }
-      return;
-    }
-    final List<Map<String, dynamic>> challengeList;
-
-    switch (response.statusCode) {
-      case 200:
-        try {
-          challengeList = _getAndValidateDataFromResponse(response);
-        } catch (_) {
-          if (isManually) {
-            showErrorStatusMessage(
-              message: (localization) =>
-                  localization.errorWhenPullingChallenges(token.serial),
-              details: (localization) => localization.pushRequestParseError,
-            );
+    final challengeList = await ref
+        .read(tokenProvider.notifier)
+        .withCurrentPushTokenLease<List<Map<String, dynamic>>>(token.id, (
+          leasedToken,
+          persist,
+          current,
+        ) async {
+          if (leasedToken.isBiometricKeyInvalidated ||
+              leasedToken.url == null) {
+            if (leasedToken.isBiometricKeyInvalidated) {
+              showErrorStatusMessage(
+                message: (localization) =>
+                    localization.biometricPushTokenInvalidTitle,
+                details: (localization) =>
+                    localization.biometricPushTokenInvalidBody,
+              );
+            }
+            return null;
           }
-          return;
-        }
-        // Everything is fine, we can just continue
-        break;
 
-      case 403:
-        final error = getErrorMessageFromResponse(response);
-        if (isManually) {
-          showErrorStatusMessage(
-            message: (localization) =>
-                localization.pollingFailedFor(token.serial),
-            details: error != null
-                ? (_) => error
-                : (localization) =>
-                      localization.statusCode(response.statusCode),
+          // Weak-biometric compatibility mode cannot bind a cryptographic key
+          // on Android. Automatic callers fail closed; an explicit manual poll
+          // receives one biometric-only prompt before each Dart-key signature.
+          final authorized = await authorizePushDartKeyUseForPolling(
+            leasedToken,
+            isManually: isManually,
+            authenticate: () => lockAuthWithSettings(
+              ref: ref,
+              localization: ref.read(localizationProvider),
+              reason: (l) => l.biometricPushKeyAuthReason,
+              forceBiometricOption: ForceBiometricOption.biometric,
+            ),
           );
-        }
-        Logger.warning(
-          'Polling push token failed with status code ${response.statusCode}',
-          error: getErrorMessageFromResponse(response),
-        );
-        return;
+          if (!authorized) return null;
 
-      default:
-        final error = getErrorMessageFromResponse(response);
-        if (isManually) {
-          showErrorStatusMessage(
-            message: (localization) =>
-                localization.pollingFailedFor(token.serial),
-            details: error != null
-                ? (_) => error
-                : (localization) =>
-                      localization.statusCode(response.statusCode),
-          );
-        }
-        return;
-    }
+          final timestamp = DateTime.now().toUtc().toIso8601String();
+          final message = '${leasedToken.serial}|$timestamp';
+          final rsaUtils = instance!._rsaUtils;
+          String? signature;
+          try {
+            signature = await rsaUtils.trySignWithToken(
+              leasedToken,
+              message,
+              onTokenChanged: (updatedToken) async {
+                final persisted = await persist(
+                  current().copyWith(
+                    privateTokenKey: () => updatedToken.privateTokenKey,
+                    biometricKeyStatus: updatedToken.biometricKeyStatus,
+                  ),
+                );
+                return persisted != null &&
+                    persisted.privateTokenKey == updatedToken.privateTokenKey &&
+                    persisted.biometricKeyStatus ==
+                        updatedToken.biometricKeyStatus;
+              },
+            );
+          } on BiometricPushKeyException catch (error) {
+            if (error.isInvalidated) {
+              showErrorStatusMessage(
+                message: (localization) =>
+                    localization.biometricPushTokenInvalidTitle,
+                details: (localization) =>
+                    localization.biometricPushTokenInvalidBody,
+              );
+            } else if (error.isStateNotPersisted) {
+              showErrorStatusMessage(
+                message: (localization) =>
+                    localization.biometricPushKeyPersistenceFailedTitle,
+                details: (localization) =>
+                    localization.biometricPushKeyPersistenceFailed,
+              );
+            } else if (isManually) {
+              showErrorStatusMessage(
+                message: (localization) =>
+                    localization.pollingFailedFor(leasedToken.serial),
+                details: (localization) => localization.couldNotSignMessage,
+              );
+            }
+            return null;
+          }
+          if (signature == null || current().isBiometricKeyInvalidated) {
+            if (isManually) {
+              showErrorStatusMessage(
+                message: (localization) =>
+                    localization.pollingFailedFor(leasedToken.serial),
+                details: (localization) => localization.couldNotSignMessage,
+              );
+            }
+            return null;
+          }
+
+          final Response response;
+          try {
+            response = await instance!._ioClient.doGet(
+              url: current().url!,
+              parameters: {
+                'serial': current().serial,
+                'timestamp': timestamp,
+                'signature': signature,
+                // Not part of the signed message. Older servers ignore it,
+                // while capable servers update the token's feature set.
+                'capabilities': canonicalizeJson(appPushCapabilities.names),
+              },
+              sslVerify: current().sslVerify,
+            );
+          } catch (_) {
+            if (isManually) {
+              showErrorStatusMessage(
+                message: (localization) =>
+                    localization.errorWhenPullingChallenges(current().serial),
+                details: (localization) => localization.couldNotConnectToServer,
+              );
+            }
+            return null;
+          }
+
+          switch (response.statusCode) {
+            case 200:
+              try {
+                return _getAndValidateDataFromResponse(response);
+              } catch (_) {
+                if (isManually) {
+                  showErrorStatusMessage(
+                    message: (localization) => localization
+                        .errorWhenPullingChallenges(current().serial),
+                    details: (localization) =>
+                        localization.pushRequestParseError,
+                  );
+                }
+                return null;
+              }
+            case 403:
+              final error = getErrorMessageFromResponse(response);
+              if (isManually) {
+                showErrorStatusMessage(
+                  message: (localization) =>
+                      localization.pollingFailedFor(current().serial),
+                  details: error != null
+                      ? (_) => error
+                      : (localization) =>
+                            localization.statusCode(response.statusCode),
+                );
+              }
+              Logger.warning(
+                'Polling push token failed with status code ${response.statusCode}',
+                error: error,
+              );
+              return null;
+            default:
+              final error = getErrorMessageFromResponse(response);
+              if (isManually) {
+                showErrorStatusMessage(
+                  message: (localization) =>
+                      localization.pollingFailedFor(current().serial),
+                  details: error != null
+                      ? (_) => error
+                      : (localization) =>
+                            localization.statusCode(response.statusCode),
+                );
+              }
+              return null;
+          }
+        });
+    if (challengeList == null) return;
     Logger.info(
       'Received ${challengeList.length} challenge(s) for ${token.label}',
     );
@@ -531,6 +671,8 @@ class PlaceholderPushProvider implements PushProvider {
   @override
   Timer? _pollTimer;
   @override
+  bool _pollInProgress = false;
+  @override
   bool pollingIsEnabled = false;
   @override
   Future<void> _foregroundHandler(RemoteMessage remoteMessage) async {}
@@ -553,6 +695,8 @@ class PlaceholderPushProvider implements PushProvider {
   }) async {}
   @override
   Future<void> pollForChallenges({required bool isManually}) async {}
+  @override
+  Future<void> _pollForChallenges({required bool isManually}) async {}
   @override
   void setPollingEnabled(bool? enablePolling) {}
   @override

--- a/lib/utils/riverpod/riverpod_providers/generated_providers/push_request_provider.dart
+++ b/lib/utils/riverpod/riverpod_providers/generated_providers/push_request_provider.dart
@@ -34,10 +34,15 @@ import '../../../../model/pi_server_response.dart';
 import '../../../../model/riverpod_states/push_request_state.dart';
 import '../../../../model/tokens/push_token.dart';
 import '../../../../repo/secure_push_request_repository.dart';
+import '../../../http_status_checker.dart';
+import '../../../lock_auth.dart';
 import '../../../logger.dart';
+import '../../../biometric_push_key_manager.dart';
 import '../../../privacyidea_io_client.dart';
 import '../../../push_provider.dart';
+import 'localization_notifier.dart';
 import '../state_providers/status_message_provider.dart';
+import 'token_notifier.dart';
 
 part 'push_request_provider.g.dart';
 
@@ -219,11 +224,12 @@ class PushRequestNotifier extends _$PushRequestNotifier {
 
   /// Accepts a push request and returns true if successful, false if not.
   /// An accepted push request is removed from the state.
-  Future<PiSuccessResponse<T, D>?> accept<
-    T extends PiServerResultValue,
-    D extends PiServerResultDetail
-  >(PushToken token, PushRequest request, {String? selectedAnswer}) async {
-    return _handleReaction<T, D>(
+  Future<PiSuccessResponse<PushResultValue, PushResultDetail>?> accept(
+    PushToken token,
+    PushRequest request, {
+    String? selectedAnswer,
+  }) async {
+    return _handleReaction(
       pushRequest: request,
       token: token,
       updater: (p0) async => p0.dynamicCopyWith(
@@ -233,11 +239,11 @@ class PushRequestNotifier extends _$PushRequestNotifier {
     );
   }
 
-  Future<PiSuccessResponse<T, D>?> decline<
-    T extends PiServerResultValue,
-    D extends PiServerResultDetail
-  >(PushToken token, PushRequest request) async {
-    return _handleReaction<T, D>(
+  Future<PiSuccessResponse<PushResultValue, PushResultDetail>?> decline(
+    PushToken token,
+    PushRequest request,
+  ) async {
+    return _handleReaction(
       pushRequest: request,
       token: token,
       updater: (p0) async => p0.dynamicCopyWith(
@@ -247,11 +253,11 @@ class PushRequestNotifier extends _$PushRequestNotifier {
     );
   }
 
-  Future<PiSuccessResponse<T, D>?> cancel<
-    T extends PiServerResultValue,
-    D extends PiServerResultDetail
-  >(PushToken token, PushRequest request) async {
-    return _handleReaction<T, D>(
+  Future<PiSuccessResponse<PushResultValue, PushResultDetail>?> cancel(
+    PushToken token,
+    PushRequest request,
+  ) async {
+    return _handleReaction(
       pushRequest: request,
       token: token,
       updater: (p0) async => p0.dynamicCopyWith(
@@ -357,10 +363,8 @@ class PushRequestNotifier extends _$PushRequestNotifier {
   /// The reaction is handled by sending a POST request to the push request's URI with the appropriate data and signature.
   /// If the request fails, it will be retried once. If it fails again, an error message will be shown.
   /// If the response has an error status code, an error message will be shown.
-  Future<PiSuccessResponse<T, D>?> _handleReaction<
-    T extends PiServerResultValue,
-    D extends PiServerResultDetail
-  >({
+  Future<PiSuccessResponse<PushResultValue, PushResultDetail>?>
+  _handleReaction({
     required PushRequest pushRequest,
     required PushToken token,
     required Future<PushRequest> Function(PushRequest) updater,
@@ -376,89 +380,221 @@ class PushRequestNotifier extends _$PushRequestNotifier {
       if (updated == null || updated.accepted == null) {
         return null;
       }
+      final response = await ref
+          .read(tokenProvider.notifier)
+          .withCurrentPushTokenLease<
+            PiSuccessResponse<PushResultValue, PushResultDetail>
+          >(token.id, (leasedToken, persist, current) async {
+            if (leasedToken.serial != pushRequest.serial ||
+                leasedToken.isBiometricKeyInvalidated) {
+              if (leasedToken.isBiometricKeyInvalidated) {
+                ref
+                    .read(statusProvider.notifier)
+                    .show(
+                      (l) => l.biometricPushTokenInvalidTitle,
+                      details: (l) => l.biometricPushTokenInvalidBody,
+                    );
+              }
+              return null;
+            }
 
-      final Map<String, String> body = updated.getResponseData(token).map(
-        (key, value) => MapEntry(key, value.toString()),
-      );
+            // The dialog may have authenticated a weaker, older snapshot.
+            // If its authorization policy or key identity changed, let the
+            // rebuilt dialog start a fresh operation with the current token.
+            if (!_samePushAuthorizationState(token, leasedToken)) {
+              Logger.warning(
+                'Push authorization state changed while the dialog was open.',
+              );
+              return null;
+            }
 
-      String msg = updated.getResponseSignMsg(token);
-      String? signature = await _rsaUtils.trySignWithToken(token, msg);
-      if (signature == null) {
-        await _addOrReplacePushRequest(oldRequest);
-        return null;
-      }
-      body['signature'] = signature;
+            // Weak-biometric compatibility keeps the private key in Dart, so
+            // the signing operation itself must own the biometric-only gate.
+            // Keeping this in the notifier also covers callers other than the
+            // standard dialog and prevents a UI-to-signing race.
+            if (leasedToken.requiresBiometricPromptBeforeDartKeyUse) {
+              final authenticated = await lockAuthWithSettingsRef(
+                ref: ref,
+                localization: ref.read(localizationProvider),
+                reason: (l) => l.biometricPushKeyAuthReason,
+                forceBiometricOption: leasedToken.forceBiometricOption,
+              );
+              if (!authenticated) return null;
+            }
 
-      Response response = await _ioClient.doPost(
-        sslVerify: updated.sslVerify,
-        url: updated.uri,
-        body: body,
-      );
-      if (response.isConnectionFailure) {
-        try {
-          response = await _ioClient.doPost(
-            sslVerify: updated.sslVerify,
-            url: updated.uri,
-            body: body,
-          );
-        } on ArgumentError {
-          rethrow;
-        } catch (e) {
-          Logger.warning('Push reaction request failed after retry', error: e);
-          await _addOrReplacePushRequest(oldRequest);
-          ref.read(statusProvider.notifier).show((l) => l.connectionFailed);
-          return null;
-        }
-        if (response.isConnectionFailure) {
-          Logger.warning(
-            'Push reaction request failed after retry',
-            error: response.body,
-          );
-          await _addOrReplacePushRequest(oldRequest);
-          ref.read(statusProvider.notifier).show((l) => l.connectionFailed);
-          return null;
-        }
-      }
-      Logger.debug('Response Body: ${response.body}');
-      PiServerResponse<T, D> piResponse;
-      try {
-        piResponse = response.asPiServerResponse<T, D>();
-      } catch (e) {
-        Logger.warning('Failed to parse push reaction response', error: e);
-        ref
-            .read(statusProvider.notifier)
-            .show(
-              (l) =>
-                  '${l.sendPushRequestResponseFailed}\n${l.statusCode(response.statusCode)}',
-              details: (_) => 'Failed to parse response: $e',
+            final body = updated
+                .getResponseData(leasedToken)
+                .map((key, value) => MapEntry(key, value.toString()));
+            final msg = updated.getResponseSignMsg(leasedToken);
+            String? signature;
+            try {
+              signature = await _rsaUtils.trySignWithToken(
+                leasedToken,
+                msg,
+                onTokenChanged: (updatedToken) async {
+                  final persisted = await persist(
+                    current().copyWith(
+                      privateTokenKey: () => updatedToken.privateTokenKey,
+                      biometricKeyStatus: updatedToken.biometricKeyStatus,
+                    ),
+                  );
+                  return persisted != null &&
+                      persisted.privateTokenKey ==
+                          updatedToken.privateTokenKey &&
+                      persisted.biometricKeyStatus ==
+                          updatedToken.biometricKeyStatus;
+                },
+              );
+            } on BiometricPushKeyException catch (error) {
+              if (error.isInvalidated) {
+                ref
+                    .read(statusProvider.notifier)
+                    .show(
+                      (l) => l.biometricPushTokenInvalidTitle,
+                      details: (l) => l.biometricPushTokenInvalidBody,
+                    );
+              } else if (error.isStateNotPersisted) {
+                ref
+                    .read(statusProvider.notifier)
+                    .show(
+                      (l) => l.biometricPushKeyPersistenceFailedTitle,
+                      details: (l) => l.biometricPushKeyPersistenceFailed,
+                    );
+              }
+              return null;
+            }
+            if (signature == null || current().isBiometricKeyInvalidated) {
+              return null;
+            }
+            body['signature'] = signature;
+
+            Response response = await _ioClient.doPost(
+              sslVerify: updated.sslVerify,
+              url: updated.uri,
+              body: body,
             );
-        await _addOrReplacePushRequest(oldRequest);
-        return null;
-      }
-      if (piResponse.isError) {
-        await _addOrReplacePushRequest(oldRequest);
-        final errorResponse = piResponse.asError!;
-        Logger.warning(
-          'Push reaction rejected by server',
-          error:
-              '${errorResponse.piServerResultError.code}: ${errorResponse.piServerResultError.message}',
-        );
-        ref
-            .read(statusProvider.notifier)
-            .show(
-              (l) =>
-                  '${l.sendPushRequestResponseFailed}\n${l.statusCode(errorResponse.statusCode)}',
-              details: (_) =>
-                  errorResponse.piServerResultError.code ==
-                      InAppErrorCodes.jsonParseError
-                  ? errorResponse.piServerResultError.message
-                  : '${errorResponse.piServerResultError.code}: ${errorResponse.piServerResultError.message}',
+            if (response.isConnectionFailure) {
+              try {
+                response = await _ioClient.doPost(
+                  sslVerify: updated.sslVerify,
+                  url: updated.uri,
+                  body: body,
+                );
+              } on ArgumentError {
+                rethrow;
+              } catch (e) {
+                Logger.warning(
+                  'Push reaction request failed after retry',
+                  error: e,
+                );
+                ref
+                    .read(statusProvider.notifier)
+                    .show((l) => l.connectionFailed);
+                return null;
+              }
+              if (response.isConnectionFailure) {
+                Logger.warning(
+                  'Push reaction request failed after retry',
+                  error: response.body,
+                );
+                ref
+                    .read(statusProvider.notifier)
+                    .show((l) => l.connectionFailed);
+                return null;
+              }
+            }
+            Logger.debug('Response Body: ${response.body}');
+            PiServerResponse<PushResultValue, PushResultDetail> piResponse;
+            try {
+              piResponse = response
+                  .asPiServerResponse<PushResultValue, PushResultDetail>();
+            } catch (e) {
+              Logger.warning(
+                'Failed to parse push reaction response',
+                error: e,
+              );
+              ref
+                  .read(statusProvider.notifier)
+                  .show(
+                    (l) =>
+                        '${l.sendPushRequestResponseFailed}\n${l.statusCode(response.statusCode)}',
+                    details: (_) => 'Failed to parse response: $e',
+                  );
+              return null;
+            }
+            if (piResponse.isError) {
+              final errorResponse = piResponse.asError!;
+              Logger.warning(
+                'Push reaction rejected by server',
+                error:
+                    '${errorResponse.piServerResultError.code}: ${errorResponse.piServerResultError.message}',
+              );
+              ref
+                  .read(statusProvider.notifier)
+                  .show(
+                    (l) =>
+                        '${l.sendPushRequestResponseFailed}\n${l.statusCode(errorResponse.statusCode)}',
+                    details: (_) =>
+                        errorResponse.piServerResultError.code ==
+                            InAppErrorCodes.jsonParseError
+                        ? errorResponse.piServerResultError.message
+                        : '${errorResponse.piServerResultError.code}: ${errorResponse.piServerResultError.message}',
+                  );
+              return null;
+            }
+            final successResponse = piResponse.asSuccess;
+            final result = successResponse?.result;
+            final resultValue = result?.value;
+            final httpAccepted = HttpStatusChecker.isSuccessful(
+              response.statusCode,
             );
+            final serverAccepted =
+                successResponse != null &&
+                result?.status == true &&
+                result?.hasError == false &&
+                resultValue is PushResultValue &&
+                resultValue.value;
+            if (!httpAccepted || !serverAccepted) {
+              final resultError = result?.error;
+              Logger.warning(
+                'Push reaction was not accepted by the server',
+                error:
+                    'HTTP ${response.statusCode}, '
+                    'result.status=${result?.status}, '
+                    'result.value=${resultValue is PushResultValue ? resultValue.value : null}, '
+                    'result.error=${resultError?.code}',
+              );
+              if (resultError != null) {
+                ref
+                    .read(statusProvider.notifier)
+                    .show(
+                      (l) => l.pushRequestResponseRejected,
+                      details: (_) =>
+                          '${resultError.code}: ${resultError.message}',
+                    );
+              } else if (!httpAccepted) {
+                ref
+                    .read(statusProvider.notifier)
+                    .show(
+                      (l) => l.pushRequestResponseRejected,
+                      details: (l) => l.statusCode(response.statusCode),
+                    );
+              } else {
+                ref
+                    .read(statusProvider.notifier)
+                    .show((l) => l.pushRequestResponseRejected);
+              }
+              return null;
+            }
+            return successResponse;
+          });
+
+      if (response == null) {
+        await _addOrReplacePushRequest(oldRequest);
         return null;
       }
-
       await _remove(updated);
-      return piResponse.asSuccess;
+      return response;
     } on ArgumentError catch (e, s) {
       Logger.error(
         'Push reaction failed due to invalid request data',
@@ -486,4 +622,15 @@ class PushRequestNotifier extends _$PushRequestNotifier {
       _reactionMutex.release();
     }
   }
+
+  bool _samePushAuthorizationState(PushToken expected, PushToken current) =>
+      expected.id == current.id &&
+      expected.serial == current.serial &&
+      expected.publicTokenKey == current.publicTokenKey &&
+      expected.privateTokenKey == current.privateTokenKey &&
+      expected.biometricKeyStatus == current.biometricKeyStatus &&
+      expected.forceBiometricOption == current.forceBiometricOption &&
+      expected.biometricLevel == current.biometricLevel &&
+      expected.invalidateOnBiometricChange ==
+          current.invalidateOnBiometricChange;
 }

--- a/lib/utils/riverpod/riverpod_providers/generated_providers/push_request_provider.g.dart
+++ b/lib/utils/riverpod/riverpod_providers/generated_providers/push_request_provider.g.dart
@@ -57,7 +57,7 @@ final class PushRequestNotifierProvider
 }
 
 String _$pushRequestNotifierHash() =>
-    r'869cfaf505b251b85b56af5ea89e7e57a05a774a';
+    r'480a2a2c94082be24fb498977776808faf137519';
 
 final class PushRequestNotifierFamily extends $Family
     with

--- a/lib/utils/riverpod/riverpod_providers/generated_providers/sortable_notifier.dart
+++ b/lib/utils/riverpod/riverpod_providers/generated_providers/sortable_notifier.dart
@@ -43,7 +43,7 @@ void _handleSortIndexUpdates(
   if (hasTokens) {
     ref
         .read(tokenProvider.notifier)
-        .addOrReplaceTokens(sorted.whereType<Token>().toList());
+        .updateTokenPlacements(sorted.whereType<Token>().toList());
   }
 
   if (hasFolders) {

--- a/lib/utils/riverpod/riverpod_providers/generated_providers/token_container_notifier.dart
+++ b/lib/utils/riverpod/riverpod_providers/generated_providers/token_container_notifier.dart
@@ -70,6 +70,17 @@ class TokenContainerNotifier extends _$TokenContainerNotifier
     with ResultHandler {
   final _stateMutex = Mutex();
   final _repoMutex = Mutex();
+  // A sync call owns its request and commit as one ordered operation. This
+  // prevents an older response from being applied after a newer invocation.
+  final _syncMutex = Mutex();
+  // Serializes the local commit phase of a container sync with local container
+  // deletion. Network requests intentionally run outside this lock.
+  final _containerLifecycleMutex = Mutex();
+  final Set<String> _containersPendingDeletion = {};
+  // A temporal pending flag is not enough: a delete attempt can finish before
+  // an older sync response arrives. Keep a monotonic in-process generation so
+  // that every response is committed only to the lifecycle it was sent for.
+  final Map<String, int> _containerLifecycleRevision = {};
 
   TokenContainerNotifier({
     this._repoOverride,
@@ -170,10 +181,28 @@ class TokenContainerNotifier extends _$TokenContainerNotifier
     required bool isManually,
     List<TokenContainerFinalized>? containersToSync,
     bool? isInitSync,
+  }) => _syncMutex.protect(
+    () => _syncContainers(
+      tokenState: tokenState,
+      isManually: isManually,
+      containersToSync: containersToSync,
+      isInitSync: isInitSync,
+    ),
+  );
+
+  Future<Map<int, TokenContainerFinalized>> _syncContainers({
+    required TokenState tokenState,
+    required bool isManually,
+    List<TokenContainerFinalized>? containersToSync,
+    bool? isInitSync,
   }) async {
+    // A queued invocation may carry a snapshot from before the preceding sync
+    // committed. Always send the latest local token state.
+    tokenState = await ref.read(tokenProvider.future);
+    List<TokenContainerFinalized> resolvedContainers;
     if (containersToSync == null) {
       final containerList = (await future).containerList;
-      containersToSync = containerList
+      resolvedContainers = containerList
           .whereType<TokenContainerFinalized>()
           .where((e) => e.syncState != SyncState.syncing)
           .toList();
@@ -184,30 +213,40 @@ class TokenContainerNotifier extends _$TokenContainerNotifier
         if (c == null) continue;
         current.add(c);
       }
-      containersToSync = current
+      resolvedContainers = current
           .whereType<TokenContainerFinalized>()
           .where((e) => e.syncState != SyncState.syncing)
           .toList();
     }
-    if (containersToSync.isEmpty) {
+    late final Map<String, int> lifecycleRevisionAtRequest;
+    var requestContainers = await _containerLifecycleMutex.protect(() async {
+      final selected = resolvedContainers
+          .where(
+            (container) =>
+                !_containersPendingDeletion.contains(container.serial),
+          )
+          .toList();
+      lifecycleRevisionAtRequest = {
+        for (final container in selected)
+          container.serial: _containerLifecycleRevision[container.serial] ?? 0,
+      };
+      return selected;
+    });
+    if (requestContainers.isEmpty) {
       return {};
     }
-    Logger.info('Syncing ${containersToSync.length} tokens');
+    Logger.info('Syncing ${requestContainers.length} tokens');
     final syncFutures = <Future<ContainerSyncUpdates?>>[];
 
-    List<Token> newTokens = [];
-    List<Token> syncedTokens = [];
-    List<Token> deletedTokensNoOffline = [];
-
     Logger.debug('Change to sync state to syncing');
-    containersToSync = await updateContainerList(
-      containersToSync,
+    requestContainers = await updateContainerList(
+      requestContainers,
       (c) => c.copyWith(syncState: SyncState.syncing),
     );
 
     final failedContainers = <int, TokenContainerFinalized>{};
 
-    for (var finalizedContainer in containersToSync) {
+    for (var finalizedContainer in requestContainers) {
       syncFutures.add(
         _syncContainer(
           finalizedContainer,
@@ -234,27 +273,15 @@ class TokenContainerNotifier extends _$TokenContainerNotifier
       );
     }
 
-    Map<String, ContainerPolicies> newPoliciesMap = {};
+    final newPoliciesMap = <String, ContainerPolicies>{};
+    final syncUpdatesBySerial = <String, ContainerSyncUpdates>{};
 
     await Future.wait(syncFutures)
         .then((syncUpdates) {
           for (var syncUpdate in syncUpdates) {
             if (syncUpdate == null) continue;
-            newTokens.addAll(syncUpdate.newTokens);
-            syncedTokens.addAll(syncUpdate.updatedTokens);
-            deletedTokensNoOffline.addAll(syncUpdate.deletedTokens.noOffline);
-            ref
-                .read(tokenProvider.notifier)
-                .updateTokens(
-                  syncUpdate.initAssignmentChecked,
-                  (t) => t.copyWith(
-                    checkedContainer: [
-                      ...t.checkedContainer,
-                      syncUpdate.containerSerial,
-                    ],
-                  ),
-                );
             newPoliciesMap[syncUpdate.containerSerial] = syncUpdate.newPolicies;
+            syncUpdatesBySerial[syncUpdate.containerSerial] = syncUpdate;
           }
         })
         .onError((error, stackTrace) {
@@ -265,25 +292,134 @@ class TokenContainerNotifier extends _$TokenContainerNotifier
           );
         });
 
-    // Do not remove tokens that are synced in any other container
-    deletedTokensNoOffline.removeWhere(
-      (deletedToken) => syncedTokens.any(
-        (syncedToken) => deletedToken.serial == syncedToken.serial,
-      ),
-    );
+    return _containerLifecycleMutex.protect(() async {
+      // A container can be deleted while its network request is in flight.
+      // Re-resolve it at the local commit boundary and completely ignore a
+      // response whose owner no longer exists. The same lifecycle lock is held
+      // by deletion through token removal and container-state removal.
+      var currentContainerState = await future;
+      bool responseOwnerBecameStale(TokenContainerFinalized container) =>
+          _containersPendingDeletion.contains(container.serial) ||
+          lifecycleRevisionAtRequest[container.serial] !=
+              (_containerLifecycleRevision[container.serial] ?? 0);
+      final staleResponseOwners = requestContainers
+          .where(
+            (container) =>
+                syncUpdatesBySerial.containsKey(container.serial) &&
+                responseOwnerBecameStale(container) &&
+                currentContainerState.containerOf(container.serial)
+                    is TokenContainerFinalized,
+          )
+          .map(
+            (container) =>
+                currentContainerState.containerOf(container.serial)!
+                    as TokenContainerFinalized,
+          )
+          .toList();
+      if (staleResponseOwners.isNotEmpty) {
+        // The response cannot be committed after a delete lifecycle started.
+        // Keep a surviving container retryable; a successful deletion removes
+        // this temporary state immediately afterwards.
+        await updateContainerList(
+          staleResponseOwners,
+          (container) => container.copyWith(syncState: SyncState.failed),
+        );
+        currentContainerState = await future;
+      }
+      final successfullySyncedContainers = requestContainers
+          .where(
+            (container) =>
+                syncUpdatesBySerial.containsKey(container.serial) &&
+                !responseOwnerBecameStale(container) &&
+                currentContainerState.containerOf(container.serial)
+                    is TokenContainerFinalized,
+          )
+          .map(
+            (container) =>
+                currentContainerState.containerOf(container.serial)!
+                    as TokenContainerFinalized,
+          )
+          .toList();
+      if (successfullySyncedContainers.isEmpty) return failedContainers;
 
-    await ref.read(tokenProvider.notifier).removeTokens(deletedTokensNoOffline);
-    await ref.read(tokenProvider.notifier).addOrReplaceTokens([
-      ...syncedTokens,
-      ...newTokens,
-    ]);
-    await updateContainerList(
-      (await future).containerList,
-      (c) => newPoliciesMap[c.serial] == null
-          ? c
-          : c.copyWith(policies: newPoliciesMap[c.serial]!),
-    );
-    return failedContainers;
+      final activeSerials = successfullySyncedContainers
+          .map((container) => container.serial)
+          .toSet();
+      final activeUpdates = syncUpdatesBySerial.values
+          .where((update) => activeSerials.contains(update.containerSerial))
+          .toList();
+      final newTokens = <Token>[];
+      final syncedTokens = <Token>[];
+      final deletedTokensNoOffline = <Token>[];
+      final checkedContainersByTokenId = <String, List<String>>{};
+      for (final syncUpdate in activeUpdates) {
+        newTokens.addAll(syncUpdate.newTokens);
+        syncedTokens.addAll(syncUpdate.updatedTokens);
+        deletedTokensNoOffline.addAll(syncUpdate.deletedTokens.noOffline);
+        for (final token in syncUpdate.initAssignmentChecked) {
+          checkedContainersByTokenId
+              .putIfAbsent(token.id, () => [])
+              .add(syncUpdate.containerSerial);
+        }
+      }
+
+      // Do not remove tokens that are synced in any other active container.
+      deletedTokensNoOffline.removeWhere(
+        (deletedToken) => syncedTokens.any(
+          (syncedToken) => deletedToken.serial == syncedToken.serial,
+        ),
+      );
+
+      var localUpdateSucceeded = true;
+      try {
+        final tokenNotifier = ref.read(tokenProvider.notifier);
+        final failedUpdates = await tokenNotifier.applyContainerSync(
+          updatedTokens: syncedTokens,
+          newTokens: newTokens,
+          deletedTokens: deletedTokensNoOffline,
+          checkedContainersByTokenId: checkedContainersByTokenId,
+        );
+        if (failedUpdates.isNotEmpty) {
+          localUpdateSucceeded = false;
+          Logger.warning(
+            'Container sync could not persist ${failedUpdates.length} token updates.',
+          );
+        }
+      } catch (error, stackTrace) {
+        localUpdateSucceeded = false;
+        Logger.error(
+          'Failed to persist container sync locally.',
+          error: error,
+          stackTrace: stackTrace,
+        );
+      }
+
+      if (!localUpdateSucceeded) {
+        await updateContainerList(
+          successfullySyncedContainers,
+          (container) => container.copyWith(syncState: SyncState.failed),
+        );
+        return failedContainers;
+      }
+
+      final completedContainers = await updateContainerList(
+        successfullySyncedContainers,
+        (container) => container.copyWith(
+          syncState: SyncState.completed,
+          initSynced: true,
+          policies: newPoliciesMap[container.serial]!,
+        ),
+      );
+      for (final container in completedContainers) {
+        final syncUpdate = syncUpdatesBySerial[container.serial]!;
+        ContainerSyncResultDialog.showDialog(
+          container: container,
+          addedTokens: syncUpdate.newTokens,
+          removedTokens: syncUpdate.deletedTokens.noOffline,
+        );
+      }
+      return failedContainers;
+    });
   }
 
   Future<ContainerSyncUpdates?> _syncContainer(
@@ -307,16 +443,6 @@ class TokenContainerNotifier extends _$TokenContainerNotifier
         );
         return null;
       }
-      await updateContainer(
-        finalizedContainer,
-        (TokenContainerFinalized c) =>
-            c.copyWith(syncState: SyncState.completed, initSynced: true),
-      );
-      ContainerSyncResultDialog.showDialog(
-        container: finalizedContainer,
-        addedTokens: syncUpdate.newTokens,
-        removedTokens: syncUpdate.deletedTokens.noOffline,
-      );
       return syncUpdate;
     } catch (error, stackTrace) {
       final isMissingOnServer =
@@ -383,49 +509,57 @@ class TokenContainerNotifier extends _$TokenContainerNotifier
   // ADD CONTAINER
 
   Future<TokenContainerState> addContainer(TokenContainer container) async {
-    await _stateMutex.acquire();
-    try {
-      await future;
-      final newState = await _saveContainerToRepo(container);
-      await update((_) => newState);
-      return newState;
-    } finally {
-      _stateMutex.release();
-    }
+    return _containerLifecycleMutex.protect(() async {
+      _advanceContainerLifecycle(container.serial);
+      await _stateMutex.acquire();
+      try {
+        await future;
+        final newState = await _saveContainerToRepo(container);
+        await update((_) => newState);
+        return newState;
+      } finally {
+        _stateMutex.release();
+      }
+    });
   }
 
   Future<TokenContainerState> addContainerList(
     List<TokenContainer> container,
   ) async {
-    await _stateMutex.acquire();
-    try {
-      final newContainers = container.toList();
-      final oldContainers = (await future).containerList;
-      Logger.debug('Loaded container: $oldContainers');
-      final combinedContainers = <TokenContainer>[];
-      for (var oldContainer in oldContainers) {
-        final newContainer = newContainers.firstWhereOrNull(
-          (newContainer) => newContainer.serial == oldContainer.serial,
-        );
-        if (newContainer == null) {
-          combinedContainers.add(oldContainer);
-        } else {
-          combinedContainers.add(newContainer);
-          newContainers.remove(newContainer);
-        }
+    return _containerLifecycleMutex.protect(() async {
+      for (final addedContainer in container) {
+        _advanceContainerLifecycle(addedContainer.serial);
       }
-      combinedContainers.addAll(newContainers);
-      Logger.debug('Combined container: $combinedContainers');
-      final newState = await _saveContainersStateToRepo(
-        TokenContainerState(containerList: combinedContainers),
-      );
-      Logger.debug('Saved container: $newState');
-      await update((_) => newState);
-      Logger.debug('Updated container: $newState');
-      return newState;
-    } finally {
-      _stateMutex.release();
-    }
+      await _stateMutex.acquire();
+      try {
+        final newContainers = container.toList();
+        final oldContainers = (await future).containerList;
+        Logger.debug('Loaded container: $oldContainers');
+        final combinedContainers = <TokenContainer>[];
+        for (var oldContainer in oldContainers) {
+          final newContainer = newContainers.firstWhereOrNull(
+            (newContainer) => newContainer.serial == oldContainer.serial,
+          );
+          if (newContainer == null) {
+            combinedContainers.add(oldContainer);
+          } else {
+            combinedContainers.add(newContainer);
+            newContainers.remove(newContainer);
+          }
+        }
+        combinedContainers.addAll(newContainers);
+        Logger.debug('Combined container: $combinedContainers');
+        final newState = await _saveContainersStateToRepo(
+          TokenContainerState(containerList: combinedContainers),
+        );
+        Logger.debug('Saved container: $newState');
+        await update((_) => newState);
+        Logger.debug('Updated container: $newState');
+        return newState;
+      } finally {
+        _stateMutex.release();
+      }
+    });
   }
 
   // UPDATE CONTAINER
@@ -443,25 +577,30 @@ class TokenContainerNotifier extends _$TokenContainerNotifier
     R extends TokenContainer,
     T extends TokenContainer
   >(TokenContainer container, R Function(T) updater) async {
-    await _stateMutex.acquire();
-    try {
-      final oldState = await future;
-      Logger.debug('Updating container ${container.serial} updater: $updater');
-      final currentContainer = oldState.currentOf<T>(container);
-      if (currentContainer == null) {
-        Logger.info(
-          'Failed to update container. It was probably removed in the meantime.',
+    return _containerLifecycleMutex.protect(() async {
+      _advanceContainerLifecycle(container.serial);
+      await _stateMutex.acquire();
+      try {
+        final oldState = await future;
+        Logger.debug(
+          'Updating container ${container.serial} updater: $updater',
         );
-        return null;
+        final currentContainer = oldState.currentOf<T>(container);
+        if (currentContainer == null) {
+          Logger.info(
+            'Failed to update container. It was probably removed in the meantime.',
+          );
+          return null;
+        }
+        Logger.info('Updating container ${currentContainer.serial}');
+        final updated = updater(currentContainer);
+        final newState = await _saveContainerToRepo(updated);
+        await update((_) => newState);
+        return updated;
+      } finally {
+        _stateMutex.release();
       }
-      Logger.info('Updating container ${currentContainer.serial}');
-      final updated = updater(currentContainer);
-      final newState = await _saveContainerToRepo(updated);
-      await update((_) => newState);
-      return updated;
-    } finally {
-      _stateMutex.release();
-    }
+    });
   }
 
   Future<List<T>> updateContainerList<T extends TokenContainer>(
@@ -505,81 +644,130 @@ class TokenContainerNotifier extends _$TokenContainerNotifier
 
   // DELETE CONTAINER
 
-  Future<bool> unregisterDelete(TokenContainerFinalized container) async {
-    try {
-      if (!(await _containerApi.unregister(container)).success) return false;
-    } on PiServerResultError catch (e) {
-      if (e.code == PiServerResultErrorCodes.resourceNotFound ||
-          e.code == PiServerResultErrorCodes.containerNotRegistered) {
-        // Server confirmed the container doesn't exist — proceed with local deletion.
-      } else if (e.code != PiServerResultErrorCodes.containerInvalidChallenge) {
-        showErrorStatusMessage(
-          message: (localization) =>
-              localization.piServerCode(e.code.toString()),
-          details: (localization) => e.message,
-        );
-        return false;
-      }
-    } on ResponseError catch (e) {
-      if (e.statusCode == HttpStatusCodes.webServerReturnedUnknownError &&
-          e.message != "Unknown Error") {
-        showErrorStatusMessage(message: (localization) => e.toString());
-        return false;
-      } else {
-        showErrorStatusMessage(
-          message: (localization) => localization.httpStatusFor(e.statusCode),
-        );
-      }
-      return false;
-    }
+  void _advanceContainerLifecycle(String serial) {
+    _containerLifecycleRevision[serial] =
+        (_containerLifecycleRevision[serial] ?? 0) + 1;
+  }
 
-    await _stateMutex.acquire();
+  Future<bool> _beginContainerDeletion(String serial) =>
+      _containerLifecycleMutex.protect(() async {
+        if (!_containersPendingDeletion.add(serial)) return false;
+        _advanceContainerLifecycle(serial);
+        return true;
+      });
+
+  Future<void> _endContainerDeletion(String serial) =>
+      _containerLifecycleMutex.protect(() async {
+        _containersPendingDeletion.remove(serial);
+      });
+
+  Future<bool> _deleteLocalContainerAndTokens(TokenContainer container) async {
+    return _containerLifecycleMutex.protect(() async {
+      final tokenNotifier = ref.read(tokenProvider.notifier);
+      final containerTokens = (await ref.read(
+        tokenProvider.future,
+      )).containerTokens(container.serial);
+
+      await tokenNotifier.removeTokens(containerTokens);
+
+      final remainingContainerTokens = (await ref.read(
+        tokenProvider.future,
+      )).containerTokens(container.serial);
+      if (remainingContainerTokens.isNotEmpty) {
+        Logger.warning(
+          'Keeping container ${container.serial} because '
+          '${remainingContainerTokens.length} managed tokens could not be removed.',
+        );
+        return false;
+      }
+
+      await _stateMutex.acquire();
+      try {
+        final newState = await _deleteContainerFromRepo(container);
+        await update((_) => newState);
+        return true;
+      } finally {
+        _stateMutex.release();
+      }
+    });
+  }
+
+  Future<bool> unregisterDelete(TokenContainerFinalized container) async {
+    if (!await _beginContainerDeletion(container.serial)) return false;
     try {
-      final newState = await _deleteContainerFromRepo(container);
-      await update((_) => newState);
-      return true;
+      try {
+        if (!(await _containerApi.unregister(container)).success) return false;
+      } on PiServerResultError catch (e) {
+        if (e.code == PiServerResultErrorCodes.resourceNotFound ||
+            e.code == PiServerResultErrorCodes.containerNotRegistered) {
+          // Server confirmed the container doesn't exist — proceed with local deletion.
+        } else if (e.code !=
+            PiServerResultErrorCodes.containerInvalidChallenge) {
+          showErrorStatusMessage(
+            message: (localization) =>
+                localization.piServerCode(e.code.toString()),
+            details: (localization) => e.message,
+          );
+          return false;
+        }
+      } on ResponseError catch (e) {
+        if (e.statusCode == HttpStatusCodes.webServerReturnedUnknownError &&
+            e.message != "Unknown Error") {
+          showErrorStatusMessage(message: (localization) => e.toString());
+          return false;
+        } else {
+          showErrorStatusMessage(
+            message: (localization) => localization.httpStatusFor(e.statusCode),
+          );
+        }
+        return false;
+      }
+      return await _deleteLocalContainerAndTokens(container);
     } finally {
-      _stateMutex.release();
+      await _endContainerDeletion(container.serial);
     }
   }
 
   Future<bool> deleteContainer(TokenContainer container) async {
-    await _stateMutex.acquire();
+    if (!await _beginContainerDeletion(container.serial)) return false;
     try {
-      final newState = await _deleteContainerFromRepo(container);
-      await update((_) => newState);
-      return true;
+      return await _deleteLocalContainerAndTokens(container);
     } finally {
-      _stateMutex.release();
+      await _endContainerDeletion(container.serial);
     }
   }
 
   Future<TokenContainerState> deleteContainerList(
     List<TokenContainer> container,
   ) async {
-    await _stateMutex.acquire();
-    try {
-      final newContainers = container.toList();
-      final oldContainers = (await future).containerList;
-      final combinedContainers = <TokenContainer>[];
-      for (var oldContainer in oldContainers) {
-        final newContainer = newContainers.firstWhereOrNull(
-          (newContainer) => newContainer.serial == oldContainer.serial,
-        );
-        if (newContainer == null) {
-          combinedContainers.add(oldContainer);
-        } else {
-          newContainers.remove(newContainer);
-        }
+    return _containerLifecycleMutex.protect(() async {
+      for (final deletedContainer in container) {
+        _advanceContainerLifecycle(deletedContainer.serial);
       }
-      final newState = await _saveContainersStateToRepo(
-        TokenContainerState(containerList: combinedContainers),
-      );
-      await update((_) => newState);
-      return newState;
-    } finally {
-      _stateMutex.release();
-    }
+      await _stateMutex.acquire();
+      try {
+        final newContainers = container.toList();
+        final oldContainers = (await future).containerList;
+        final combinedContainers = <TokenContainer>[];
+        for (var oldContainer in oldContainers) {
+          final newContainer = newContainers.firstWhereOrNull(
+            (newContainer) => newContainer.serial == oldContainer.serial,
+          );
+          if (newContainer == null) {
+            combinedContainers.add(oldContainer);
+          } else {
+            newContainers.remove(newContainer);
+          }
+        }
+        final newState = await _saveContainersStateToRepo(
+          TokenContainerState(containerList: combinedContainers),
+        );
+        await update((_) => newState);
+        return newState;
+      } finally {
+        _stateMutex.release();
+      }
+    });
   }
 
   /* /////////////////////////////////////////////////////////////////////////

--- a/lib/utils/riverpod/riverpod_providers/generated_providers/token_container_notifier.g.dart
+++ b/lib/utils/riverpod/riverpod_providers/generated_providers/token_container_notifier.g.dart
@@ -58,7 +58,7 @@ final class TokenContainerNotifierProvider
 }
 
 String _$tokenContainerNotifierHash() =>
-    r'd415bdff7782390ce1f99b6a638a4eb1b1056e1d';
+    r'ee336a676c1131b6d78b7598ec16e5ccb3372936';
 
 final class TokenContainerNotifierFamily extends $Family
     with

--- a/lib/utils/riverpod/riverpod_providers/generated_providers/token_notifier.dart
+++ b/lib/utils/riverpod/riverpod_providers/generated_providers/token_notifier.dart
@@ -26,7 +26,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart';
 import 'package:pointycastle/asymmetric/api.dart';
-import 'package:privacyidea_authenticator/model/extensions/token_list_extension.dart';
 import 'package:privacyidea_authenticator/utils/helpers/mutex.dart';
 import 'package:privacyidea_authenticator/utils/riverpod/riverpod_providers/generated_providers/localization_notifier.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -35,6 +34,9 @@ import '../../../../../../model/extensions/enums/push_token_rollout_state_extens
 import '../../../../../../model/extensions/enums/token_origin_source_type.dart';
 import '../../../../interfaces/repo/token_repository.dart';
 import '../../../../l10n/app_localizations.dart';
+import '../../../../model/enums/biometric_push_key_status.dart';
+import '../../../../model/enums/force_biometric_option.dart';
+import '../../../../model/enums/push_app_biometric_level.dart';
 import '../../../../model/enums/push_token_rollout_state.dart';
 import '../../../../model/enums/token_import_type.dart';
 import '../../../../model/enums/token_origin_source_type.dart';
@@ -56,6 +58,7 @@ import '../../../lock_auth.dart';
 import '../../../logger.dart';
 import '../../../privacyidea_io_client.dart';
 import '../../../rsa_utils.dart';
+import '../../../biometric_push_key_manager.dart';
 import '../../../utils.dart';
 import '../state_providers/status_message_provider.dart';
 import 'settings_notifier.dart';
@@ -120,27 +123,96 @@ class TokenNotifier extends _$TokenNotifier with ResultHandler {
   //   */
 
   /// Loads the tokens from the repository and returns them as a [TokenState].
-  Future<TokenState> _loadStateFromRepo() => _repoMutex.protect(() async {
-    final tokens = await repo.loadTokens();
+  Future<TokenState> _loadStateFromRepo() async {
+    final loadedTokens = await _repoMutex.protect(() => repo.loadTokens());
+    final tokens = await _reconcileBiometricPushKeys(loadedTokens);
     return TokenState(tokens: tokens, lastlyUpdatedTokens: tokens);
-  });
+  }
+
+  Token? _currentTokenForWrite(TokenState currentState, Token incoming) =>
+      currentState.currentOfId(incoming.id) ?? currentState.currentOf(incoming);
+
+  Token _prepareTokenForWrite(Token incoming, Token? current) {
+    if (incoming is PushToken && current is PushToken) {
+      return incoming.withMonotonicBiometricStateFrom(current);
+    }
+    if (incoming is PushToken) {
+      return incoming.withFailClosedBiometricLifecycle();
+    }
+    return incoming;
+  }
+
+  Future<void> _deleteNewlyInvalidatedNativeKey(
+    Token? previous,
+    Token written,
+  ) async {
+    if (written is! PushToken || !written.isBiometricKeyInvalidated) return;
+    if (previous is PushToken && previous.isBiometricKeyInvalidated) return;
+    try {
+      await rsaUtils.deleteBiometricPushKey(written.id);
+    } catch (error, stackTrace) {
+      Logger.warning(
+        'Could not remove a newly invalidated native Push key.',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  Future<void> _deleteNativePushKey(Token token) async {
+    if (token is! PushToken) return;
+    try {
+      await rsaUtils.deleteBiometricPushKey(token.id);
+    } catch (error, stackTrace) {
+      Logger.warning(
+        'Could not remove native biometric Push key state.',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  bool _hasSameContainerIdentityIgnoringId(Token first, Token second) {
+    if (first.runtimeType != second.runtimeType) return false;
+    final comparison = second.copyWith(
+      id: '__container_identity__${second.id}',
+    );
+    return first.isSameTokenAs(comparison) == true;
+  }
+
+  bool _tightensPushAuthentication(Token? previous, Token candidate) {
+    if (previous is! PushToken || candidate is! PushToken) return false;
+    if (candidate.forceBiometricOption != ForceBiometricOption.biometric) {
+      return false;
+    }
+    return previous.forceBiometricOption != ForceBiometricOption.biometric ||
+        (previous.biometricLevel != PushAppBiometricLevel.strong &&
+            candidate.biometricLevel == PushAppBiometricLevel.strong) ||
+        (!previous.invalidateOnBiometricChange &&
+            candidate.invalidateOnBiometricChange) ||
+        (!previous.requiresBiometricKeyProtection &&
+            candidate.requiresBiometricKeyProtection);
+  }
 
   /// Adds a token and returns true if successful, false if not.
   /// Updates repo and state.
   Future<bool> _addOrReplaceToken(Token token) {
     return _stateMutex.protect(() async {
+      final currentState = await future;
+      final current = _currentTokenForWrite(currentState, token);
+      if (current != null && current.id != token.id) {
+        token = token.copyWith(id: current.id);
+      }
+      token = _prepareTokenForWrite(token, current);
       final success = await _repoMutex.protect(
         () => repo.saveOrReplaceToken(token),
       );
-      final currentId = (await future).currentOf(token)?.id;
-      if (currentId != null) {
-        token = token.copyWith(id: currentId);
-      }
       if (!success) {
         Logger.warning('Saving token failed. Token: ${token.id}');
         return false;
       }
-      state = AsyncValue.data((await future).addOrReplaceToken(token));
+      state = AsyncValue.data(currentState.addOrReplaceToken(token));
+      await _deleteNewlyInvalidatedNativeKey(current, token);
       return true;
     });
   }
@@ -149,18 +221,31 @@ class TokenNotifier extends _$TokenNotifier with ResultHandler {
   /// Updates repo and state.
   Future<List<Token>> _addOrReplaceTokens(List<Token> tokens) {
     return _stateMutex.protect(() async {
-      tokens = [...tokens, ...(await future).tokens].filterDuplicates();
+      final currentState = await future;
+      final workingTokens = List<Token>.from(currentState.tokens);
+      final previousById = <String, Token>{};
+      for (var incoming in tokens) {
+        final workingState = TokenState(tokens: workingTokens);
+        final current = _currentTokenForWrite(workingState, incoming);
+        if (current != null && current.id != incoming.id) {
+          incoming = incoming.copyWith(id: current.id);
+        }
+        final prepared = _prepareTokenForWrite(incoming, current);
+        if (current != null) {
+          previousById.putIfAbsent(prepared.id, () => current);
+        }
+        final index = workingTokens.indexWhere((t) => t.id == prepared.id);
+        if (index == -1) {
+          workingTokens.add(prepared);
+        } else {
+          workingTokens[index] = prepared;
+        }
+      }
+      tokens = workingTokens;
       if (tokens.isEmpty) {
         return [];
       }
       Logger.debug('Adding ${tokens.length} tokens.', verbose: true);
-      // We set currentState because the map function cant be async
-      final currentState = await future;
-      tokens = tokens.map((token) {
-        final currentId = currentState.currentOf(token)?.id;
-        if (currentId != null) return token.copyWith(id: currentId);
-        return token;
-      }).toList();
       final failedTokens = await _repoMutex.protect(
         () => repo.saveOrReplaceTokens(tokens),
       );
@@ -175,68 +260,320 @@ class TokenNotifier extends _$TokenNotifier with ResultHandler {
           .toList();
       // Add the saved tokens to the state
       Logger.info('Saved ${savedTokens.length} Tokens to storage.');
-      state = AsyncValue.data((await future).addOrReplaceTokens(savedTokens));
+      state = AsyncValue.data(currentState.addOrReplaceTokens(savedTokens));
+      for (final savedToken in savedTokens) {
+        await _deleteNewlyInvalidatedNativeKey(
+          previousById[savedToken.id],
+          savedToken,
+        );
+      }
       Logger.debug('New State: ${(await future).tokens.length} Tokens');
       return failedTokens;
     });
   }
 
-  /// Replaces a token if it exists and returns true if successful, false if not.
-  /// Updates repo and state.
-  Future<bool> _replaceToken(Token token) {
-    return _stateMutex.protect(() async {
-      final (newState, replaced) = (await future).replaceToken(token);
-      if (!replaced) {
-        Logger.warning('Tried to replace a token that does not exist.');
-        return false;
-      }
-      final saved = await _repoMutex.protect(
-        () => repo.saveOrReplaceToken(token),
-      );
-      if (!saved) {
-        Logger.warning('Saving token failed. Token: ${token.id}');
-        return false;
-      }
-      state = AsyncValue.data(newState);
-      return true;
-    });
-  }
+  /// Applies container responses to the latest local tokens without reviving
+  /// records deleted while the network request was in flight. Existing tokens
+  /// are rebased from server-authoritative template fields; local lifecycle,
+  /// key material, UI placement, and Push state remain owned by the latest
+  /// local record. Only [newTokens] may create a record.
+  Future<List<Token>> applyContainerSync({
+    required List<Token> updatedTokens,
+    required List<Token> newTokens,
+    List<Token> deletedTokens = const [],
+    required Map<String, List<String>> checkedContainersByTokenId,
+  }) async {
+    var removedLastPushToken = false;
+    final failed = await _stateMutex.protect(() async {
+      final currentState = await future;
+      final candidatesById = <String, Token>{};
+      final previousById = <String, Token>{};
+      final failedBeforeSaveById = <String, Token>{};
+      final incomingIdAliases = <String, String>{};
 
-  /// Returns a list of tokens that could not be replaced
-  /// Updates repo and state.
-  Future<List<T>> _replaceTokens<T extends Token>(List<T> tokens) {
-    return _stateMutex.protect(() async {
-      final failedToReplace = (await future).replaceTokens(tokens);
-      if (failedToReplace.isNotEmpty) {
-        Logger.warning('Failed to replace ${failedToReplace.length} tokens');
-        return failedToReplace;
+      void mergeExisting(Token incoming, Token current) {
+        final targetId = current.id;
+        incomingIdAliases[incoming.id] = targetId;
+        if (current.runtimeType != incoming.runtimeType) {
+          Logger.warning(
+            'Rejecting incompatible container token update ${incoming.id}.',
+          );
+          failedBeforeSaveById[targetId] = incoming;
+          return;
+        }
+        final template = incoming.toTemplate();
+        if (template == null) {
+          Logger.warning(
+            'Rejecting container token update without a stable template ${incoming.id}.',
+          );
+          failedBeforeSaveById[targetId] = incoming;
+          return;
+        }
+        try {
+          var merged = current.copyUpdateByTemplate(
+            template.copyWith(additionalData: current.additionalData),
+          );
+          merged = merged.copyWith(
+            id: targetId,
+            containerSerial: () => incoming.containerSerial,
+            origin: incoming.origin,
+          );
+          if (current is PushToken &&
+              incoming is PushToken &&
+              merged is PushToken) {
+            merged = merged.copyWith(
+              forceBiometricOption:
+                  current.forceBiometricOption == ForceBiometricOption.biometric
+                  ? current.forceBiometricOption
+                  : incoming.forceBiometricOption ==
+                        ForceBiometricOption.biometric
+                  ? incoming.forceBiometricOption
+                  : merged.forceBiometricOption,
+              biometricLevel:
+                  current.biometricLevel == PushAppBiometricLevel.strong
+                  ? current.biometricLevel
+                  : incoming.biometricLevel == PushAppBiometricLevel.strong
+                  ? incoming.biometricLevel
+                  : merged.biometricLevel,
+              invalidateOnBiometricChange:
+                  current.invalidateOnBiometricChange ||
+                  incoming.invalidateOnBiometricChange ||
+                  merged.invalidateOnBiometricChange,
+            );
+          }
+          merged = _prepareTokenForWrite(merged, current);
+          final original = currentState.currentOfId(targetId);
+          if (original != null) {
+            previousById.putIfAbsent(targetId, () => original);
+          }
+          candidatesById[targetId] = merged;
+        } catch (error, stackTrace) {
+          Logger.warning(
+            'Rejecting invalid container token update ${incoming.id}.',
+            error: error,
+            stackTrace: stackTrace,
+          );
+          failedBeforeSaveById[targetId] = incoming;
+        }
       }
-      tokens = tokens
-          .where((element) => !failedToReplace.contains(element))
+
+      for (final incoming in updatedTokens) {
+        // An update response may predate a local delete and re-enrollment.
+        // Never target a different UUID merely because its serial matches.
+        final current =
+            candidatesById[incoming.id] ??
+            currentState.currentOfId(incoming.id);
+        if (current == null) {
+          Logger.warning(
+            'Skipping stale container token update ${incoming.id}.',
+          );
+          continue;
+        }
+        mergeExisting(incoming, current);
+      }
+
+      for (final incoming in newTokens) {
+        final idCollision =
+            candidatesById[incoming.id] ??
+            currentState.currentOfId(incoming.id);
+        if (idCollision != null &&
+            !_hasSameContainerIdentityIgnoringId(idCollision, incoming)) {
+          Logger.warning(
+            'Rejecting new container token with colliding id ${incoming.id}.',
+          );
+          failedBeforeSaveById[incoming.id] = incoming;
+          continue;
+        }
+        final current =
+            idCollision ??
+            candidatesById.values.firstWhereOrNull(
+              (token) => token.isSameTokenAs(incoming) == true,
+            ) ??
+            currentState.tokens.firstWhereOrNull(
+              (token) => token.isSameTokenAs(incoming) == true,
+            );
+        if (current != null) {
+          Logger.warning(
+            'Treating colliding new container token ${incoming.id} as an update.',
+          );
+          mergeExisting(incoming, current);
+          continue;
+        }
+        final prepared = _prepareTokenForWrite(incoming, null);
+        incomingIdAliases[incoming.id] = prepared.id;
+        candidatesById[prepared.id] = prepared;
+      }
+
+      for (final entry in checkedContainersByTokenId.entries) {
+        final targetId = incomingIdAliases[entry.key] ?? entry.key;
+        final current = currentState.currentOfId(targetId);
+        final candidate = candidatesById[targetId] ?? current;
+        if (candidate == null) continue;
+        if (current != null) {
+          previousById.putIfAbsent(current.id, () => current);
+        }
+        candidatesById[targetId] = candidate.copyWith(
+          checkedContainer: {
+            ...candidate.checkedContainer,
+            ...entry.value,
+          }.toList(),
+        );
+      }
+
+      final candidates = candidatesById.values
+          .where((token) => !failedBeforeSaveById.containsKey(token.id))
           .toList();
-      final failedToSave = await _repoMutex.protect(
-        () => repo.saveOrReplaceTokens<T>(tokens),
+      final failedTokens = candidates.isEmpty
+          ? <Token>[]
+          : await _repoMutex.protect(
+              () => repo.saveOrReplaceTokens(candidates),
+            );
+      final failedIds = failedTokens.map((token) => token.id).toSet();
+      final failedCandidates = candidates
+          .where((token) => failedIds.contains(token.id))
+          .toList();
+      final savedById = {
+        for (final token in candidates)
+          if (!failedIds.contains(token.id)) token.id: token,
+      };
+
+      // If persistence of a stricter Push policy fails, do not leave the old,
+      // weaker token usable in this process. Persist a terminal state in a
+      // second, narrow write when possible; if even that fails, remove the old
+      // record from storage. A final in-memory invalidation is the last-resort
+      // fail-closed state for a completely unavailable secure store.
+      final removedAfterFailedTighteningIds = <String>{};
+      final inMemoryTerminalById = <String, PushToken>{};
+      final terminalCleanupById = <String, PushToken>{};
+      for (final candidate in failedCandidates.whereType<PushToken>()) {
+        final previous = previousById[candidate.id];
+        final becameInvalidated =
+            previous is PushToken &&
+            !previous.isBiometricKeyInvalidated &&
+            candidate.isBiometricKeyInvalidated;
+        if (!_tightensPushAuthentication(previous, candidate) &&
+            !becameInvalidated) {
+          continue;
+        }
+        final terminal = candidate.copyWith(
+          privateTokenKey: () => null,
+          biometricKeyStatus: BiometricPushKeyStatus.invalidated,
+        );
+        terminalCleanupById[terminal.id] = terminal;
+        final terminalSaved = await _repoMutex.protect(
+          () => repo.saveOrReplaceToken(terminal),
+        );
+        if (terminalSaved) {
+          savedById[terminal.id] = terminal;
+        } else if (previous != null &&
+            await _repoMutex.protect(() => repo.deleteToken(previous))) {
+          removedAfterFailedTighteningIds.add(previous.id);
+        } else if (previous != null) {
+          inMemoryTerminalById[terminal.id] = terminal;
+        }
+      }
+
+      var nextState = currentState.addOrReplaceTokens(
+        savedById.values.toList(),
       );
-      if (failedToSave.isNotEmpty) {
-        Logger.warning('Failed to save ${failedToSave.length} tokens');
+      if (removedAfterFailedTighteningIds.isNotEmpty) {
+        nextState = nextState.withoutTokens(
+          currentState.tokens
+              .where(
+                (token) => removedAfterFailedTighteningIds.contains(token.id),
+              )
+              .toList(),
+        );
       }
-      tokens = tokens
-          .where((element) => !failedToSave.contains(element))
+      if (inMemoryTerminalById.isNotEmpty) {
+        nextState = nextState.addOrReplaceTokens(
+          inMemoryTerminalById.values.toList(),
+        );
+      }
+
+      final updateFailures = <Token>[
+        ...failedBeforeSaveById.values,
+        ...failedCandidates,
+      ];
+      final deleteCandidatesById = <String, Token>{};
+      if (updateFailures.isEmpty) {
+        for (final incoming in deletedTokens) {
+          final currentById = currentState.currentOfId(incoming.id);
+          if (currentById != null &&
+              !_hasSameContainerIdentityIgnoringId(currentById, incoming)) {
+            Logger.warning(
+              'Skipping stale container token deletion ${incoming.id}.',
+            );
+            continue;
+          }
+          final current = currentById;
+          if (current == null || candidatesById.containsKey(current.id)) {
+            continue;
+          }
+          deleteCandidatesById[current.id] = current;
+        }
+      }
+      final deleteCandidates = deleteCandidatesById.values.toList();
+      final failedDeletions = deleteCandidates.isEmpty
+          ? <Token>[]
+          : await _repoMutex.protect(() => repo.deleteTokens(deleteCandidates));
+      final failedDeletionIds = failedDeletions
+          .map((token) => token.id)
+          .toSet();
+      final deleted = deleteCandidates
+          .where((token) => !failedDeletionIds.contains(token.id))
           .toList();
-      state = AsyncValue.data((await future).addOrReplaceTokens(tokens));
-      return failedToSave;
+      if (deleted.isNotEmpty) {
+        nextState = nextState.withoutTokens(deleted);
+      }
+      removedLastPushToken =
+          deleted.any((token) => token is PushToken) &&
+          nextState.pushTokens.isEmpty;
+
+      state = AsyncValue.data(nextState);
+      for (final token in deleted) {
+        await _deleteNativePushKey(token);
+      }
+      for (final token in savedById.values) {
+        await _deleteNewlyInvalidatedNativeKey(previousById[token.id], token);
+      }
+      for (final entry in terminalCleanupById.entries) {
+        if (!savedById.containsKey(entry.key)) {
+          await _deleteNativePushKey(entry.value);
+        }
+      }
+      return <Token>[...updateFailures, ...failedDeletions];
     });
+    // Firebase registration is shared by all Push tokens. Keep it while any
+    // Push token remains; remove it best-effort only after the last one is gone.
+    if (removedLastPushToken) {
+      try {
+        await firebaseUtils.deleteFirebaseToken();
+      } catch (error, stackTrace) {
+        Logger.warning(
+          'Could not remove the unused Firebase token after container sync.',
+          error: error,
+          stackTrace: stackTrace,
+        );
+      }
+    }
+    await _handlePushTokensIfExist();
+    return failed;
   }
 
   /// Removes a token and returns true if successful, false if not.
   Future<bool> _removeToken(Token token) async {
     final success = await _stateMutex.protect(() async {
-      final deleted = await _repoMutex.protect(() => repo.deleteToken(token));
+      final currentState = await future;
+      final current = currentState.currentOfId(token.id);
+      if (current == null) return false;
+      final deleted = await _repoMutex.protect(() => repo.deleteToken(current));
       if (!deleted) {
         Logger.warning('Deleting token failed. Token: ${token.id}');
         return false;
       }
-      state = AsyncValue.data((await future).withoutToken(token));
+      await _deleteNativePushKey(current);
+      state = AsyncValue.data(currentState.withoutToken(current));
       return true;
     });
     if (!success) return false;
@@ -249,24 +586,31 @@ class TokenNotifier extends _$TokenNotifier with ResultHandler {
     if (tokens.isEmpty) return [];
     Logger.info('Removing ${tokens.length} tokens.');
     final failedTokens = await _stateMutex.protect(() async {
+      final currentState = await future;
+      final currentTokens = tokens
+          .map((token) => currentState.currentOfId(token.id))
+          .nonNulls
+          .toList();
       final failedTokens = await _repoMutex.protect(
-        () => repo.deleteTokens(tokens),
+        () => repo.deleteTokens(currentTokens),
       );
       if (failedTokens.isNotEmpty) {
         Logger.warning(
           'Deleting tokens failed. Failed Tokens: ${failedTokens.length}',
         );
-        return failedTokens;
       }
-      final remainingTokens = tokens
-          .where((element) => !failedTokens.contains(element))
+      final failedIds = failedTokens.map((token) => token.id).toSet();
+      final deletedTokens = currentTokens
+          .where((element) => !failedIds.contains(element.id))
           .toList();
-      state = AsyncValue.data((await future).withoutTokens(remainingTokens));
-      return <Token>[];
+      for (final token in deletedTokens) {
+        await _deleteNativePushKey(token);
+      }
+      state = AsyncValue.data(currentState.withoutTokens(deletedTokens));
+      return failedTokens;
     });
-    if (failedTokens.isNotEmpty) return failedTokens;
     await _handlePushTokensIfExist();
-    return [];
+    return failedTokens;
   }
 
   /// Loads the tokens from the repository sets it as the new state and returns the new(await future).
@@ -274,7 +618,8 @@ class TokenNotifier extends _$TokenNotifier with ResultHandler {
     TokenState? newState;
     newState = await _stateMutex.protect(() async {
       try {
-        final tokens = await _repoMutex.protect(() => repo.loadTokens());
+        final loadedTokens = await _repoMutex.protect(() => repo.loadTokens());
+        final tokens = await _reconcileBiometricPushKeys(loadedTokens);
         final loadedState = TokenState(
           tokens: tokens,
           lastlyUpdatedTokens: tokens,
@@ -291,18 +636,114 @@ class TokenNotifier extends _$TokenNotifier with ResultHandler {
     return newState;
   }
 
-  Future<bool> _saveStateToRepo() async {
-    final tokens = (await future).tokens;
-    return _repoMutex.protect(() async {
-      try {
-        await repo.saveOrReplaceTokens(tokens);
-        return true;
-      } catch (e) {
-        Logger.error('Saving tokens to storage failed.', error: e);
-        return false;
+  Future<List<Token>> _reconcileBiometricPushKeys(List<Token> tokens) async {
+    if (!rsaUtils.supportsBiometricPushKeyProtection) return tokens;
+    final reconciled = <Token>[];
+    for (final token in tokens) {
+      if (token is! PushToken || !token.requiresBiometricKeyProtection) {
+        reconciled.add(token);
+        continue;
       }
-    });
+      try {
+        // Local invalidation is terminal. In particular, a native key that was
+        // created before the server tightened enrollment binding must never
+        // revive the token merely because the platform still reports it as
+        // protected. Remove any remaining native material defensively.
+        if (token.isBiometricKeyInvalidated) {
+          final terminalToken = token.copyWith(
+            privateTokenKey: () => null,
+            biometricKeyStatus: BiometricPushKeyStatus.invalidated,
+          );
+          var reconciledToken = token;
+          if (!terminalToken.sameValuesAs(token)) {
+            final saved = await _repoMutex.protect(
+              () => repo.saveOrReplaceToken(terminalToken),
+            );
+            if (saved) {
+              reconciledToken = terminalToken;
+            } else {
+              Logger.warning(
+                'Could not persist terminal biometric Push key state.',
+              );
+            }
+          }
+          try {
+            await rsaUtils.deleteBiometricPushKey(token.id);
+          } catch (error, stackTrace) {
+            Logger.warning(
+              'Could not remove a terminally invalidated native Push key.',
+              error: error,
+              stackTrace: stackTrace,
+            );
+          }
+          reconciled.add(reconciledToken);
+          continue;
+        }
+        final nativeStatus = await rsaUtils.biometricPushKeyStatus(token.id);
+        final PushToken updated;
+        if (nativeStatus == RsaUtils.biometricKeyStatusInvalidated ||
+            (token.biometricKeyStatus == BiometricPushKeyStatus.protected &&
+                nativeStatus == RsaUtils.biometricKeyStatusUnprotected)) {
+          updated = token.copyWith(
+            privateTokenKey: () => null,
+            biometricKeyStatus: BiometricPushKeyStatus.invalidated,
+          );
+        } else if (token.isRolledOut &&
+            token.biometricKeyStatus == BiometricPushKeyStatus.unprotected &&
+            nativeStatus == RsaUtils.biometricKeyStatusUnprotected) {
+          // A deployed legacy token has no trustworthy enrollment baseline.
+          // Binding it on first use would silently trust biometrics added after
+          // the original token enrollment, so require a fresh enrollment.
+          updated = token.copyWith(
+            privateTokenKey: () => null,
+            biometricKeyStatus: BiometricPushKeyStatus.invalidated,
+          );
+        } else if (nativeStatus == RsaUtils.biometricKeyStatusProtected) {
+          updated = token.copyWith(
+            privateTokenKey: () => null,
+            biometricKeyStatus: BiometricPushKeyStatus.protected,
+          );
+        } else {
+          updated = token;
+        }
+        if (!identical(updated, token) && !updated.sameValuesAs(token)) {
+          final saved = await _repoMutex.protect(
+            () => repo.saveOrReplaceToken(updated),
+          );
+          if (!saved) {
+            Logger.warning(
+              'Could not persist reconciled biometric Push key state.',
+            );
+            reconciled.add(token);
+            continue;
+          }
+          await _deleteNewlyInvalidatedNativeKey(token, updated);
+        }
+        reconciled.add(updated);
+      } catch (error, stackTrace) {
+        Logger.warning(
+          'Could not reconcile native biometric Push key state.',
+          error: error,
+          stackTrace: stackTrace,
+        );
+        reconciled.add(token);
+      }
+    }
+    return reconciled;
   }
+
+  Future<bool> _saveStateToRepo() => _stateMutex.protect(() async {
+    final tokens = (await future).tokens;
+    try {
+      final failed = await _repoMutex.protect(
+        () => repo.saveOrReplaceTokens(tokens),
+      );
+      return failed.isEmpty;
+    } catch (e) {
+      Logger.error('Saving tokens to storage failed.', error: e);
+      return false;
+    }
+  });
 
   /*
   //////////////////////////////////////////////////////////////////////////////
@@ -317,14 +758,26 @@ class TokenNotifier extends _$TokenNotifier with ResultHandler {
     T token,
     T Function(T) updater,
   ) async {
-    final current = (await future).currentOf<T>(token);
-    if (current == null) {
-      Logger.warning('Tried to update a token that does not exist.');
-      return null;
-    }
-    final updated = updater(current);
-    final replaced = await _replaceToken(updated);
-    return replaced ? updated : current;
+    return _stateMutex.protect(() async {
+      final currentState = await future;
+      final current = currentState.currentOfId<T>(token.id);
+      if (current == null) {
+        Logger.warning('Tried to update a token that does not exist.');
+        return null;
+      }
+      var updated = updater(current);
+      updated = _prepareTokenForWrite(updated, current) as T;
+      final saved = await _repoMutex.protect(
+        () => repo.saveOrReplaceToken(updated),
+      );
+      if (!saved) {
+        Logger.warning('Saving token failed. Token: ${updated.id}');
+        return current;
+      }
+      state = AsyncValue.data(currentState.addOrReplaceToken(updated));
+      await _deleteNewlyInvalidatedNativeKey(current, updated);
+      return updated;
+    });
   }
 
   /// Updates a list of tokens and returns the updated tokens if successful.
@@ -334,19 +787,125 @@ class TokenNotifier extends _$TokenNotifier with ResultHandler {
     T Function(T) updater,
   ) async {
     if (tokens.isEmpty) return [];
-    List<T> updatedTokens = [];
-    for (final token in tokens) {
-      final current = (await future).currentOf<T>(token) ?? token;
-      updatedTokens.add(updater(current));
-    }
+    return _stateMutex.protect(() async {
+      final currentState = await future;
+      final previousById = <String, T>{};
+      final updatedTokens = <T>[];
+      for (final token in tokens) {
+        final current = currentState.currentOfId<T>(token.id);
+        if (current == null) continue;
+        previousById[token.id] = current;
+        updatedTokens.add(
+          _prepareTokenForWrite(updater(current), current) as T,
+        );
+      }
+      final failedToSave = await _repoMutex.protect(
+        () => repo.saveOrReplaceTokens<T>(updatedTokens),
+      );
+      final savedTokens = updatedTokens
+          .where((element) => !failedToSave.contains(element))
+          .toList();
+      state = AsyncValue.data(currentState.addOrReplaceTokens(savedTokens));
+      for (final savedToken in savedTokens) {
+        await _deleteNewlyInvalidatedNativeKey(
+          previousById[savedToken.id],
+          savedToken,
+        );
+      }
+      final newState = await future;
+      return newState.tokens
+          .whereType<T>()
+          .where((stateToken) => tokens.any((t) => t.id == stateToken.id))
+          .toList();
+    });
+  }
 
-    await _replaceTokens(updatedTokens);
+  /// Applies only sortable placement fields to records that still exist.
+  /// Delayed drag/post-frame snapshots must not recreate a deleted token or
+  /// overwrite newer Push rollout, policy, Firebase, or key state.
+  Future<List<Token>> updateTokenPlacements(List<Token> placements) {
+    return _stateMutex.protect(() async {
+      final currentState = await future;
+      final updates = <Token>[];
+      for (final placement in placements) {
+        final current = currentState.currentOfId(placement.id);
+        if (current == null || current.runtimeType != placement.runtimeType) {
+          continue;
+        }
+        updates.add(
+          current.copyWith(
+            sortIndex: placement.sortIndex,
+            folderId: () => placement.folderId,
+          ),
+        );
+      }
+      if (updates.isEmpty) return <Token>[];
+      final failed = await _repoMutex.protect(
+        () => repo.saveOrReplaceTokens(updates),
+      );
+      final failedIds = failed.map((token) => token.id).toSet();
+      final saved = updates
+          .where((token) => !failedIds.contains(token.id))
+          .toList();
+      state = AsyncValue.data(currentState.addOrReplaceTokens(saved));
+      return failed;
+    });
+  }
 
-    final newState = (await future);
-    return newState.tokens
-        .whereType<T>()
-        .where((stateToken) => tokens.contains(stateToken))
-        .toList();
+  /// Runs a security-sensitive Push operation against the latest local token
+  /// while holding the same state lock used by deletion, policy updates, and
+  /// biometric invalidation.
+  ///
+  /// Keeping the lock through signing and the authenticated HTTP request makes
+  /// those operations linearizable: a deletion or terminal invalidation either
+  /// completes before this callback starts (and the token is not returned), or
+  /// waits until the already-started request has finished. [persist] lets a
+  /// native key migration update storage without trying to acquire this lock a
+  /// second time.
+  Future<R?> withCurrentPushTokenLease<R>(
+    String tokenId,
+    Future<R?> Function(
+      PushToken token,
+      Future<PushToken?> Function(PushToken proposed) persist,
+      PushToken Function() current,
+    )
+    operation,
+  ) {
+    return _stateMutex.protect(() async {
+      var currentState = await future;
+      var currentToken = currentState.currentOfId<PushToken>(tokenId);
+      if (currentToken == null) {
+        Logger.warning(
+          'Refusing a Push operation for a token that no longer exists.',
+        );
+        return null;
+      }
+
+      Future<PushToken?> persist(PushToken proposed) async {
+        if (proposed.id != currentToken!.id) {
+          Logger.warning('Refusing to change token identity inside a lease.');
+          return null;
+        }
+        final previous = currentToken!;
+        final prepared = _prepareTokenForWrite(proposed, previous) as PushToken;
+        final saved = await _repoMutex.protect(
+          () => repo.saveOrReplaceToken(prepared),
+        );
+        if (!saved) {
+          Logger.warning(
+            'Could not persist Push token state inside an operation lease.',
+          );
+          return null;
+        }
+        currentState = currentState.addOrReplaceToken(prepared);
+        currentToken = prepared;
+        state = AsyncValue.data(currentState);
+        await _deleteNewlyInvalidatedNativeKey(previous, prepared);
+        return prepared;
+      }
+
+      return operation(currentToken!, persist, () => currentToken!);
+    });
   }
 
   /*
@@ -430,6 +989,10 @@ class TokenNotifier extends _$TokenNotifier with ResultHandler {
 
   Future<TokenState?> loadStateFromRepo() async {
     try {
+      // Do not race the provider's initial build for the same state mutex.
+      // The biometric reconciliation step is asynchronous, so callers may
+      // otherwise enter _updateStateFromRepo while build() still owns it.
+      await future;
       return await _updateStateFromRepo();
     } catch (_) {
       Logger.warning('Loading tokens from storage failed.');
@@ -562,16 +1125,94 @@ class TokenNotifier extends _$TokenNotifier with ResultHandler {
 
     Logger.info('Rolling out token "${pushToken.id}"');
 
-    if (pushToken.privateTokenKey == null) {
+    final hasProtectedPrivateKey =
+        pushToken.biometricKeyStatus == BiometricPushKeyStatus.protected;
+    final needsKeyPair =
+        pushToken.publicTokenKey == null ||
+        (!hasProtectedPrivateKey && pushToken.privateTokenKey == null);
+    if (needsKeyPair) {
+      if (hasProtectedPrivateKey) {
+        Logger.error(
+          'Protected Push token is missing its matching public key.',
+        );
+        await _updateToken(
+          pushToken,
+          (current) => current.copyWith(
+            privateTokenKey: () => null,
+            biometricKeyStatus: BiometricPushKeyStatus.invalidated,
+          ),
+        );
+        ref
+            .read(statusProvider.notifier)
+            .show(
+              (l) => l.biometricPushTokenInvalidTitle,
+              details: (l) => l.biometricPushTokenInvalidBody,
+            );
+        return false;
+      }
       pushToken = await _handleKeyGeneration(pushToken);
       if (pushToken == null) return false;
+    }
+
+    if (pushToken.requiresBiometricKeyProtection &&
+        pushToken.biometricKeyStatus != BiometricPushKeyStatus.protected) {
+      try {
+        await rsaUtils.protectBiometricPushKey(pushToken);
+        final protectedToken = pushToken.copyWith(
+          privateTokenKey: () => null,
+          biometricKeyStatus: BiometricPushKeyStatus.protected,
+        );
+        final persistedToken = await _updateToken(
+          pushToken,
+          (current) => current.copyWith(
+            privateTokenKey: () => protectedToken.privateTokenKey,
+            biometricKeyStatus: protectedToken.biometricKeyStatus,
+          ),
+        );
+        if (persistedToken == null ||
+            persistedToken.privateTokenKey != null ||
+            persistedToken.biometricKeyStatus !=
+                BiometricPushKeyStatus.protected) {
+          Logger.error(
+            'Protected Push key state could not be persisted; rollout stopped.',
+          );
+          ref
+              .read(statusProvider.notifier)
+              .show(
+                (l) => l.errorRollOutFailed(pushToken!.label),
+                details: (l) => l.biometricPushKeyPersistenceFailed,
+              );
+          return false;
+        }
+        pushToken = persistedToken;
+      } on BiometricPushKeyException catch (error, stackTrace) {
+        Logger.warning(
+          'Could not protect Push key with strong biometrics.',
+          error: error,
+          stackTrace: stackTrace,
+        );
+        ref
+            .read(statusProvider.notifier)
+            .show(
+              (l) => l.errorRollOutFailed(pushToken!.label),
+              details: (l) => l.biometricStrongRequired,
+            );
+        return false;
+      }
     }
 
     String? fbToken;
     if (pushToken.isPollOnly != true) {
       fbToken = await _getFirebaseToken(pushToken);
       if (fbToken == null) return false;
-      pushToken = await getTokenById(pushToken.id) ?? pushToken;
+      final refreshed = await getTokenById<PushToken>(pushToken.id);
+      if (refreshed == null || refreshed.isBiometricKeyInvalidated) {
+        Logger.warning(
+          'Push token disappeared or was invalidated during rollout.',
+        );
+        return false;
+      }
+      pushToken = refreshed;
     }
 
     if (!kIsWeb && Platform.isIOS) {
@@ -583,6 +1224,16 @@ class TokenNotifier extends _$TokenNotifier with ResultHandler {
 
   Future<bool> _isEligibleForRollout(PushToken token) async {
     assert(token.url != null, 'Token url is null.');
+
+    if (token.isBiometricKeyInvalidated) {
+      ref
+          .read(statusProvider.notifier)
+          .show(
+            (l) => l.biometricPushTokenInvalidTitle,
+            details: (l) => l.biometricPushTokenInvalidBody,
+          );
+      return false;
+    }
 
     if (token.rolloutState.rollOutInProgress) {
       Logger.info('Rollout already in progress for "${token.id}".');
@@ -663,67 +1314,96 @@ class TokenNotifier extends _$TokenNotifier with ResultHandler {
   }
 
   Future<bool> _executeServerRollout(PushToken token, String? fbToken) async {
-    token =
-        await _updateStatus(token, PushTokenRollOutState.sendRSAPublicKey) ??
-        token;
-    try {
-      final response = await ioClient.doPost(
-        sslVerify: token.sslVerify,
-        url: token.url!,
-        body: {
-          'enrollment_credential': token.enrollmentCredentials,
-          'serial': token.serial,
-          'fbtoken': fbToken ?? NoFirebaseUtils.NO_FIREBASE_TOKEN,
-          'pubkey': rsaUtils.serializeRSAPublicKeyPKCS8(
-            token.rsaPublicTokenKey!,
-          ),
-          'capabilities': canonicalizeJson(appPushCapabilities.names),
-        },
-      );
+    return await withCurrentPushTokenLease<bool>(token.id, (
+          leasedToken,
+          persist,
+          current,
+        ) async {
+          if (leasedToken.isBiometricKeyInvalidated ||
+              leasedToken.url == null ||
+              leasedToken.publicTokenKey == null) {
+            return false;
+          }
+          if (leasedToken.requiresBiometricKeyProtection &&
+              leasedToken.biometricKeyStatus !=
+                  BiometricPushKeyStatus.protected) {
+            return false;
+          }
+          if (leasedToken.requiresBiometricPromptBeforeDartKeyUse) {
+            final authenticated = await lockAuthWithSettingsRef(
+              ref: ref,
+              localization: ref.read(localizationProvider),
+              reason: (l) => l.biometricPushKeyAuthReason,
+              forceBiometricOption: leasedToken.forceBiometricOption,
+            );
+            if (!authenticated) return false;
+          }
 
-      if (HttpStatusChecker.isError(response.statusCode)) {
-        _showPushRolloutStatus(response, token.label);
-        await _updateStatus(
-          token,
-          PushTokenRollOutState.sendRSAPublicKeyFailed,
-        );
-        return false;
-      }
-
-      token =
-          await _updateToken(
-            token,
-            (p) => p.copyWith(
-              rolloutState: PushTokenRollOutState.parsingResponse,
-              fbToken: fbToken,
+          final sending = await persist(
+            leasedToken.copyWith(
+              rolloutState: PushTokenRollOutState.sendRSAPublicKey,
             ),
-          ) ??
-          token;
-
-      final publicServerKey = await _parseRollOutResponse(response);
-      await _updateToken(
-        token,
-        (p) => p
-            .withPublicServerKey(publicServerKey)
-            .copyWith(
-              isRolledOut: true,
-              rolloutState: PushTokenRollOutState.rolloutComplete,
-            ),
-      );
-
-      checkNotificationPermission();
-      return true;
-    } catch (e, s) {
-      Logger.error('Roll out failed.', error: e, stackTrace: s);
-      ref
-          .read(statusProvider.notifier)
-          .show(
-            (localization) =>
-                localization.errorRollOutUnknownError(token.label),
           );
-      await _updateStatus(token, PushTokenRollOutState.sendRSAPublicKeyFailed);
-      return false;
-    }
+          if (sending == null) return false;
+          try {
+            final response = await ioClient.doPost(
+              sslVerify: current().sslVerify,
+              url: current().url!,
+              body: {
+                'enrollment_credential': current().enrollmentCredentials,
+                'serial': current().serial,
+                'fbtoken': fbToken ?? NoFirebaseUtils.NO_FIREBASE_TOKEN,
+                'pubkey': rsaUtils.serializeRSAPublicKeyPKCS8(
+                  current().rsaPublicTokenKey!,
+                ),
+                'capabilities': canonicalizeJson(appPushCapabilities.names),
+              },
+            );
+
+            if (HttpStatusChecker.isError(response.statusCode)) {
+              _showPushRolloutStatus(response, current().label);
+              await persist(
+                current().copyWith(
+                  rolloutState: PushTokenRollOutState.sendRSAPublicKeyFailed,
+                ),
+              );
+              return false;
+            }
+
+            final parsing = await persist(
+              current().copyWith(
+                rolloutState: PushTokenRollOutState.parsingResponse,
+                fbToken: fbToken,
+              ),
+            );
+            if (parsing == null) return false;
+
+            final publicServerKey = await _parseRollOutResponse(response);
+            final completed = await persist(
+              current()
+                  .withPublicServerKey(publicServerKey)
+                  .copyWith(
+                    isRolledOut: true,
+                    rolloutState: PushTokenRollOutState.rolloutComplete,
+                  ),
+            );
+            if (completed == null || !completed.isRolledOut) return false;
+            checkNotificationPermission();
+            return true;
+          } catch (e, s) {
+            Logger.error('Roll out failed.', error: e, stackTrace: s);
+            ref
+                .read(statusProvider.notifier)
+                .show((loc) => loc.errorRollOutUnknownError(current().label));
+            await persist(
+              current().copyWith(
+                rolloutState: PushTokenRollOutState.sendRSAPublicKeyFailed,
+              ),
+            );
+            return false;
+          }
+        }) ??
+        false;
   }
 
   Future<PushToken?> _updateStatus(
@@ -851,34 +1531,92 @@ class TokenNotifier extends _$TokenNotifier with ResultHandler {
     //timestamp=<timestamp>
     //signature=SIGNATURE(<new firebase token>|<tokenserial>|<timestamp>)
     Logger.info('Updating firebase token for push token "${token.serial}"');
-    String timestamp = DateTime.now().toUtc().toIso8601String();
-    String message = '$firebaseToken|${token.serial}|$timestamp';
-    String? signature = await rsaUtils.trySignWithToken(token, message);
-    if (signature == null) {
-      Logger.error(
-        'Cannot update firebase token for push token "${token.serial}". No signature available.',
-      );
-      return false;
-    }
-    Response response = await ioClient.doPost(
-      url: token.url!,
-      body: {
-        'new_fb_token': firebaseToken,
-        'serial': token.serial,
-        'timestamp': timestamp,
-        'signature': signature,
-        // Not part of the signed message, see pollForChallenge.
-        'capabilities': canonicalizeJson(appPushCapabilities.names),
-      },
-      sslVerify: token.sslVerify,
-    );
-    if (HttpStatusChecker.isError(response.statusCode)) {
-      Logger.warning('Updating firebase token for push token failed!');
-      return false;
-    }
-    Logger.info('Updating firebase token for push token succeeded!');
-    await _updateToken(token, (p0) => p0.copyWith(fbToken: firebaseToken));
-    return true;
+    return await withCurrentPushTokenLease<bool>(token.id, (
+          leasedToken,
+          persist,
+          current,
+        ) async {
+          if (!leasedToken.isRolledOut ||
+              leasedToken.url == null ||
+              leasedToken.isBiometricKeyInvalidated) {
+            return false;
+          }
+          if (leasedToken.requiresBiometricPromptBeforeDartKeyUse) {
+            final authenticated = await lockAuthWithSettingsRef(
+              ref: ref,
+              localization: ref.read(localizationProvider),
+              reason: (l) => l.biometricPushKeyAuthReason,
+              forceBiometricOption: leasedToken.forceBiometricOption,
+            );
+            if (!authenticated) return false;
+          }
+          final timestamp = DateTime.now().toUtc().toIso8601String();
+          final message = '$firebaseToken|${leasedToken.serial}|$timestamp';
+          String? signature;
+          try {
+            signature = await rsaUtils.trySignWithToken(
+              leasedToken,
+              message,
+              onTokenChanged: (updated) async {
+                final persisted = await persist(
+                  current().copyWith(
+                    privateTokenKey: () => updated.privateTokenKey,
+                    biometricKeyStatus: updated.biometricKeyStatus,
+                  ),
+                );
+                return persisted != null &&
+                    persisted.privateTokenKey == updated.privateTokenKey &&
+                    persisted.biometricKeyStatus == updated.biometricKeyStatus;
+              },
+            );
+          } on BiometricPushKeyException catch (error) {
+            if (error.isInvalidated) {
+              ref
+                  .read(statusProvider.notifier)
+                  .show(
+                    (l) => l.biometricPushTokenInvalidTitle,
+                    details: (l) => l.biometricPushTokenInvalidBody,
+                  );
+            } else if (error.isStateNotPersisted) {
+              ref
+                  .read(statusProvider.notifier)
+                  .show(
+                    (l) => l.biometricPushKeyPersistenceFailedTitle,
+                    details: (l) => l.biometricPushKeyPersistenceFailed,
+                  );
+            }
+            return false;
+          }
+          if (signature == null || current().isBiometricKeyInvalidated) {
+            Logger.error(
+              'Cannot update firebase token for push token "${leasedToken.serial}". No valid signature is available.',
+            );
+            return false;
+          }
+          final response = await ioClient.doPost(
+            url: current().url!,
+            body: {
+              'new_fb_token': firebaseToken,
+              'serial': current().serial,
+              'timestamp': timestamp,
+              'signature': signature,
+              // Not part of the signed message; older servers ignore it.
+              'capabilities': canonicalizeJson(appPushCapabilities.names),
+            },
+            sslVerify: current().sslVerify,
+          );
+          if (HttpStatusChecker.isError(response.statusCode)) {
+            Logger.warning('Updating firebase token for push token failed!');
+            return false;
+          }
+          final persisted = await persist(
+            current().copyWith(fbToken: firebaseToken),
+          );
+          if (persisted?.fbToken != firebaseToken) return false;
+          Logger.info('Updating firebase token for push token succeeded!');
+          return true;
+        }) ??
+        false;
   }
 
   /* ////////////////////////////////////////////////////////////////////////////

--- a/lib/utils/riverpod/riverpod_providers/generated_providers/token_notifier.g.dart
+++ b/lib/utils/riverpod/riverpod_providers/generated_providers/token_notifier.g.dart
@@ -56,7 +56,7 @@ final class TokenNotifierProvider
   }
 }
 
-String _$tokenNotifierHash() => r'6f1e9925ea0854c50f585684713775bdc7234f93';
+String _$tokenNotifierHash() => r'd589365908a9ab6ba57f48e8c18f539a43e45dbf';
 
 final class TokenNotifierFamily extends $Family
     with

--- a/lib/utils/rsa_utils.dart
+++ b/lib/utils/rsa_utils.dart
@@ -26,12 +26,39 @@ import 'package:pointycastle/export.dart';
 import 'package:privacyidea_authenticator/utils/helpers/base32_helper.dart';
 
 import '../model/tokens/push_token.dart';
+import '../model/enums/biometric_push_key_status.dart';
+import '../l10n/app_localizations.dart';
+import 'biometric_push_key_manager.dart';
+import 'globals.dart';
 import '../utils/crypto_utils.dart';
 import '../utils/identifiers.dart';
 import '../utils/logger.dart';
 
 class RsaUtils {
-  const RsaUtils();
+  static const biometricKeyStatusUnprotected = 'unprotected';
+  static const biometricKeyStatusProtected = 'protected';
+  static const biometricKeyStatusInvalidated = 'invalidated';
+  static const biometricKeyStatusUnsupported = 'unsupported';
+
+  final BiometricPushKeyManager _biometricPushKeyManager;
+
+  // Keep the public injection parameter readable while the dependency itself
+  // remains private (and therefore outside generated Mockito interfaces).
+  const RsaUtils({
+    BiometricPushKeyManager biometricPushKeyManager =
+        const BiometricPushKeyManager(),
+  }) : this._withBiometricPushKeyManager(biometricPushKeyManager);
+
+  const RsaUtils._withBiometricPushKeyManager(this._biometricPushKeyManager);
+
+  bool get supportsBiometricPushKeyProtection =>
+      _biometricPushKeyManager.isSupportedPlatform;
+
+  Future<String> biometricPushKeyStatus(String tokenId) async =>
+      (await _biometricPushKeyManager.status(tokenId)).name;
+
+  Future<void> deleteBiometricPushKey(String tokenId) =>
+      _biometricPushKeyManager.delete(tokenId);
 
   /// Extract RSA-Public-Keys from DER structure that is a BASE64 encoded Strings.
   /// According to the PKCS#1 format:
@@ -162,7 +189,7 @@ class RsaUtils {
     ASN1Sequence s = ASN1Sequence()
       ..add(ASN1Integer.fromInt(0)) // version
       ..add(ASN1Integer(key.modulus!)) // modulus
-      ..add(ASN1Integer(key.exponent!)) // e
+      ..add(ASN1Integer(key.publicExponent!)) // e
       ..add(ASN1Integer(key.privateExponent!)) // d
       ..add(ASN1Integer(key.p!)) // p
       ..add(ASN1Integer(key.q!)) // q
@@ -199,14 +226,42 @@ class RsaUtils {
     Uint8List keyBytes = base64.decode(keyStr);
     ASN1Sequence asn1sequence =
         ASN1Parser(keyBytes).nextObject() as ASN1Sequence;
+    if (asn1sequence.elements.length != 9 ||
+        (asn1sequence.elements[0] as ASN1Integer).valueAsBigInteger !=
+            BigInt.zero) {
+      throw const FormatException('Unsupported RSA private key format.');
+    }
     BigInt modulus =
         (asn1sequence.elements[1] as ASN1Integer).valueAsBigInteger;
-    BigInt exponent =
+    BigInt publicExponent =
         (asn1sequence.elements[2] as ASN1Integer).valueAsBigInteger;
+    BigInt privateExponent =
+        (asn1sequence.elements[3] as ASN1Integer).valueAsBigInteger;
     BigInt p = (asn1sequence.elements[4] as ASN1Integer).valueAsBigInteger;
     BigInt q = (asn1sequence.elements[5] as ASN1Integer).valueAsBigInteger;
+    final exponent1 =
+        (asn1sequence.elements[6] as ASN1Integer).valueAsBigInteger;
+    final exponent2 =
+        (asn1sequence.elements[7] as ASN1Integer).valueAsBigInteger;
+    final coefficient =
+        (asn1sequence.elements[8] as ASN1Integer).valueAsBigInteger;
 
-    return RSAPrivateKey(modulus, exponent, p, q);
+    if (modulus != p * q ||
+        exponent1 != privateExponent % (p - BigInt.one) ||
+        exponent2 != privateExponent % (q - BigInt.one) ||
+        coefficient != q.modInverse(p)) {
+      throw const FormatException('Inconsistent RSA private key parameters.');
+    }
+
+    final privateKey = RSAPrivateKey(modulus, privateExponent, p, q);
+    if (publicExponent == privateExponent) {
+      if (privateKey.publicExponent != BigInt.from(65537)) {
+        throw const FormatException('Unexpected legacy RSA public exponent.');
+      }
+    } else if (privateKey.publicExponent != publicExponent) {
+      throw const FormatException('Inconsistent RSA public exponent.');
+    }
+    return privateKey;
   }
 
   /// signedMessage is what was allegedly signed, signature gets validated
@@ -246,7 +301,108 @@ class RsaUtils {
   /// if a [context] is provided, telling the users that it might be better to enroll a new
   /// push token so that the app can directly access the private key.
   /// Returns the signature on success and null on failure.
-  Future<String?> trySignWithToken(PushToken token, String message) async {
+  Future<String?> trySignWithToken(
+    PushToken token,
+    String message, {
+    Future<bool> Function(PushToken token)? onTokenChanged,
+  }) async {
+    if (token.requiresBiometricKeyProtection) {
+      if (!supportsBiometricPushKeyProtection) {
+        throw const BiometricPushKeyException(
+          BiometricPushKeyManager.unsupportedCode,
+        );
+      }
+      if (token.isBiometricKeyInvalidated) {
+        throw const BiometricPushKeyException(
+          BiometricPushKeyManager.invalidatedCode,
+        );
+      }
+      if (token.isRolledOut &&
+          token.biometricKeyStatus == BiometricPushKeyStatus.unprotected) {
+        if (onTokenChanged != null) {
+          try {
+            await onTokenChanged(
+              token.copyWith(
+                privateTokenKey: () => null,
+                biometricKeyStatus: BiometricPushKeyStatus.invalidated,
+              ),
+            );
+          } catch (persistError, stackTrace) {
+            Logger.warning(
+              'Could not persist invalidated legacy biometric Push state.',
+              error: persistError,
+              stackTrace: stackTrace,
+            );
+          }
+        }
+        throw const BiometricPushKeyException(
+          BiometricPushKeyManager.invalidatedCode,
+        );
+      }
+      try {
+        final localization = globalContextSync == null
+            ? null
+            : AppLocalizations.of(globalContextSync!);
+        final result = await _biometricPushKeyManager.sign(
+          tokenId: token.id,
+          message: message,
+          reason:
+              localization?.biometricPushKeyAuthReason ??
+              'Authenticate to use this Push token',
+          cancelLabel: localization?.cancel ?? 'Cancel',
+          invalidateOnBiometricChange: token.invalidateOnBiometricChange,
+          privateKey:
+              token.biometricKeyStatus == BiometricPushKeyStatus.unprotected
+              ? token.privateTokenKey
+              : null,
+        );
+        final migrationMustBePersisted =
+            result.protectedNow ||
+            token.privateTokenKey != null ||
+            token.biometricKeyStatus != BiometricPushKeyStatus.protected;
+        if (migrationMustBePersisted) {
+          final updatedToken = token.copyWith(
+            privateTokenKey: () => null,
+            biometricKeyStatus: BiometricPushKeyStatus.protected,
+          );
+          var persisted = false;
+          try {
+            persisted =
+                onTokenChanged != null && await onTokenChanged(updatedToken);
+          } catch (persistError, stackTrace) {
+            Logger.warning(
+              'Could not persist protected biometric Push key state.',
+              error: persistError,
+              stackTrace: stackTrace,
+            );
+          }
+          if (!persisted) {
+            throw const BiometricPushKeyException(
+              BiometricPushKeyManager.stateNotPersistedCode,
+            );
+          }
+        }
+        return base32Encode(base64.decode(result.signature));
+      } on BiometricPushKeyException catch (error) {
+        if (error.isInvalidated && onTokenChanged != null) {
+          try {
+            await onTokenChanged(
+              token.copyWith(
+                privateTokenKey: () => null,
+                biometricKeyStatus: BiometricPushKeyStatus.invalidated,
+              ),
+            );
+          } catch (persistError, stackTrace) {
+            Logger.warning(
+              'Could not persist invalidated biometric Push key state.',
+              error: persistError,
+              stackTrace: stackTrace,
+            );
+          }
+        }
+        rethrow;
+      }
+    }
     if (token.privateTokenKey != null) {
       return createBase32Signature(
         token.rsaPrivateTokenKey!,
@@ -257,6 +413,38 @@ class RsaUtils {
       'Token ${token.serial} does not have a private key. Cannot sign message.',
     );
     return null;
+  }
+
+  /// Moves a biometric-required Push private key behind Android Keystore or
+  /// iOS Keychain before its public key is sent to privacyIDEA.
+  Future<void> protectBiometricPushKey(PushToken token) async {
+    if (!token.requiresBiometricKeyProtection ||
+        token.biometricKeyStatus == BiometricPushKeyStatus.protected) {
+      return;
+    }
+    if (!supportsBiometricPushKeyProtection) {
+      throw const BiometricPushKeyException(
+        BiometricPushKeyManager.unsupportedCode,
+      );
+    }
+    final privateKey = token.privateTokenKey;
+    if (privateKey == null) {
+      throw const BiometricPushKeyException(
+        BiometricPushKeyManager.keyMissingCode,
+      );
+    }
+    final localization = globalContextSync == null
+        ? null
+        : AppLocalizations.of(globalContextSync!);
+    await _biometricPushKeyManager.protect(
+      tokenId: token.id,
+      privateKey: privateKey,
+      reason:
+          localization?.biometricPushKeyProtectReason ??
+          'Protect this Push token with strong biometrics',
+      cancelLabel: localization?.cancel ?? 'Cancel',
+      invalidateOnBiometricChange: token.invalidateOnBiometricChange,
+    );
   }
 
   Future<AsymmetricKeyPair<RSAPublicKey, RSAPrivateKey>>

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -189,7 +189,7 @@ Future<void> dragSortableOnAccept({
   final modifiedFolders = allSortables.whereType<TokenFolder>().toList();
   if (!ref.context.mounted) return;
   final futures = [
-    ref.read(tokenProvider.notifier).addOrReplaceTokens(modifiedTokens),
+    ref.read(tokenProvider.notifier).updateTokenPlacements(modifiedTokens),
     ref.read(tokenFolderProvider.notifier).addOrReplaceFolders(modifiedFolders),
   ];
   final draggingSortableProviderNotifier = ref.read(

--- a/lib/views/main_view/main_view_widgets/token_widgets/default_token_actions/default_delete_action.dart
+++ b/lib/views/main_view/main_view_widgets/token_widgets/default_token_actions/default_delete_action.dart
@@ -22,6 +22,7 @@ import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:privacyidea_authenticator/utils/view_utils.dart';
 
 import '../../../../../l10n/app_localizations.dart';
+import '../../../../../model/tokens/push_token.dart';
 import '../../../../../model/tokens/token.dart';
 import '../../../../../utils/customization/theme_extentions/action_theme.dart';
 import '../../../../../utils/lock_auth.dart';
@@ -53,6 +54,8 @@ class DefaultDeleteAction extends ConsumerSlideableAction {
           ? (_) async {
               final notifier = ref.read(tokenProvider.notifier);
               if (token.isLocked &&
+                  !(token is PushToken &&
+                      (token as PushToken).isBiometricKeyInvalidated) &&
                   !await lockAuthWithSettings(
                     ref: ref,
                     reason: (localization) => localization.deleteLockedToken,

--- a/lib/views/main_view/main_view_widgets/token_widgets/push_token_widgets/push_token_widget_tile.dart
+++ b/lib/views/main_view/main_view_widgets/token_widgets/push_token_widgets/push_token_widget_tile.dart
@@ -39,6 +39,12 @@ class PushTokenWidgetTile extends ConsumerWidget {
       key: Key('${token.hashCode}TokenWidgetTile'),
       token: token,
       title: token.label,
+      titleStyle: token.isBiometricKeyInvalidated
+          ? TextStyle(color: Theme.of(context).colorScheme.error)
+          : null,
+      additionalSubtitles: token.isBiometricKeyInvalidated
+          ? [AppLocalizations.of(context)!.biometricPushTokenInvalid]
+          : const [],
       semanticsLabel: AppLocalizations.of(context)!.containerSerial,
       trailing: FocusedItemAsOverlay(
         tooltipWhenFocused: AppLocalizations.of(
@@ -60,8 +66,18 @@ class PushTokenWidgetTile extends ConsumerWidget {
               .read(introductionNotifierProvider.notifier)
               .complete(Introduction.pollForChallenges);
         },
-        child: const CustomTrailing(
-          child: FittedBox(child: Icon(size: 100, Icons.notifications)),
+        child: CustomTrailing(
+          child: FittedBox(
+            child: Icon(
+              size: 100,
+              token.isBiometricKeyInvalidated
+                  ? Icons.gpp_bad
+                  : Icons.notifications,
+              color: token.isBiometricKeyInvalidated
+                  ? Theme.of(context).colorScheme.error
+                  : null,
+            ),
+          ),
         ),
       ),
     );

--- a/lib/widgets/dialog_widgets/push_request_dialogs/push_code_to_phone_dialog.dart
+++ b/lib/widgets/dialog_widgets/push_request_dialogs/push_code_to_phone_dialog.dart
@@ -124,7 +124,7 @@ class _PushCodeToPhoneDialogState extends ConsumerState<PushCodeToPhoneDialog> {
           ),
           const SizedBox(height: 24),
           PushActionButton(
-            onPressed: () async => widget.handleDiscard(context, ref),
+            onPressed: () => widget.handleLocalDismiss(context, ref),
             child: Text(localizations.done),
           ),
         ],

--- a/lib/widgets/dialog_widgets/push_request_dialogs/push_default_dialog.dart
+++ b/lib/widgets/dialog_widgets/push_request_dialogs/push_default_dialog.dart
@@ -72,7 +72,7 @@ class PushDefaultDialog extends ConsumerWidget with PushDialogMixin {
   }
 
   Future<void> _handleAccept(BuildContext context, WidgetRef ref) async {
-    await super.handleAccept<PushResultValue, PushResultDetail>(
+    await super.handleAccept(
       context,
       ref,
       onSuccess: _addCodeToPhonePushRequest,

--- a/lib/widgets/dialog_widgets/push_request_dialogs/push_request_dialog.dart
+++ b/lib/widgets/dialog_widgets/push_request_dialogs/push_request_dialog.dart
@@ -30,12 +30,14 @@ import '../../../../model/push_request/push_requests.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../model/api_results/pi_server_results/pi_server_result_detail.dart';
 import '../../../model/api_results/pi_server_results/pi_server_result_value.dart';
+import '../../../model/enums/force_biometric_option.dart';
 import '../../../model/pi_server_response.dart';
 import '../../../utils/customization/theme_extentions/push_request_theme.dart';
 import '../../../utils/lock_auth.dart';
 import '../../../utils/logger.dart';
 import '../../../utils/riverpod/riverpod_providers/generated_providers/push_request_provider.dart';
 import '../../../utils/riverpod/riverpod_providers/generated_providers/settings_notifier.dart';
+import '../../../utils/riverpod/riverpod_providers/state_providers/status_message_provider.dart';
 import '../../../utils/view_utils.dart';
 import '../default_dialog.dart';
 import 'widgets/push_decline_confirm_dialog.dart';
@@ -84,30 +86,37 @@ mixin PushDialogMixin {
   PushToken get token;
   PushRequest get pushRequest;
 
-  Future<void>
-  handleAccept<V extends PiServerResultValue, D extends PiServerResultDetail>(
+  Future<void> handleAccept(
     BuildContext context,
     WidgetRef ref, {
     String? answer,
-    Future<bool> Function(PiSuccessResponse<V, D>, WidgetRef ref)? onSuccess,
+    Future<bool> Function(
+      PiSuccessResponse<PushResultValue, PushResultDetail>,
+      WidgetRef ref,
+    )?
+    onSuccess,
   }) async {
+    if (!_ensureTokenIsValid(context, ref)) return;
     if (token.isLocked) {
-      final authenticated = await lockAuthWithSettings(
-        ref: ref,
-        reason: (l10n) => l10n.authToAcceptPushRequest,
-        localization: AppLocalizations.of(context)!,
-        forceBiometricOption: token.forceBiometricOption,
-      );
-      if (!context.mounted || !ref.context.mounted || !authenticated) {
+      final authenticated =
+          token.forceBiometricOption == ForceBiometricOption.biometric
+          ? true
+          : await lockAuthWithSettings(
+              ref: ref,
+              reason: (l10n) => l10n.authToAcceptPushRequest,
+              localization: AppLocalizations.of(context)!,
+              forceBiometricOption: token.forceBiometricOption,
+            );
+      if (!context.mounted || !authenticated) {
         return;
       }
     }
 
-    final PiSuccessResponse<V, D>? response;
+    final PiSuccessResponse<PushResultValue, PushResultDetail>? response;
     try {
       response = await ref
           .read(pushRequestProvider.notifier)
-          .accept<V, D>(token, pushRequest, selectedAnswer: answer);
+          .accept(token, pushRequest, selectedAnswer: answer);
     } catch (e) {
       Logger.error('Error accepting push request: $e');
       if (context.mounted) {
@@ -132,14 +141,18 @@ mixin PushDialogMixin {
   }
 
   Future<void> handleDecline(BuildContext context, WidgetRef ref) async {
+    if (!_ensureTokenIsValid(context, ref)) return;
     if (token.isLocked) {
-      final authenticated = await lockAuthWithSettings(
-        ref: ref,
-        reason: (l10n) => l10n.authToDeclinePushRequest,
-        localization: AppLocalizations.of(context)!,
-        forceBiometricOption: token.forceBiometricOption,
-      );
-      if (!context.mounted || !ref.context.mounted || !authenticated) {
+      final authenticated =
+          token.forceBiometricOption == ForceBiometricOption.biometric
+          ? true
+          : await lockAuthWithSettings(
+              ref: ref,
+              reason: (l10n) => l10n.authToDeclinePushRequest,
+              localization: AppLocalizations.of(context)!,
+              forceBiometricOption: token.forceBiometricOption,
+            );
+      if (!context.mounted || !authenticated) {
         return;
       }
     }
@@ -154,7 +167,9 @@ mixin PushDialogMixin {
   }
 
   Future<void> handleDiscard(BuildContext context, WidgetRef ref) async {
-    if (token.isHidden &&
+    if (!_ensureTokenIsValid(context, ref)) return;
+    if (token.isLocked &&
+        token.forceBiometricOption != ForceBiometricOption.biometric &&
         !await lockAuthWithSettings(
           ref: ref,
           reason: (l10n) => l10n.authToDiscardPushRequest,
@@ -163,22 +178,43 @@ mixin PushDialogMixin {
         )) {
       return;
     }
-    if (!ref.context.mounted) return;
     final response = await ref
         .read(pushRequestProvider.notifier)
         .cancel(token, pushRequest);
-    if (!ref.context.mounted) return;
+    if (!ref.context.mounted || response == null) return;
     if (context.mounted) {
       await _onHandled(context: context, ref: ref, response: response);
     }
   }
 
-  Future<void>
-  _onHandled<V extends PiServerResultValue, D extends PiServerResultDetail>({
+  Future<void> handleLocalDismiss(BuildContext context, WidgetRef ref) async {
+    final removed = await ref
+        .read(pushRequestProvider.notifier)
+        .remove(pushRequest);
+    if (!removed || !context.mounted || !ref.context.mounted) return;
+    await _onHandled(context: context, ref: ref);
+  }
+
+  bool _ensureTokenIsValid(BuildContext context, WidgetRef ref) {
+    if (!token.isBiometricKeyInvalidated) return true;
+    ref
+        .read(statusProvider.notifier)
+        .show(
+          (l) => l.biometricPushTokenInvalidTitle,
+          details: (l) => l.biometricPushTokenInvalidBody,
+        );
+    return false;
+  }
+
+  Future<void> _onHandled({
     required BuildContext context,
     required WidgetRef ref,
-    PiServerResponse<V, D>? response,
-    Future<bool> Function(PiSuccessResponse<V, D>, WidgetRef ref)? onSuccess,
+    PiServerResponse<PushResultValue, PushResultDetail>? response,
+    Future<bool> Function(
+      PiSuccessResponse<PushResultValue, PushResultDetail>,
+      WidgetRef ref,
+    )?
+    onSuccess,
   }) async {
     final onSuccessResult =
         (onSuccess != null && response != null && response.isSuccess)

--- a/lib/widgets/push_request_listener.dart
+++ b/lib/widgets/push_request_listener.dart
@@ -21,6 +21,8 @@ import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../model/push_request/push_request.dart';
+import '../model/tokens/push_token.dart';
 import '../utils/push_provider.dart';
 import '../utils/riverpod/riverpod_providers/generated_providers/push_request_provider.dart';
 import '../utils/riverpod/riverpod_providers/generated_providers/token_notifier.dart';
@@ -50,17 +52,17 @@ class _PushRequestListenerState extends ConsumerState<PushRequestListener> {
 
     if (pushTokens.isEmpty) return widget.child;
 
-    final pushRequest = ref
+    final candidate = ref
         .watch(pushRequestProvider)
-        .whenOrNull(data: (data) => data.pushRequests.lastOrNull);
+        .whenOrNull(
+          data: (data) => _latestActionableRequest(
+            pushRequests: data.pushRequests,
+            pushTokens: pushTokens,
+          ),
+        );
 
-    if (pushRequest == null) return widget.child;
-
-    final matchingToken = pushTokens.firstWhereOrNull(
-      (t) => t.serial == pushRequest.serial,
-    );
-
-    if (matchingToken == null) return widget.child;
+    if (candidate == null) return widget.child;
+    final (pushRequest, matchingToken) = candidate;
 
     return Stack(
       children: [
@@ -72,5 +74,20 @@ class _PushRequestListenerState extends ConsumerState<PushRequestListener> {
         ),
       ],
     );
+  }
+
+  (PushRequest, PushToken)? _latestActionableRequest({
+    required List<PushRequest> pushRequests,
+    required List<PushToken> pushTokens,
+  }) {
+    for (final pushRequest in pushRequests.reversed) {
+      final matchingToken = pushTokens.firstWhereOrNull(
+        (token) =>
+            token.serial == pushRequest.serial &&
+            !token.isBiometricKeyInvalidated,
+      );
+      if (matchingToken != null) return (pushRequest, matchingToken);
+    }
+    return null;
   }
 }

--- a/test/tests_app_wrapper.mocks.dart
+++ b/test/tests_app_wrapper.mocks.dart
@@ -905,6 +905,43 @@ class MockPrivacyideaIOClient extends _i1.Mock
 /// See the documentation for Mockito's code generation for more information.
 class MockRsaUtils extends _i1.Mock implements _i10.RsaUtils {
   @override
+  bool get supportsBiometricPushKeyProtection =>
+      (super.noSuchMethod(
+            Invocation.getter(#supportsBiometricPushKeyProtection),
+            returnValue: false,
+            returnValueForMissingStub: false,
+          )
+          as bool);
+
+  @override
+  _i24.Future<String> biometricPushKeyStatus(String? tokenId) =>
+      (super.noSuchMethod(
+            Invocation.method(#biometricPushKeyStatus, [tokenId]),
+            returnValue: _i24.Future<String>.value(
+              _i27.dummyValue<String>(
+                this,
+                Invocation.method(#biometricPushKeyStatus, [tokenId]),
+              ),
+            ),
+            returnValueForMissingStub: _i24.Future<String>.value(
+              _i27.dummyValue<String>(
+                this,
+                Invocation.method(#biometricPushKeyStatus, [tokenId]),
+              ),
+            ),
+          )
+          as _i24.Future<String>);
+
+  @override
+  _i24.Future<void> deleteBiometricPushKey(String? tokenId) =>
+      (super.noSuchMethod(
+            Invocation.method(#deleteBiometricPushKey, [tokenId]),
+            returnValue: _i24.Future<void>.value(),
+            returnValueForMissingStub: _i24.Future<void>.value(),
+          )
+          as _i24.Future<void>);
+
+  @override
   _i7.RSAPublicKey deserializeRSAPublicKeyPKCS1(String? keyStr) =>
       (super.noSuchMethod(
             Invocation.method(#deserializeRSAPublicKeyPKCS1, [keyStr]),
@@ -1014,14 +1051,28 @@ class MockRsaUtils extends _i1.Mock implements _i10.RsaUtils {
   @override
   _i24.Future<String?> trySignWithToken(
     _i31.PushToken? token,
-    String? message,
-  ) =>
+    String? message, {
+    _i24.Future<bool> Function(_i31.PushToken)? onTokenChanged,
+  }) =>
       (super.noSuchMethod(
-            Invocation.method(#trySignWithToken, [token, message]),
+            Invocation.method(
+              #trySignWithToken,
+              [token, message],
+              {#onTokenChanged: onTokenChanged},
+            ),
             returnValue: _i24.Future<String?>.value(),
             returnValueForMissingStub: _i24.Future<String?>.value(),
           )
           as _i24.Future<String?>);
+
+  @override
+  _i24.Future<void> protectBiometricPushKey(_i31.PushToken? token) =>
+      (super.noSuchMethod(
+            Invocation.method(#protectBiometricPushKey, [token]),
+            returnValue: _i24.Future<void>.value(),
+            returnValueForMissingStub: _i24.Future<void>.value(),
+          )
+          as _i24.Future<void>);
 
   @override
   _i24.Future<_i7.AsymmetricKeyPair<_i7.RSAPublicKey, _i7.RSAPrivateKey>>
@@ -2839,6 +2890,57 @@ class MockTokenNotifier extends _i1.Mock implements _i46.TokenNotifier {
           as _i24.Future<_i18.TokenState>);
 
   @override
+  _i24.Future<List<_i16.Token>> applyContainerSync({
+    required List<_i16.Token>? updatedTokens,
+    required List<_i16.Token>? newTokens,
+    List<_i16.Token>? deletedTokens = const [],
+    required Map<String, List<String>>? checkedContainersByTokenId,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#applyContainerSync, [], {
+              #updatedTokens: updatedTokens,
+              #newTokens: newTokens,
+              #deletedTokens: deletedTokens,
+              #checkedContainersByTokenId: checkedContainersByTokenId,
+            }),
+            returnValue: _i24.Future<List<_i16.Token>>.value(<_i16.Token>[]),
+            returnValueForMissingStub: _i24.Future<List<_i16.Token>>.value(
+              <_i16.Token>[],
+            ),
+          )
+          as _i24.Future<List<_i16.Token>>);
+
+  @override
+  _i24.Future<List<_i16.Token>> updateTokenPlacements(
+    List<_i16.Token>? placements,
+  ) =>
+      (super.noSuchMethod(
+            Invocation.method(#updateTokenPlacements, [placements]),
+            returnValue: _i24.Future<List<_i16.Token>>.value(<_i16.Token>[]),
+            returnValueForMissingStub: _i24.Future<List<_i16.Token>>.value(
+              <_i16.Token>[],
+            ),
+          )
+          as _i24.Future<List<_i16.Token>>);
+
+  @override
+  _i24.Future<R?> withCurrentPushTokenLease<R>(
+    String? tokenId,
+    _i24.Future<R?> Function(
+      _i31.PushToken,
+      _i24.Future<_i31.PushToken?> Function(_i31.PushToken),
+      _i31.PushToken Function(),
+    )?
+    operation,
+  ) =>
+      (super.noSuchMethod(
+            Invocation.method(#withCurrentPushTokenLease, [tokenId, operation]),
+            returnValue: _i24.Future<R?>.value(),
+            returnValueForMissingStub: _i24.Future<R?>.value(),
+          )
+          as _i24.Future<R?>);
+
+  @override
   _i24.Future<bool> addNewToken(_i16.Token? token) =>
       (super.noSuchMethod(
             Invocation.method(#addNewToken, [token]),
@@ -3420,10 +3522,10 @@ class MockPushRequestNotifier extends _i1.Mock
           as _i24.Future<_i4.PushRequestState>);
 
   @override
-  _i24.Future<_i54.PiSuccessResponse<T, D>?> accept<
-    T extends _i5.PiServerResultValue,
-    D extends _i55.PiServerResultDetail
-  >(
+  _i24.Future<
+    _i54.PiSuccessResponse<_i5.PushResultValue, _i55.PushResultDetail>?
+  >
+  accept(
     _i31.PushToken? token,
     _i28.PushRequest? request, {
     String? selectedAnswer,
@@ -3434,37 +3536,76 @@ class MockPushRequestNotifier extends _i1.Mock
               [token, request],
               {#selectedAnswer: selectedAnswer},
             ),
-            returnValue: _i24.Future<_i54.PiSuccessResponse<T, D>?>.value(),
+            returnValue:
+                _i24.Future<
+                  _i54.PiSuccessResponse<
+                    _i5.PushResultValue,
+                    _i55.PushResultDetail
+                  >?
+                >.value(),
             returnValueForMissingStub:
-                _i24.Future<_i54.PiSuccessResponse<T, D>?>.value(),
+                _i24.Future<
+                  _i54.PiSuccessResponse<
+                    _i5.PushResultValue,
+                    _i55.PushResultDetail
+                  >?
+                >.value(),
           )
-          as _i24.Future<_i54.PiSuccessResponse<T, D>?>);
+          as _i24.Future<
+            _i54.PiSuccessResponse<_i5.PushResultValue, _i55.PushResultDetail>?
+          >);
 
   @override
-  _i24.Future<_i54.PiSuccessResponse<T, D>?> decline<
-    T extends _i5.PiServerResultValue,
-    D extends _i55.PiServerResultDetail
-  >(_i31.PushToken? token, _i28.PushRequest? request) =>
+  _i24.Future<
+    _i54.PiSuccessResponse<_i5.PushResultValue, _i55.PushResultDetail>?
+  >
+  decline(_i31.PushToken? token, _i28.PushRequest? request) =>
       (super.noSuchMethod(
             Invocation.method(#decline, [token, request]),
-            returnValue: _i24.Future<_i54.PiSuccessResponse<T, D>?>.value(),
+            returnValue:
+                _i24.Future<
+                  _i54.PiSuccessResponse<
+                    _i5.PushResultValue,
+                    _i55.PushResultDetail
+                  >?
+                >.value(),
             returnValueForMissingStub:
-                _i24.Future<_i54.PiSuccessResponse<T, D>?>.value(),
+                _i24.Future<
+                  _i54.PiSuccessResponse<
+                    _i5.PushResultValue,
+                    _i55.PushResultDetail
+                  >?
+                >.value(),
           )
-          as _i24.Future<_i54.PiSuccessResponse<T, D>?>);
+          as _i24.Future<
+            _i54.PiSuccessResponse<_i5.PushResultValue, _i55.PushResultDetail>?
+          >);
 
   @override
-  _i24.Future<_i54.PiSuccessResponse<T, D>?> cancel<
-    T extends _i5.PiServerResultValue,
-    D extends _i55.PiServerResultDetail
-  >(_i31.PushToken? token, _i28.PushRequest? request) =>
+  _i24.Future<
+    _i54.PiSuccessResponse<_i5.PushResultValue, _i55.PushResultDetail>?
+  >
+  cancel(_i31.PushToken? token, _i28.PushRequest? request) =>
       (super.noSuchMethod(
             Invocation.method(#cancel, [token, request]),
-            returnValue: _i24.Future<_i54.PiSuccessResponse<T, D>?>.value(),
+            returnValue:
+                _i24.Future<
+                  _i54.PiSuccessResponse<
+                    _i5.PushResultValue,
+                    _i55.PushResultDetail
+                  >?
+                >.value(),
             returnValueForMissingStub:
-                _i24.Future<_i54.PiSuccessResponse<T, D>?>.value(),
+                _i24.Future<
+                  _i54.PiSuccessResponse<
+                    _i5.PushResultValue,
+                    _i55.PushResultDetail
+                  >?
+                >.value(),
           )
-          as _i24.Future<_i54.PiSuccessResponse<T, D>?>);
+          as _i24.Future<
+            _i54.PiSuccessResponse<_i5.PushResultValue, _i55.PushResultDetail>?
+          >);
 
   @override
   _i24.Future<bool> add(_i28.PushRequest? pr) =>

--- a/test/unit_test/model/tokens/push_token_test.dart
+++ b/test/unit_test/model/tokens/push_token_test.dart
@@ -21,6 +21,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:privacyidea_authenticator/model/enums/algorithms.dart';
 import 'package:privacyidea_authenticator/model/enums/day_password_token_view_mode.dart';
 import 'package:privacyidea_authenticator/model/enums/push_token_rollout_state.dart';
+import 'package:privacyidea_authenticator/model/enums/biometric_push_key_status.dart';
+import 'package:privacyidea_authenticator/model/enums/force_biometric_option.dart';
+import 'package:privacyidea_authenticator/model/enums/push_app_biometric_level.dart';
 import 'package:privacyidea_authenticator/model/exception_errors/localized_argument_error.dart';
 import 'package:privacyidea_authenticator/model/token_template.dart';
 import 'package:privacyidea_authenticator/model/tokens/day_password_token.dart';
@@ -120,6 +123,233 @@ void main() {
     test('isHidden is constant false for PushToken', () {
       final token = createPush().copyWith(isHidden: true);
       expect(token.isHidden, isFalse);
+    });
+
+    test('biometric key status survives JSON persistence', () {
+      final protected = createPush().copyWith(
+        privateTokenKey: () => null,
+        biometricKeyStatus: BiometricPushKeyStatus.protected,
+      );
+
+      final restored = PushToken.fromJson(protected.toJson());
+
+      expect(restored.privateTokenKey, isNull);
+      expect(restored.biometricKeyStatus, BiometricPushKeyStatus.protected);
+    });
+
+    test('old JSON defaults biometric key status to unprotected', () {
+      final restored = PushToken.fromJson({
+        'id': testId,
+        'type': 'PIPUSH',
+        'serial': testSerial,
+      });
+
+      expect(restored.biometricKeyStatus, BiometricPushKeyStatus.unprotected);
+    });
+
+    test('missing biometric policy fields fail closed for biometric Push', () {
+      final restored = PushToken.fromJson({
+        'id': testId,
+        'type': 'PIPUSH',
+        'serial': testSerial,
+        'forceBiometricOption': 'biometric',
+      });
+
+      expect(restored.biometricLevel, PushAppBiometricLevel.strong);
+      expect(restored.invalidateOnBiometricChange, isTrue);
+      expect(restored.requiresBiometricKeyProtection, isTrue);
+    });
+
+    test('accepts future server policy aliases from a Push enrollment URL', () {
+      final enrollmentMap =
+          createPush()
+              .copyWith(forceBiometricOption: ForceBiometricOption.biometric)
+              .toOtpAuthMap()
+            ..remove(PushToken.APP_BIOMETRIC_LEVEL)
+            ..remove(PushToken.APP_INVALIDATE_ON_BIOMETRIC_CHANGE)
+            ..[PushToken.PUSH_APP_BIOMETRIC_LEVEL] = 'any'
+            ..[PushToken.PUSH_APP_INVALIDATE_ON_BIOMETRIC_CHANGE] = 'false';
+
+      final restored = PushToken.fromOtpAuthMap(enrollmentMap);
+
+      expect(restored.biometricLevel, PushAppBiometricLevel.any);
+      expect(restored.invalidateOnBiometricChange, isFalse);
+      expect(restored.requiresBiometricKeyProtection, isFalse);
+    });
+
+    test('server policy aliases override stale app policy aliases', () {
+      final enrollmentMap =
+          createPush()
+              .copyWith(forceBiometricOption: ForceBiometricOption.biometric)
+              .toOtpAuthMap()
+            ..[PushToken.APP_BIOMETRIC_LEVEL] = 'any'
+            ..[PushToken.APP_INVALIDATE_ON_BIOMETRIC_CHANGE] = 'false'
+            ..[PushToken.PUSH_APP_BIOMETRIC_LEVEL] = 'strong'
+            ..[PushToken.PUSH_APP_INVALIDATE_ON_BIOMETRIC_CHANGE] = 'true';
+
+      final restored = PushToken.fromOtpAuthMap(enrollmentMap);
+
+      expect(restored.biometricLevel, PushAppBiometricLevel.strong);
+      expect(restored.invalidateOnBiometricChange, isTrue);
+    });
+
+    test('invalidation binding upgrades Android any to strong', () {
+      final token = PushToken(
+        serial: testSerial,
+        id: testId,
+        forceBiometricOption: ForceBiometricOption.biometric,
+        biometricLevel: PushAppBiometricLevel.any,
+        invalidateOnBiometricChange: true,
+      );
+
+      expect(token.requiresStrongBiometric, isTrue);
+      expect(token.requiresBiometricKeyProtection, isTrue);
+    });
+
+    test('a protected key remains native after policy relaxation', () {
+      final protected = createPush().copyWith(
+        forceBiometricOption: ForceBiometricOption.biometric,
+        biometricLevel: PushAppBiometricLevel.strong,
+        invalidateOnBiometricChange: false,
+        biometricKeyStatus: BiometricPushKeyStatus.protected,
+      );
+      final policy = protected.toOtpAuthMap()
+        ..[PushToken.APP_BIOMETRIC_LEVEL] = 'any'
+        ..[PushToken.APP_INVALIDATE_ON_BIOMETRIC_CHANGE] = 'false';
+
+      final updated =
+          protected.copyUpdateByTemplate(
+                TokenTemplate.withSerial(
+                  otpAuthMap: policy,
+                  serial: testSerial,
+                ),
+              )
+              as PushToken;
+
+      expect(updated.biometricLevel, PushAppBiometricLevel.any);
+      expect(updated.invalidateOnBiometricChange, isFalse);
+      expect(updated.biometricKeyStatus, BiometricPushKeyStatus.protected);
+      expect(updated.requiresStrongBiometric, isFalse);
+      expect(updated.requiresBiometricKeyProtection, isTrue);
+    });
+
+    test(
+      'tightening enrollment binding invalidates an existing native key',
+      () {
+        final protectedWithoutBinding = createPush().copyWith(
+          forceBiometricOption: ForceBiometricOption.biometric,
+          biometricLevel: PushAppBiometricLevel.strong,
+          invalidateOnBiometricChange: false,
+          biometricKeyStatus: BiometricPushKeyStatus.protected,
+        );
+        final policy = protectedWithoutBinding.toOtpAuthMap()
+          ..[PushToken.APP_INVALIDATE_ON_BIOMETRIC_CHANGE] = 'true';
+
+        final updated =
+            protectedWithoutBinding.copyUpdateByTemplate(
+                  TokenTemplate.withSerial(
+                    otpAuthMap: policy,
+                    serial: testSerial,
+                  ),
+                )
+                as PushToken;
+
+        expect(updated.invalidateOnBiometricChange, isTrue);
+        expect(updated.biometricKeyStatus, BiometricPushKeyStatus.invalidated);
+        expect(updated.privateTokenKey, isNull);
+      },
+    );
+
+    test('tightening protection keeps an enrollment key before rollout', () {
+      final before = createPush().copyWith(
+        forceBiometricOption: ForceBiometricOption.biometric,
+        biometricLevel: PushAppBiometricLevel.any,
+        invalidateOnBiometricChange: false,
+        privateTokenKey: () => 'legacy-private-key',
+      );
+      final policy = before.toOtpAuthMap()
+        ..[PushToken.PUSH_APP_BIOMETRIC_LEVEL] = 'strong'
+        ..[PushToken.PUSH_APP_INVALIDATE_ON_BIOMETRIC_CHANGE] = 'true';
+
+      final updated =
+          before.copyUpdateByTemplate(
+                TokenTemplate.withSerial(
+                  otpAuthMap: policy,
+                  serial: testSerial,
+                ),
+              )
+              as PushToken;
+
+      expect(updated.invalidateOnBiometricChange, isTrue);
+      expect(updated.biometricKeyStatus, BiometricPushKeyStatus.unprotected);
+      expect(updated.privateTokenKey, 'legacy-private-key');
+      expect(updated.requiresBiometricKeyProtection, isTrue);
+    });
+
+    test('tightening protection invalidates a deployed plaintext key', () {
+      final before = createPush().copyWith(
+        forceBiometricOption: ForceBiometricOption.biometric,
+        biometricLevel: PushAppBiometricLevel.any,
+        invalidateOnBiometricChange: false,
+        privateTokenKey: () => 'legacy-private-key',
+        isRolledOut: true,
+        rolloutState: PushTokenRollOutState.rolloutComplete,
+      );
+      final policy = before.toOtpAuthMap()
+        ..[PushToken.PUSH_APP_BIOMETRIC_LEVEL] = 'strong'
+        ..[PushToken.PUSH_APP_INVALIDATE_ON_BIOMETRIC_CHANGE] = 'false';
+
+      final updated =
+          before.copyUpdateByTemplate(
+                TokenTemplate.withSerial(
+                  otpAuthMap: policy,
+                  serial: testSerial,
+                ),
+              )
+              as PushToken;
+
+      expect(updated.requiresBiometricKeyProtection, isTrue);
+      expect(updated.biometricKeyStatus, BiometricPushKeyStatus.invalidated);
+      expect(updated.privateTokenKey, isNull);
+    });
+
+    test('a new deployed strong plaintext record fails closed', () {
+      final imported = createPush().copyWith(
+        forceBiometricOption: ForceBiometricOption.biometric,
+        biometricLevel: PushAppBiometricLevel.strong,
+        invalidateOnBiometricChange: true,
+        privateTokenKey: () => 'private-key',
+        isRolledOut: true,
+        rolloutState: PushTokenRollOutState.rolloutComplete,
+      );
+
+      final stored = imported.withFailClosedBiometricLifecycle();
+
+      expect(stored.biometricKeyStatus, BiometricPushKeyStatus.invalidated);
+      expect(stored.privateTokenKey, isNull);
+    });
+
+    test('stale writes preserve a protected native key pair', () {
+      final current = createPush().copyWith(
+        forceBiometricOption: ForceBiometricOption.biometric,
+        invalidateOnBiometricChange: true,
+        publicTokenKey: 'public-a',
+        privateTokenKey: () => null,
+        biometricKeyStatus: BiometricPushKeyStatus.protected,
+        isRolledOut: true,
+        rolloutState: PushTokenRollOutState.rolloutComplete,
+        fbToken: 'firebase-current',
+      );
+      final stale = createPush().copyWith(
+        forceBiometricOption: ForceBiometricOption.biometric,
+        invalidateOnBiometricChange: true,
+      );
+
+      final merged = stale.withMonotonicBiometricStateFrom(current);
+
+      expect(merged.biometricKeyStatus, BiometricPushKeyStatus.protected);
+      expect(merged.privateTokenKey, isNull);
+      expect(merged.publicTokenKey, 'public-a');
     });
   });
 

--- a/test/unit_test/repo/secure_token_repository_test.dart
+++ b/test/unit_test/repo/secure_token_repository_test.dart
@@ -24,6 +24,11 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:privacyidea_authenticator/model/enums/algorithms.dart';
+import 'package:privacyidea_authenticator/model/enums/biometric_push_key_status.dart';
+import 'package:privacyidea_authenticator/model/enums/force_biometric_option.dart';
+import 'package:privacyidea_authenticator/model/enums/push_app_biometric_level.dart';
+import 'package:privacyidea_authenticator/model/enums/push_token_rollout_state.dart';
+import 'package:privacyidea_authenticator/model/tokens/push_token.dart';
 import 'package:privacyidea_authenticator/model/tokens/totp_token.dart';
 import 'package:privacyidea_authenticator/repo/secure_storage.dart';
 import 'package:privacyidea_authenticator/repo/secure_token_repository.dart';
@@ -137,6 +142,12 @@ void main() {
       };
 
       when(mockLegacyStorage.readAll()).thenAnswer((_) async => legacyMap);
+      when(
+        mockStorage.read(key: '${newPrefix}_id1'),
+      ).thenAnswer((_) async => null);
+      when(
+        mockStorage.read(key: '${newPrefix}_id2'),
+      ).thenAnswer((_) async => null);
 
       when(
         mockStorage.write(key: '${newPrefix}_id1', value: anyNamed('value')),
@@ -156,6 +167,182 @@ void main() {
       verify(mockLegacyStorage.delete(key: '${legacyPrefix}_id2')).called(1);
       verifyNever(mockLegacyStorage.delete(key: '${legacyPrefix}_id1'));
     });
+
+    test('Migration never overwrites a token already in new storage', () async {
+      final legacy = createToken('id1');
+      final current = createToken('id1').copyWith(label: 'current');
+      final legacyMap = {'${legacyPrefix}_id1': jsonEncode(legacy.toJson())};
+      final currentJson = jsonEncode(current.toJson());
+
+      when(mockLegacyStorage.readAll()).thenAnswer((_) async => legacyMap);
+      when(
+        mockStorage.read(key: '${newPrefix}_id1'),
+      ).thenAnswer((_) async => currentJson);
+      when(
+        mockLegacyStorage.delete(key: '${legacyPrefix}_id1'),
+      ).thenAnswer((_) async {});
+      when(
+        mockStorage.readAll(),
+      ).thenAnswer((_) async => {'${newPrefix}_id1': currentJson});
+
+      final tokens = await repository.loadTokens();
+
+      expect(tokens.single.label, 'current');
+      verifyNever(
+        mockStorage.write(key: anyNamed('key'), value: anyNamed('value')),
+      );
+      verify(mockLegacyStorage.delete(key: '${legacyPrefix}_id1')).called(1);
+    });
+
+    test(
+      'Migration invalidates a rolled-out biometric Push token before writing legacy plaintext',
+      () async {
+        final legacy = PushToken(
+          id: 'push-id',
+          serial: 'PIPU0001',
+          label: 'Push',
+          issuer: 'privacyIDEA',
+          forceBiometricOption: ForceBiometricOption.biometric,
+          privateTokenKey: 'legacy-private-key',
+          publicTokenKey: 'public-key',
+          isRolledOut: true,
+          rolloutState: PushTokenRollOutState.rolloutComplete,
+        );
+        final legacyMap = {
+          '${legacyPrefix}_${legacy.id}': jsonEncode(legacy.toJson()),
+        };
+        String? migratedValue;
+
+        when(mockLegacyStorage.readAll()).thenAnswer((_) async => legacyMap);
+        when(
+          mockStorage.read(key: '${newPrefix}_${legacy.id}'),
+        ).thenAnswer((_) async => null);
+        when(
+          mockStorage.write(
+            key: '${newPrefix}_${legacy.id}',
+            value: anyNamed('value'),
+          ),
+        ).thenAnswer((invocation) async {
+          migratedValue = invocation.namedArguments[#value] as String;
+        });
+        when(
+          mockLegacyStorage.delete(key: '${legacyPrefix}_${legacy.id}'),
+        ).thenAnswer((_) async {});
+        when(mockStorage.readAll()).thenAnswer(
+          (_) async => migratedValue == null
+              ? <String, String>{}
+              : {'${newPrefix}_${legacy.id}': migratedValue!},
+        );
+
+        final tokens = await repository.loadTokens();
+
+        final migrated = tokens.single as PushToken;
+        expect(migrated.biometricKeyStatus, BiometricPushKeyStatus.invalidated);
+        expect(migrated.privateTokenKey, isNull);
+        expect(migrated.isRolledOut, isTrue);
+        final writtenJson = jsonDecode(migratedValue!) as Map<String, dynamic>;
+        expect(writtenJson['biometricKeyStatus'], 'invalidated');
+        expect(writtenJson['privateTokenKey'], isNull);
+        verify(
+          mockLegacyStorage.delete(key: '${legacyPrefix}_${legacy.id}'),
+        ).called(1);
+      },
+    );
+
+    test(
+      'Migration keeps an existing protected Push token instead of unsafe legacy plaintext',
+      () async {
+        final legacy = PushToken(
+          id: 'push-id',
+          serial: 'PIPU0001',
+          label: 'Legacy Push',
+          issuer: 'privacyIDEA',
+          forceBiometricOption: ForceBiometricOption.biometric,
+          privateTokenKey: 'legacy-private-key',
+          publicTokenKey: 'public-key',
+          isRolledOut: true,
+          rolloutState: PushTokenRollOutState.rolloutComplete,
+        );
+        final current = legacy.copyWith(
+          label: 'Current Push',
+          privateTokenKey: () => null,
+          biometricKeyStatus: BiometricPushKeyStatus.protected,
+        );
+        final legacyMap = {
+          '${legacyPrefix}_${legacy.id}': jsonEncode(legacy.toJson()),
+        };
+        final currentJson = jsonEncode(current.toJson());
+
+        when(mockLegacyStorage.readAll()).thenAnswer((_) async => legacyMap);
+        when(
+          mockStorage.read(key: '${newPrefix}_${legacy.id}'),
+        ).thenAnswer((_) async => currentJson);
+        when(
+          mockLegacyStorage.delete(key: '${legacyPrefix}_${legacy.id}'),
+        ).thenAnswer((_) async {});
+        when(
+          mockStorage.readAll(),
+        ).thenAnswer((_) async => {'${newPrefix}_${legacy.id}': currentJson});
+
+        final tokens = await repository.loadTokens();
+
+        final loaded = tokens.single as PushToken;
+        expect(loaded.label, 'Current Push');
+        expect(loaded.biometricKeyStatus, BiometricPushKeyStatus.protected);
+        expect(loaded.privateTokenKey, isNull);
+        verifyNever(
+          mockStorage.write(key: anyNamed('key'), value: anyNamed('value')),
+        );
+      },
+    );
+
+    test(
+      'Migration preserves an explicit weak-compatible biometric Push token',
+      () async {
+        final legacy = PushToken(
+          id: 'push-any-id',
+          serial: 'PIPU0002',
+          label: 'Push any',
+          issuer: 'privacyIDEA',
+          forceBiometricOption: ForceBiometricOption.biometric,
+          biometricLevel: PushAppBiometricLevel.any,
+          invalidateOnBiometricChange: false,
+          privateTokenKey: 'legacy-private-key',
+          publicTokenKey: 'public-key',
+          isRolledOut: true,
+          rolloutState: PushTokenRollOutState.rolloutComplete,
+        );
+        final legacyMap = {
+          '${legacyPrefix}_${legacy.id}': jsonEncode(legacy.toJson()),
+        };
+        String? migratedValue;
+
+        when(mockLegacyStorage.readAll()).thenAnswer((_) async => legacyMap);
+        when(
+          mockStorage.read(key: '${newPrefix}_${legacy.id}'),
+        ).thenAnswer((_) async => null);
+        when(
+          mockStorage.write(
+            key: '${newPrefix}_${legacy.id}',
+            value: anyNamed('value'),
+          ),
+        ).thenAnswer((invocation) async {
+          migratedValue = invocation.namedArguments[#value] as String;
+        });
+        when(
+          mockLegacyStorage.delete(key: '${legacyPrefix}_${legacy.id}'),
+        ).thenAnswer((_) async {});
+        when(mockStorage.readAll()).thenAnswer(
+          (_) async => {'${newPrefix}_${legacy.id}': migratedValue!},
+        );
+
+        final migrated = (await repository.loadTokens()).single as PushToken;
+
+        expect(migrated.requiresBiometricKeyProtection, isFalse);
+        expect(migrated.biometricKeyStatus, BiometricPushKeyStatus.unprotected);
+        expect(migrated.privateTokenKey, 'legacy-private-key');
+      },
+    );
 
     test('Migration skips entries without type field', () async {
       final invalidLegacyData = {

--- a/test/unit_test/state_notifiers/push_request_notifier_test.dart
+++ b/test/unit_test/state_notifiers/push_request_notifier_test.dart
@@ -1,13 +1,23 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart';
+import 'package:local_auth/local_auth.dart';
 import 'package:mockito/mockito.dart';
+import 'package:privacyidea_authenticator/l10n/app_localizations_en.dart';
+import 'package:privacyidea_authenticator/model/enums/biometric_push_key_status.dart';
+import 'package:privacyidea_authenticator/model/enums/force_biometric_option.dart';
+import 'package:privacyidea_authenticator/model/enums/push_app_biometric_level.dart';
 import 'package:privacyidea_authenticator/model/push_request/push_default_request.dart';
 import 'package:privacyidea_authenticator/model/riverpod_states/push_request_state.dart';
+import 'package:privacyidea_authenticator/model/riverpod_states/settings_state.dart';
 import 'package:privacyidea_authenticator/model/tokens/push_token.dart';
 import 'package:privacyidea_authenticator/utils/custom_int_buffer.dart';
+import 'package:privacyidea_authenticator/utils/biometric_push_key_manager.dart';
+import 'package:privacyidea_authenticator/utils/lock_auth.dart';
 import 'package:privacyidea_authenticator/utils/privacyidea_io_client.dart';
 import 'package:privacyidea_authenticator/utils/riverpod/riverpod_providers/generated_providers/push_request_provider.dart';
+import 'package:privacyidea_authenticator/utils/riverpod/riverpod_providers/generated_providers/settings_notifier.dart';
+import 'package:privacyidea_authenticator/utils/riverpod/riverpod_providers/generated_providers/token_notifier.dart';
 import 'package:privacyidea_authenticator/utils/riverpod/riverpod_providers/state_providers/status_message_provider.dart';
 
 import '../../tests_app_wrapper.mocks.dart';
@@ -17,7 +27,8 @@ const mockResponseBody = '''
   "id": 1,
   "jsonrpc": "2.0",
   "result": {
-    "status": true
+    "status": true,
+    "value": true
   },
   "time": 0.1,
   "version": "privacyIDEA 1.0",
@@ -31,10 +42,32 @@ void main() {
   _testPushRequestNotifier();
 }
 
+ProviderContainer _containerWithCurrentPushToken({PushToken? token}) {
+  final tokenRepo = MockTokenRepository();
+  final settingsRepo = MockSettingsRepository();
+  when(
+    tokenRepo.loadTokens(),
+  ).thenAnswer((_) async => [token ?? PushToken(serial: 'serial', id: 'id')]);
+  when(tokenRepo.saveOrReplaceToken(any)).thenAnswer((_) async => true);
+  when(tokenRepo.saveOrReplaceTokens(any)).thenAnswer((_) async => []);
+  when(settingsRepo.loadSettings()).thenAnswer(
+    (_) async => SettingsState(appAuthMethod: ForceBiometricOption.any),
+  );
+  when(settingsRepo.saveSettings(any)).thenAnswer((_) async => true);
+  return ProviderContainer(
+    overrides: [
+      settingsProvider.overrideWith(
+        () => SettingsNotifier(repoOverride: settingsRepo),
+      ),
+      tokenProvider.overrideWith(() => TokenNotifier(repoOverride: tokenRepo)),
+    ],
+  );
+}
+
 void _testPushRequestNotifier() {
   group('PushRequestNotifier', () {
     test('accept', () async {
-      final container = ProviderContainer();
+      final container = _containerWithCurrentPushToken();
       addTearDown(container.dispose);
       final mockIoClient = MockPrivacyideaIOClient();
       final mockPushProvider = MockPushProvider();
@@ -72,7 +105,11 @@ void _testPushRequestNotifier() {
       when(mockPushRepo.loadState()).thenAnswer((_) async => before);
       when(mockPushRepo.saveState(any)).thenAnswer((_) async {});
       when(
-        mockRsaUtils.trySignWithToken(any, any),
+        mockRsaUtils.trySignWithToken(
+          any,
+          any,
+          onTokenChanged: anyNamed('onTokenChanged'),
+        ),
       ).thenAnswer((_) async => 'signature');
       when(
         mockIoClient.doPost(
@@ -99,7 +136,13 @@ void _testPushRequestNotifier() {
 
       // Verify that necessary calls were triggered
       verify(mockPushRepo.loadState()).called(1);
-      verify(mockRsaUtils.trySignWithToken(any, any)).called(1);
+      verify(
+        mockRsaUtils.trySignWithToken(
+          any,
+          any,
+          onTokenChanged: anyNamed('onTokenChanged'),
+        ),
+      ).called(1);
       verify(
         mockIoClient.doPost(
           url: anyNamed('url'),
@@ -110,7 +153,7 @@ void _testPushRequestNotifier() {
       verify(mockPushRepo.saveState(any)).called(2);
     });
     test('decline', () async {
-      final container = ProviderContainer();
+      final container = _containerWithCurrentPushToken();
       addTearDown(container.dispose);
       final mockIoClient = MockPrivacyideaIOClient();
       final mockPushProvider = MockPushProvider();
@@ -143,7 +186,11 @@ void _testPushRequestNotifier() {
       when(mockPushRepo.loadState()).thenAnswer((_) async => before);
       when(mockPushRepo.saveState(any)).thenAnswer((_) async {});
       when(
-        mockRsaUtils.trySignWithToken(any, any),
+        mockRsaUtils.trySignWithToken(
+          any,
+          any,
+          onTokenChanged: anyNamed('onTokenChanged'),
+        ),
       ).thenAnswer((_) async => 'signature');
       when(
         mockIoClient.doPost(
@@ -161,7 +208,13 @@ void _testPushRequestNotifier() {
           .decline(PushToken(serial: 'serial', id: 'id'), pr);
       expect((await container.read(pushProvider.future)), after);
       verify(mockPushRepo.loadState()).called(1);
-      verify(mockRsaUtils.trySignWithToken(any, any)).called(1);
+      verify(
+        mockRsaUtils.trySignWithToken(
+          any,
+          any,
+          onTokenChanged: anyNamed('onTokenChanged'),
+        ),
+      ).called(1);
       verify(
         mockIoClient.doPost(
           url: anyNamed('url'),
@@ -172,8 +225,185 @@ void _testPushRequestNotifier() {
       verify(mockPushRepo.saveState(any)).called(2);
     });
 
+    test(
+      'weak biometric Push reaction authenticates inside the notifier before signing',
+      () async {
+        final weakToken = PushToken(
+          serial: 'serial',
+          id: 'id',
+          forceBiometricOption: ForceBiometricOption.biometric,
+          biometricLevel: PushAppBiometricLevel.any,
+          invalidateOnBiometricChange: false,
+          privateTokenKey: 'private-key',
+          isRolledOut: true,
+        );
+        final container = _containerWithCurrentPushToken(token: weakToken);
+        addTearDown(container.dispose);
+        final mockLocalAuth = MockLocalAuthentication();
+        when(mockLocalAuth.isDeviceSupported()).thenAnswer((_) async => true);
+        when(mockLocalAuth.canCheckBiometrics).thenAnswer((_) async => true);
+        when(
+          mockLocalAuth.getAvailableBiometrics(),
+        ).thenAnswer((_) async => [BiometricType.weak]);
+        when(
+          mockLocalAuth.authenticate(
+            localizedReason: anyNamed('localizedReason'),
+            biometricOnly: anyNamed('biometricOnly'),
+            authMessages: anyNamed('authMessages'),
+          ),
+        ).thenAnswer((_) async => false);
+        localAuthInstance = mockLocalAuth;
+        resetAuthMutex();
+        addTearDown(() {
+          localAuthInstance = LocalAuthentication();
+          resetAuthMutex();
+        });
+
+        final request = PushDefaultRequest(
+          title: 'title',
+          question: 'question',
+          uri: Uri.parse('http://example.com'),
+          nonce: 'nonce',
+          sslVerify: false,
+          expirationDate: DateTime.now().add(const Duration(minutes: 5)),
+          signature: 'signature',
+          serial: 'serial',
+        );
+        final before = PushRequestState(
+          pushRequests: [request],
+          knownPushRequests: CustomIntBuffer(list: [request.id]),
+        );
+        final mockIoClient = MockPrivacyideaIOClient();
+        final mockPushProvider = MockPushProvider();
+        final mockRsaUtils = MockRsaUtils();
+        final mockPushRepo = MockPushRequestRepository();
+        when(mockPushRepo.loadState()).thenAnswer((_) async => before);
+        when(mockPushRepo.saveState(any)).thenAnswer((_) async {});
+        final provider = pushRequestProviderOf(
+          ioClient: mockIoClient,
+          rsaUtils: mockRsaUtils,
+          pushProvider: mockPushProvider,
+          pushRepo: mockPushRepo,
+        );
+
+        await container.read(provider.future);
+        final response = await container
+            .read(provider.notifier)
+            .accept(weakToken, request);
+
+        expect(response, isNull);
+        expect((await container.read(provider.future)).pushRequests, [request]);
+        verify(
+          mockLocalAuth.authenticate(
+            localizedReason: anyNamed('localizedReason'),
+            biometricOnly: true,
+            authMessages: anyNamed('authMessages'),
+          ),
+        ).called(1);
+        verifyNever(
+          mockRsaUtils.trySignWithToken(
+            any,
+            any,
+            onTokenChanged: anyNamed('onTokenChanged'),
+          ),
+        );
+        verifyNever(
+          mockIoClient.doPost(
+            url: anyNamed('url'),
+            body: anyNamed('body'),
+            sslVerify: anyNamed('sslVerify'),
+          ),
+        );
+      },
+    );
+
+    test(
+      'native biometric Push reaction does not add a local_auth prompt',
+      () async {
+        final nativeToken = PushToken(
+          serial: 'serial',
+          id: 'id',
+          forceBiometricOption: ForceBiometricOption.biometric,
+          biometricKeyStatus: BiometricPushKeyStatus.protected,
+          publicTokenKey: 'public-key',
+          isRolledOut: true,
+        );
+        final container = _containerWithCurrentPushToken(token: nativeToken);
+        addTearDown(container.dispose);
+        final mockLocalAuth = MockLocalAuthentication();
+        localAuthInstance = mockLocalAuth;
+        resetAuthMutex();
+        addTearDown(() {
+          localAuthInstance = LocalAuthentication();
+          resetAuthMutex();
+        });
+
+        final request = PushDefaultRequest(
+          title: 'title',
+          question: 'question',
+          uri: Uri.parse('http://example.com'),
+          nonce: 'nonce',
+          sslVerify: false,
+          expirationDate: DateTime.now().add(const Duration(minutes: 5)),
+          signature: 'signature',
+          serial: 'serial',
+        );
+        final before = PushRequestState(
+          pushRequests: [request],
+          knownPushRequests: CustomIntBuffer(list: [request.id]),
+        );
+        final mockIoClient = MockPrivacyideaIOClient();
+        final mockPushProvider = MockPushProvider();
+        final mockRsaUtils = MockRsaUtils();
+        final mockPushRepo = MockPushRequestRepository();
+        when(mockPushRepo.loadState()).thenAnswer((_) async => before);
+        when(mockPushRepo.saveState(any)).thenAnswer((_) async {});
+        when(
+          mockRsaUtils.trySignWithToken(
+            any,
+            any,
+            onTokenChanged: anyNamed('onTokenChanged'),
+          ),
+        ).thenAnswer((_) async => 'signature');
+        when(
+          mockIoClient.doPost(
+            url: anyNamed('url'),
+            body: anyNamed('body'),
+            sslVerify: anyNamed('sslVerify'),
+          ),
+        ).thenAnswer((_) async => Response(mockResponseBody, 200));
+        final provider = pushRequestProviderOf(
+          ioClient: mockIoClient,
+          rsaUtils: mockRsaUtils,
+          pushProvider: mockPushProvider,
+          pushRepo: mockPushRepo,
+        );
+
+        await container.read(provider.future);
+        final response = await container
+            .read(provider.notifier)
+            .accept(nativeToken, request);
+
+        expect(response, isNotNull);
+        verifyNever(
+          mockLocalAuth.authenticate(
+            localizedReason: anyNamed('localizedReason'),
+            biometricOnly: anyNamed('biometricOnly'),
+            authMessages: anyNamed('authMessages'),
+          ),
+        );
+        verify(
+          mockRsaUtils.trySignWithToken(
+            any,
+            any,
+            onTokenChanged: anyNamed('onTokenChanged'),
+          ),
+        ).called(1);
+      },
+    );
+
     test('add', () async {
-      final container = ProviderContainer();
+      final container = _containerWithCurrentPushToken();
       addTearDown(container.dispose);
       final mockIoClient = MockPrivacyideaIOClient();
       final mockPushProvider = MockPushProvider();
@@ -213,7 +443,7 @@ void _testPushRequestNotifier() {
       expect((await container.read(pushProvider.future)), after);
     });
     test('remove', () async {
-      final container = ProviderContainer();
+      final container = _containerWithCurrentPushToken();
       addTearDown(container.dispose);
       final mockIoClient = MockPrivacyideaIOClient();
       final mockPushProvider = MockPushProvider();
@@ -255,9 +485,138 @@ void _testPushRequestNotifier() {
     });
 
     test(
+      'invalidated biometric key keeps the request pending and blocks the server response',
+      () async {
+        final container = _containerWithCurrentPushToken();
+        addTearDown(container.dispose);
+        final mockIoClient = MockPrivacyideaIOClient();
+        final mockPushProvider = MockPushProvider();
+        final mockRsaUtils = MockRsaUtils();
+        final mockPushRepo = MockPushRequestRepository();
+        final pushProvider = pushRequestProviderOf(
+          ioClient: mockIoClient,
+          rsaUtils: mockRsaUtils,
+          pushProvider: mockPushProvider,
+          pushRepo: mockPushRepo,
+        );
+        final request = PushDefaultRequest(
+          title: 'title',
+          question: 'question',
+          uri: Uri.parse('http://example.com'),
+          nonce: 'nonce',
+          sslVerify: false,
+          expirationDate: DateTime.now().add(const Duration(minutes: 5)),
+          signature: 'signature',
+          serial: 'serial',
+        );
+        final before = PushRequestState(
+          pushRequests: [request],
+          knownPushRequests: CustomIntBuffer(list: [request.id]),
+        );
+        when(mockPushRepo.loadState()).thenAnswer((_) async => before);
+        when(mockPushRepo.saveState(any)).thenAnswer((_) async {});
+        when(
+          mockRsaUtils.trySignWithToken(
+            any,
+            any,
+            onTokenChanged: anyNamed('onTokenChanged'),
+          ),
+        ).thenThrow(
+          const BiometricPushKeyException(
+            BiometricPushKeyManager.invalidatedCode,
+          ),
+        );
+
+        await container.read(pushProvider.future);
+        final response = await container
+            .read(pushProvider.notifier)
+            .accept(PushToken(serial: 'serial', id: 'id'), request);
+
+        expect(response, isNull);
+        expect((await container.read(pushProvider.future)).pushRequests, [
+          request,
+        ]);
+        expect(container.read(statusProvider).current, isNotNull);
+        verifyNever(
+          mockIoClient.doPost(
+            url: anyNamed('url'),
+            body: anyNamed('body'),
+            sslVerify: anyNamed('sslVerify'),
+          ),
+        );
+      },
+    );
+
+    test(
+      'accept keeps the request pending when the server returns value false',
+      () async {
+        final container = _containerWithCurrentPushToken();
+        addTearDown(container.dispose);
+        final mockIoClient = MockPrivacyideaIOClient();
+        final mockPushProvider = MockPushProvider();
+        final mockRsaUtils = MockRsaUtils();
+        final mockPushRepo = MockPushRequestRepository();
+        final provider = pushRequestProviderOf(
+          ioClient: mockIoClient,
+          rsaUtils: mockRsaUtils,
+          pushProvider: mockPushProvider,
+          pushRepo: mockPushRepo,
+        );
+        final request = PushDefaultRequest(
+          title: 'title',
+          question: 'question',
+          uri: Uri.parse('http://example.com'),
+          nonce: 'nonce',
+          sslVerify: false,
+          expirationDate: DateTime.now().add(const Duration(minutes: 5)),
+          signature: 'signature',
+          serial: 'serial',
+        );
+        final before = PushRequestState(
+          pushRequests: [request],
+          knownPushRequests: CustomIntBuffer(list: [request.id]),
+        );
+        when(mockPushRepo.loadState()).thenAnswer((_) async => before);
+        when(mockPushRepo.saveState(any)).thenAnswer((_) async {});
+        when(
+          mockRsaUtils.trySignWithToken(
+            any,
+            any,
+            onTokenChanged: anyNamed('onTokenChanged'),
+          ),
+        ).thenAnswer((_) async => 'signature');
+        when(
+          mockIoClient.doPost(
+            url: anyNamed('url'),
+            body: anyNamed('body'),
+            sslVerify: anyNamed('sslVerify'),
+          ),
+        ).thenAnswer(
+          (_) async => Response(
+            '{"result":{"status":true,"value":false},'
+            '"version":"privacyIDEA 1.0"}',
+            200,
+          ),
+        );
+
+        await container.read(provider.future);
+        final response = await container
+            .read(provider.notifier)
+            .accept(PushToken(serial: 'serial', id: 'id'), request);
+
+        expect(response, isNull);
+        expect((await container.read(provider.future)).pushRequests, [request]);
+        expect(
+          container.read(statusProvider).current!.message(AppLocalizationsEn()),
+          AppLocalizationsEn().pushRequestResponseRejected,
+        );
+      },
+    );
+
+    test(
       'accept does not retry when the server returns a real (non-connection-failure) response',
       () async {
-        final container = ProviderContainer();
+        final container = _containerWithCurrentPushToken();
         addTearDown(container.dispose);
         final mockIoClient = MockPrivacyideaIOClient();
         final mockPushProvider = MockPushProvider();
@@ -289,7 +648,11 @@ void _testPushRequestNotifier() {
         when(mockPushRepo.loadState()).thenAnswer((_) async => before);
         when(mockPushRepo.saveState(any)).thenAnswer((_) async {});
         when(
-          mockRsaUtils.trySignWithToken(any, any),
+          mockRsaUtils.trySignWithToken(
+            any,
+            any,
+            onTokenChanged: anyNamed('onTokenChanged'),
+          ),
         ).thenAnswer((_) async => 'signature');
         // A real server response with a non-2xx status but a body that isn't
         // marked as a connection failure must NOT trigger a retry, even
@@ -320,7 +683,7 @@ void _testPushRequestNotifier() {
     test(
       'accept retries exactly once after a connection failure and succeeds if the retry works',
       () async {
-        final container = ProviderContainer();
+        final container = _containerWithCurrentPushToken();
         addTearDown(container.dispose);
         final mockIoClient = MockPrivacyideaIOClient();
         final mockPushProvider = MockPushProvider();
@@ -356,7 +719,11 @@ void _testPushRequestNotifier() {
         when(mockPushRepo.loadState()).thenAnswer((_) async => before);
         when(mockPushRepo.saveState(any)).thenAnswer((_) async {});
         when(
-          mockRsaUtils.trySignWithToken(any, any),
+          mockRsaUtils.trySignWithToken(
+            any,
+            any,
+            onTokenChanged: anyNamed('onTokenChanged'),
+          ),
         ).thenAnswer((_) async => 'signature');
 
         var callCount = 0;
@@ -397,7 +764,7 @@ void _testPushRequestNotifier() {
     test(
       'accept gives up after the retry also fails, restores the pending request and shows a status message',
       () async {
-        final container = ProviderContainer();
+        final container = _containerWithCurrentPushToken();
         addTearDown(container.dispose);
         final mockIoClient = MockPrivacyideaIOClient();
         final mockPushProvider = MockPushProvider();
@@ -429,7 +796,11 @@ void _testPushRequestNotifier() {
         when(mockPushRepo.loadState()).thenAnswer((_) async => before);
         when(mockPushRepo.saveState(any)).thenAnswer((_) async {});
         when(
-          mockRsaUtils.trySignWithToken(any, any),
+          mockRsaUtils.trySignWithToken(
+            any,
+            any,
+            onTokenChanged: anyNamed('onTokenChanged'),
+          ),
         ).thenAnswer((_) async => 'signature');
         // Both the first attempt and the retry fail to connect.
         when(

--- a/test/unit_test/state_notifiers/token_container_notifier_test.dart
+++ b/test/unit_test/state_notifiers/token_container_notifier_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:collection/collection.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -17,6 +18,7 @@ import 'package:privacyidea_authenticator/model/riverpod_states/settings_state.d
 import 'package:privacyidea_authenticator/model/riverpod_states/token_container_state.dart';
 import 'package:privacyidea_authenticator/model/riverpod_states/token_state.dart';
 import 'package:privacyidea_authenticator/model/token_container.dart';
+import 'package:privacyidea_authenticator/model/token_import/token_origin_data.dart';
 import 'package:privacyidea_authenticator/model/tokens/hotp_token.dart';
 import 'package:privacyidea_authenticator/model/tokens/token.dart';
 import 'package:privacyidea_authenticator/model/tokens/totp_token.dart';
@@ -507,7 +509,6 @@ void main() {
     test('deleteContainer', () async {
       // prepare
       TestWidgetsFlutterBinding.ensureInitialized();
-      final container = ProviderContainer();
       var containerRepoState = buildUnfinalizedContainerState();
       final mockContainerRepo = setupMockContainerRepo(
         () => containerRepoState,
@@ -555,6 +556,17 @@ void main() {
         containerApi: mockContainerApi,
         eccUtils: EccUtils(),
       );
+      final mockTokenRepo = MockTokenRepository();
+      when(mockTokenRepo.loadTokens()).thenAnswer((_) async => []);
+      when(mockTokenRepo.deleteTokens(any)).thenAnswer((_) async => []);
+      final container = ProviderContainer(
+        overrides: [
+          tokenProvider.overrideWith(
+            () => TokenNotifier(repoOverride: mockTokenRepo),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
       await container.read(tokenContainerProvider.future);
       // act
       await container
@@ -919,7 +931,7 @@ void main() {
                 containerSerial: "CONTAINER01",
                 algorithm: Algorithms.SHA256,
                 digits: 6,
-                secret: "SECRET01",
+                secret: "JBSWY3DPEHPK3PXP",
                 counter: 8,
               ),
             ],
@@ -962,7 +974,7 @@ void main() {
             containerSerial: "CONTAINER01",
             algorithm: Algorithms.SHA256,
             digits: 8,
-            secret: "SECRET01",
+            secret: "JBSWY3DPEHPK3PXP",
             counter: 10,
           ),
           "ID02": HOTPToken(
@@ -993,6 +1005,13 @@ void main() {
             repoTokens[token.id] = token;
           }
           return Future.value([]);
+        });
+        when(mockTokenRepo.deleteTokens(any)).thenAnswer((invocation) async {
+          final tokens = invocation.positionalArguments[0] as List<Token>;
+          for (final token in tokens) {
+            repoTokens.remove(token.id);
+          }
+          return <Token>[];
         });
 
         final mockTokenNotifier = TokenNotifier(repoOverride: mockTokenRepo);
@@ -1040,7 +1059,7 @@ void main() {
               containerSerial: "CONTAINER01",
               algorithm: Algorithms.SHA256,
               digits: 6,
-              secret: "SECRET01",
+              secret: "JBSWY3DPEHPK3PXP",
               counter: 8,
             ),
             TOTPToken(
@@ -1092,6 +1111,897 @@ void main() {
           unorderedEquals(expectedStateUnordered.tokens),
         );
       });
+
+      test(
+        'ignores an in-flight sync response after local container deletion',
+        () async {
+          var containerRepoState = buildFinalizedContainerState();
+          final containerToDelete =
+              containerRepoState.containerList.single
+                  as TokenContainerFinalized;
+          final syncStarted = Completer<void>();
+          final syncResponse = Completer<ContainerSyncUpdates?>();
+          final mockContainerApi = MockTokenContainerApi();
+          when(
+            mockContainerApi.sync(any, any, isInitSync: anyNamed('isInitSync')),
+          ).thenAnswer((_) {
+            syncStarted.complete();
+            return syncResponse.future;
+          });
+          final mockContainerRepo = setupMockContainerRepo(
+            () => containerRepoState,
+            (state) => containerRepoState = state,
+          );
+          final mockTokenRepo = MockTokenRepository();
+          when(mockTokenRepo.loadTokens()).thenAnswer((_) async => []);
+          when(mockTokenRepo.deleteTokens(any)).thenAnswer((_) async => []);
+          when(
+            mockTokenRepo.saveOrReplaceTokens(any),
+          ).thenAnswer((_) async => []);
+          final mockSettingsRepo = MockSettingsRepository();
+          when(
+            mockSettingsRepo.loadSettings(),
+          ).thenAnswer((_) async => SettingsState());
+          final providerContainer = ProviderContainer(
+            overrides: [
+              tokenContainerProvider.overrideWith(
+                () => TokenContainerNotifier(
+                  repoOverride: mockContainerRepo,
+                  containerApiOverride: mockContainerApi,
+                  eccUtilsOverride: EccUtils(),
+                ),
+              ),
+              tokenProvider.overrideWith(
+                () => TokenNotifier(repoOverride: mockTokenRepo),
+              ),
+              settingsProvider.overrideWith(
+                () => SettingsNotifier(repoOverride: mockSettingsRepo),
+              ),
+            ],
+          );
+          addTearDown(providerContainer.dispose);
+          final tokenState = await providerContainer.read(tokenProvider.future);
+          await providerContainer.read(tokenContainerProvider.future);
+
+          final syncFuture = providerContainer
+              .read(tokenContainerProvider.notifier)
+              .syncContainers(
+                tokenState: tokenState,
+                isManually: false,
+                isInitSync: false,
+              );
+          await syncStarted.future;
+          final deleted = await providerContainer
+              .read(tokenContainerProvider.notifier)
+              .deleteContainer(containerToDelete);
+          syncResponse.complete(
+            ContainerSyncUpdates(
+              containerSerial: containerToDelete.serial,
+              newTokens: [
+                TOTPToken(
+                  id: 'orphan-id',
+                  serial: 'TOTP-ORPHAN',
+                  containerSerial: containerToDelete.serial,
+                  algorithm: Algorithms.SHA256,
+                  digits: 6,
+                  period: 30,
+                  secret: 'JBSWY3DPEHPK3PXP',
+                ),
+              ],
+              updatedTokens: const [],
+              deletedTokens: const [],
+              initAssignmentChecked: const [],
+              newPolicies: ContainerPolicies(
+                rolloverAllowed: false,
+                initialTokenAssignment: false,
+                disabledTokenDeletion: false,
+                disabledUnregister: false,
+              ),
+            ),
+          );
+          await syncFuture;
+
+          expect(deleted, isTrue);
+          expect(
+            (await providerContainer.read(
+              tokenContainerProvider.future,
+            )).containerList,
+            isEmpty,
+          );
+          expect(
+            (await providerContainer.read(tokenProvider.future)).tokens,
+            isEmpty,
+          );
+          verifyNever(mockTokenRepo.saveOrReplaceTokens(any));
+        },
+      );
+
+      test(
+        'marks sync failed and preserves policies when token updates cannot be saved',
+        () async {
+          TestWidgetsFlutterBinding.ensureInitialized();
+          var containerRepoState = buildFinalizedContainerState();
+          final originalContainer =
+              containerRepoState.containerList.single
+                  as TokenContainerFinalized;
+          final mockContainerApi = MockTokenContainerApi();
+          final currentToken = HOTPToken(
+            id: 'ID01',
+            serial: 'HOTPTOKEN01',
+            containerSerial: originalContainer.serial,
+            algorithm: Algorithms.SHA256,
+            digits: 6,
+            secret: 'JBSWY3DPEHPK3PXP',
+            counter: 10,
+          );
+          when(
+            mockContainerApi.sync(any, any, isInitSync: anyNamed('isInitSync')),
+          ).thenAnswer(
+            (_) async => ContainerSyncUpdates(
+              containerSerial: originalContainer.serial,
+              newTokens: const [],
+              updatedTokens: [currentToken.copyWith(counter: 11)],
+              deletedTokens: const [],
+              initAssignmentChecked: const [],
+              newPolicies: ContainerPolicies(
+                rolloverAllowed: true,
+                initialTokenAssignment: true,
+                disabledTokenDeletion: false,
+                disabledUnregister: false,
+              ),
+            ),
+          );
+          final mockContainerRepo = setupMockContainerRepo(
+            () => containerRepoState,
+            (state) => containerRepoState = state,
+          );
+          final mockTokenRepo = MockTokenRepository();
+          when(
+            mockTokenRepo.loadTokens(),
+          ).thenAnswer((_) async => [currentToken]);
+          when(mockTokenRepo.saveOrReplaceTokens(any)).thenAnswer((
+            invocation,
+          ) async {
+            return List<Token>.from(
+              invocation.positionalArguments.single as List<Token>,
+            );
+          });
+          final mockSettingsRepo = MockSettingsRepository();
+          when(
+            mockSettingsRepo.loadSettings(),
+          ).thenAnswer((_) async => SettingsState());
+          final providerContainer = ProviderContainer(
+            overrides: [
+              tokenContainerProvider.overrideWith(
+                () => TokenContainerNotifier(
+                  repoOverride: mockContainerRepo,
+                  containerApiOverride: mockContainerApi,
+                  eccUtilsOverride: EccUtils(),
+                ),
+              ),
+              tokenProvider.overrideWith(
+                () => TokenNotifier(repoOverride: mockTokenRepo),
+              ),
+              settingsProvider.overrideWith(
+                () => SettingsNotifier(repoOverride: mockSettingsRepo),
+              ),
+            ],
+          );
+          addTearDown(providerContainer.dispose);
+          final tokenState = await providerContainer.read(tokenProvider.future);
+
+          await providerContainer
+              .read(tokenContainerProvider.notifier)
+              .syncContainers(
+                tokenState: tokenState,
+                isManually: false,
+                isInitSync: false,
+              );
+
+          final state = await providerContainer.read(
+            tokenContainerProvider.future,
+          );
+          final failedContainer =
+              state.containerList.single as TokenContainerFinalized;
+          final unchangedToken =
+              (await providerContainer.read(tokenProvider.future)).tokens.single
+                  as HOTPToken;
+          expect(failedContainer.syncState, SyncState.failed);
+          expect(failedContainer.initSynced, isFalse);
+          expect(failedContainer.policies, originalContainer.policies);
+          expect(unchangedToken.counter, currentToken.counter);
+        },
+      );
+
+      test(
+        'marks sync failed and preserves policies when token deletion fails',
+        () async {
+          TestWidgetsFlutterBinding.ensureInitialized();
+          var containerRepoState = buildFinalizedContainerState();
+          final originalContainer =
+              containerRepoState.containerList.single
+                  as TokenContainerFinalized;
+          final mockContainerApi = MockTokenContainerApi();
+          final currentToken = HOTPToken(
+            id: 'ID01',
+            serial: 'HOTPTOKEN01',
+            containerSerial: originalContainer.serial,
+            algorithm: Algorithms.SHA256,
+            digits: 6,
+            secret: 'JBSWY3DPEHPK3PXP',
+            counter: 10,
+          );
+          when(
+            mockContainerApi.sync(any, any, isInitSync: anyNamed('isInitSync')),
+          ).thenAnswer(
+            (_) async => ContainerSyncUpdates(
+              containerSerial: originalContainer.serial,
+              newTokens: const [],
+              updatedTokens: const [],
+              deletedTokens: [currentToken],
+              initAssignmentChecked: const [],
+              newPolicies: ContainerPolicies(
+                rolloverAllowed: true,
+                initialTokenAssignment: true,
+                disabledTokenDeletion: false,
+                disabledUnregister: false,
+              ),
+            ),
+          );
+          final mockContainerRepo = setupMockContainerRepo(
+            () => containerRepoState,
+            (state) => containerRepoState = state,
+          );
+          final mockTokenRepo = MockTokenRepository();
+          when(
+            mockTokenRepo.loadTokens(),
+          ).thenAnswer((_) async => [currentToken]);
+          when(mockTokenRepo.deleteTokens(any)).thenAnswer((invocation) async {
+            return List<Token>.from(
+              invocation.positionalArguments.single as List<Token>,
+            );
+          });
+          final mockSettingsRepo = MockSettingsRepository();
+          when(
+            mockSettingsRepo.loadSettings(),
+          ).thenAnswer((_) async => SettingsState());
+          final providerContainer = ProviderContainer(
+            overrides: [
+              tokenContainerProvider.overrideWith(
+                () => TokenContainerNotifier(
+                  repoOverride: mockContainerRepo,
+                  containerApiOverride: mockContainerApi,
+                  eccUtilsOverride: EccUtils(),
+                ),
+              ),
+              tokenProvider.overrideWith(
+                () => TokenNotifier(repoOverride: mockTokenRepo),
+              ),
+              settingsProvider.overrideWith(
+                () => SettingsNotifier(repoOverride: mockSettingsRepo),
+              ),
+            ],
+          );
+          addTearDown(providerContainer.dispose);
+          final tokenState = await providerContainer.read(tokenProvider.future);
+
+          await providerContainer
+              .read(tokenContainerProvider.notifier)
+              .syncContainers(
+                tokenState: tokenState,
+                isManually: false,
+                isInitSync: false,
+              );
+
+          final state = await providerContainer.read(
+            tokenContainerProvider.future,
+          );
+          final failedContainer =
+              state.containerList.single as TokenContainerFinalized;
+          final tokens = (await providerContainer.read(
+            tokenProvider.future,
+          )).tokens;
+          expect(failedContainer.syncState, SyncState.failed);
+          expect(failedContainer.initSynced, isFalse);
+          expect(failedContainer.policies, originalContainer.policies);
+          expect(tokens.single.id, currentToken.id);
+        },
+      );
+
+      test(
+        'ignores a response when the container is deleted during the network request',
+        () async {
+          TestWidgetsFlutterBinding.ensureInitialized();
+          var containerRepoState = buildFinalizedContainerState();
+          final originalContainer =
+              containerRepoState.containerList.single
+                  as TokenContainerFinalized;
+          final syncStarted = Completer<void>();
+          final syncResponse = Completer<ContainerSyncUpdates?>();
+          final mockContainerApi = MockTokenContainerApi();
+          when(
+            mockContainerApi.sync(any, any, isInitSync: anyNamed('isInitSync')),
+          ).thenAnswer((_) {
+            if (!syncStarted.isCompleted) syncStarted.complete();
+            return syncResponse.future;
+          });
+          final mockContainerRepo = setupMockContainerRepo(
+            () => containerRepoState,
+            (state) => containerRepoState = state,
+          );
+          final mockTokenRepo = MockTokenRepository();
+          when(mockTokenRepo.loadTokens()).thenAnswer((_) async => <Token>[]);
+          final mockSettingsRepo = MockSettingsRepository();
+          when(
+            mockSettingsRepo.loadSettings(),
+          ).thenAnswer((_) async => SettingsState());
+          final providerContainer = ProviderContainer(
+            overrides: [
+              tokenContainerProvider.overrideWith(
+                () => TokenContainerNotifier(
+                  repoOverride: mockContainerRepo,
+                  containerApiOverride: mockContainerApi,
+                  eccUtilsOverride: EccUtils(),
+                ),
+              ),
+              tokenProvider.overrideWith(
+                () => TokenNotifier(repoOverride: mockTokenRepo),
+              ),
+              settingsProvider.overrideWith(
+                () => SettingsNotifier(repoOverride: mockSettingsRepo),
+              ),
+            ],
+          );
+          addTearDown(providerContainer.dispose);
+          final tokenState = await providerContainer.read(tokenProvider.future);
+          final notifier = providerContainer.read(
+            tokenContainerProvider.notifier,
+          );
+
+          final syncFuture = notifier.syncContainers(
+            tokenState: tokenState,
+            isManually: false,
+            isInitSync: false,
+          );
+          await syncStarted.future;
+
+          expect(await notifier.deleteContainer(originalContainer), isTrue);
+          expect(
+            (await providerContainer.read(
+              tokenContainerProvider.future,
+            )).containerList,
+            isEmpty,
+          );
+
+          syncResponse.complete(
+            ContainerSyncUpdates(
+              containerSerial: originalContainer.serial,
+              newTokens: [
+                TOTPToken(
+                  id: 'orphan-id',
+                  serial: 'ORPHAN01',
+                  period: 30,
+                  algorithm: Algorithms.SHA256,
+                  digits: 6,
+                  secret: 'SECRET',
+                ),
+              ],
+              updatedTokens: const [],
+              deletedTokens: const [],
+              initAssignmentChecked: const [],
+              newPolicies: ContainerPolicies.defaultSetting,
+            ),
+          );
+          await syncFuture;
+
+          expect(
+            (await providerContainer.read(tokenProvider.future)).tokens,
+            isEmpty,
+          );
+          expect(
+            (await providerContainer.read(
+              tokenContainerProvider.future,
+            )).containerList,
+            isEmpty,
+          );
+          verifyNever(mockTokenRepo.saveOrReplaceTokens(any));
+        },
+      );
+
+      test(
+        'discards an in-flight sync response after unregister fails',
+        () async {
+          TestWidgetsFlutterBinding.ensureInitialized();
+          var containerRepoState = buildFinalizedContainerState();
+          final originalContainer =
+              containerRepoState.containerList.single
+                  as TokenContainerFinalized;
+          final firstSyncStarted = Completer<void>();
+          final firstSyncResponse = Completer<ContainerSyncUpdates?>();
+          final unregisterStarted = Completer<void>();
+          final unregisterResponse = Completer<UnregisterContainerResult>();
+          final mockContainerApi = MockTokenContainerApi();
+          var syncCalls = 0;
+          ContainerSyncUpdates successfulResponse() => ContainerSyncUpdates(
+            containerSerial: originalContainer.serial,
+            newTokens: const [],
+            updatedTokens: const [],
+            deletedTokens: const [],
+            initAssignmentChecked: const [],
+            newPolicies: originalContainer.policies,
+          );
+          when(
+            mockContainerApi.sync(any, any, isInitSync: anyNamed('isInitSync')),
+          ).thenAnswer((_) {
+            syncCalls++;
+            if (syncCalls == 1) {
+              firstSyncStarted.complete();
+              return firstSyncResponse.future;
+            }
+            return Future.value(successfulResponse());
+          });
+          when(mockContainerApi.unregister(any)).thenAnswer((_) {
+            unregisterStarted.complete();
+            return unregisterResponse.future;
+          });
+          final mockContainerRepo = setupMockContainerRepo(
+            () => containerRepoState,
+            (state) => containerRepoState = state,
+          );
+          final mockTokenRepo = MockTokenRepository();
+          when(mockTokenRepo.loadTokens()).thenAnswer((_) async => <Token>[]);
+          when(
+            mockTokenRepo.saveOrReplaceTokens(any),
+          ).thenAnswer((_) async => <Token>[]);
+          final mockSettingsRepo = MockSettingsRepository();
+          when(
+            mockSettingsRepo.loadSettings(),
+          ).thenAnswer((_) async => SettingsState());
+          final providerContainer = ProviderContainer(
+            overrides: [
+              tokenContainerProvider.overrideWith(
+                () => TokenContainerNotifier(
+                  repoOverride: mockContainerRepo,
+                  containerApiOverride: mockContainerApi,
+                  eccUtilsOverride: EccUtils(),
+                ),
+              ),
+              tokenProvider.overrideWith(
+                () => TokenNotifier(repoOverride: mockTokenRepo),
+              ),
+              settingsProvider.overrideWith(
+                () => SettingsNotifier(repoOverride: mockSettingsRepo),
+              ),
+            ],
+          );
+          addTearDown(providerContainer.dispose);
+          final tokenState = await providerContainer.read(tokenProvider.future);
+          final notifier = providerContainer.read(
+            tokenContainerProvider.notifier,
+          );
+
+          final syncFuture = notifier.syncContainers(
+            tokenState: tokenState,
+            isManually: false,
+            isInitSync: false,
+          );
+          await firstSyncStarted.future;
+          final unregisterFuture = notifier.unregisterDelete(originalContainer);
+          await unregisterStarted.future;
+
+          unregisterResponse.complete(
+            UnregisterContainerResult(success: false),
+          );
+          expect(await unregisterFuture, isFalse);
+          firstSyncResponse.complete(
+            ContainerSyncUpdates(
+              containerSerial: originalContainer.serial,
+              newTokens: [
+                TOTPToken(
+                  id: 'stale-id',
+                  serial: 'STALE01',
+                  containerSerial: originalContainer.serial,
+                  period: 30,
+                  algorithm: Algorithms.SHA256,
+                  digits: 6,
+                  secret: 'JBSWY3DPEHPK3PXP',
+                ),
+              ],
+              updatedTokens: const [],
+              deletedTokens: const [],
+              initAssignmentChecked: const [],
+              newPolicies: ContainerPolicies(
+                rolloverAllowed: !originalContainer.policies.rolloverAllowed,
+                initialTokenAssignment:
+                    !originalContainer.policies.initialTokenAssignment,
+                disabledTokenDeletion:
+                    !originalContainer.policies.disabledTokenDeletion,
+                disabledUnregister:
+                    !originalContainer.policies.disabledUnregister,
+              ),
+            ),
+          );
+          await syncFuture;
+          final skippedContainer =
+              (await providerContainer.read(
+                    tokenContainerProvider.future,
+                  )).containerList.single
+                  as TokenContainerFinalized;
+          expect(skippedContainer.syncState, SyncState.failed);
+          expect(skippedContainer.initSynced, isFalse);
+          expect(skippedContainer.policies, originalContainer.policies);
+          expect(
+            (await providerContainer.read(tokenProvider.future)).tokens,
+            isEmpty,
+          );
+          verifyNever(mockTokenRepo.saveOrReplaceTokens(any));
+
+          await notifier.syncContainers(
+            tokenState: tokenState,
+            isManually: false,
+            isInitSync: false,
+          );
+          final retriedContainer =
+              (await providerContainer.read(
+                    tokenContainerProvider.future,
+                  )).containerList.single
+                  as TokenContainerFinalized;
+          expect(syncCalls, 2);
+          expect(retriedContainer.syncState, SyncState.completed);
+        },
+      );
+
+      test(
+        'discards sync response after local deletion fails during unregister',
+        () async {
+          TestWidgetsFlutterBinding.ensureInitialized();
+          var containerRepoState = buildFinalizedContainerState();
+          final originalContainer =
+              containerRepoState.containerList.single
+                  as TokenContainerFinalized;
+          final managedToken = TOTPToken(
+            id: 'managed-id',
+            serial: 'MANAGED01',
+            containerSerial: originalContainer.serial,
+            period: 30,
+            algorithm: Algorithms.SHA256,
+            digits: 6,
+            secret: 'JBSWY3DPEHPK3PXP',
+            origin: TokenOriginData.fromContainer(
+              container: originalContainer,
+              tokenData: 'managed',
+            ),
+          );
+          final syncStarted = Completer<void>();
+          final syncResponse = Completer<ContainerSyncUpdates?>();
+          final mockContainerApi = MockTokenContainerApi();
+          when(
+            mockContainerApi.sync(any, any, isInitSync: anyNamed('isInitSync')),
+          ).thenAnswer((_) {
+            syncStarted.complete();
+            return syncResponse.future;
+          });
+          when(
+            mockContainerApi.unregister(any),
+          ).thenAnswer((_) async => UnregisterContainerResult(success: true));
+          final mockContainerRepo = setupMockContainerRepo(
+            () => containerRepoState,
+            (state) => containerRepoState = state,
+          );
+          final mockTokenRepo = MockTokenRepository();
+          when(
+            mockTokenRepo.loadTokens(),
+          ).thenAnswer((_) async => [managedToken]);
+          when(mockTokenRepo.deleteTokens(any)).thenAnswer((invocation) async {
+            return List<Token>.from(
+              invocation.positionalArguments.single as List<Token>,
+            );
+          });
+          final mockSettingsRepo = MockSettingsRepository();
+          when(
+            mockSettingsRepo.loadSettings(),
+          ).thenAnswer((_) async => SettingsState());
+          final providerContainer = ProviderContainer(
+            overrides: [
+              tokenContainerProvider.overrideWith(
+                () => TokenContainerNotifier(
+                  repoOverride: mockContainerRepo,
+                  containerApiOverride: mockContainerApi,
+                  eccUtilsOverride: EccUtils(),
+                ),
+              ),
+              tokenProvider.overrideWith(
+                () => TokenNotifier(repoOverride: mockTokenRepo),
+              ),
+              settingsProvider.overrideWith(
+                () => SettingsNotifier(repoOverride: mockSettingsRepo),
+              ),
+            ],
+          );
+          addTearDown(providerContainer.dispose);
+          final tokenState = await providerContainer.read(tokenProvider.future);
+          final notifier = providerContainer.read(
+            tokenContainerProvider.notifier,
+          );
+
+          final syncFuture = notifier.syncContainers(
+            tokenState: tokenState,
+            isManually: false,
+            isInitSync: false,
+          );
+          await syncStarted.future;
+          expect(await notifier.unregisterDelete(originalContainer), isFalse);
+
+          syncResponse.complete(
+            ContainerSyncUpdates(
+              containerSerial: originalContainer.serial,
+              newTokens: const [],
+              updatedTokens: const [],
+              deletedTokens: const [],
+              initAssignmentChecked: const [],
+              newPolicies: ContainerPolicies(
+                rolloverAllowed: !originalContainer.policies.rolloverAllowed,
+                initialTokenAssignment:
+                    !originalContainer.policies.initialTokenAssignment,
+                disabledTokenDeletion:
+                    !originalContainer.policies.disabledTokenDeletion,
+                disabledUnregister:
+                    !originalContainer.policies.disabledUnregister,
+              ),
+            ),
+          );
+          await syncFuture;
+
+          final retainedContainer =
+              (await providerContainer.read(
+                    tokenContainerProvider.future,
+                  )).containerList.single
+                  as TokenContainerFinalized;
+          expect(retainedContainer.syncState, SyncState.failed);
+          expect(retainedContainer.initSynced, isFalse);
+          expect(retainedContainer.policies, originalContainer.policies);
+          expect((await providerContainer.read(tokenProvider.future)).tokens, [
+            managedToken,
+          ]);
+        },
+      );
+
+      test(
+        'discards a sync response sent before the container URL changed',
+        () async {
+          TestWidgetsFlutterBinding.ensureInitialized();
+          var containerRepoState = buildFinalizedContainerState();
+          final originalContainer =
+              containerRepoState.containerList.single
+                  as TokenContainerFinalized;
+          final syncStarted = Completer<void>();
+          final syncResponse = Completer<ContainerSyncUpdates?>();
+          final mockContainerApi = MockTokenContainerApi();
+          when(
+            mockContainerApi.sync(any, any, isInitSync: anyNamed('isInitSync')),
+          ).thenAnswer((_) {
+            syncStarted.complete();
+            return syncResponse.future;
+          });
+          final mockContainerRepo = setupMockContainerRepo(
+            () => containerRepoState,
+            (state) => containerRepoState = state,
+          );
+          final mockTokenRepo = MockTokenRepository();
+          when(mockTokenRepo.loadTokens()).thenAnswer((_) async => <Token>[]);
+          when(
+            mockTokenRepo.saveOrReplaceTokens(any),
+          ).thenAnswer((_) async => <Token>[]);
+          final mockSettingsRepo = MockSettingsRepository();
+          when(
+            mockSettingsRepo.loadSettings(),
+          ).thenAnswer((_) async => SettingsState());
+          final providerContainer = ProviderContainer(
+            overrides: [
+              tokenContainerProvider.overrideWith(
+                () => TokenContainerNotifier(
+                  repoOverride: mockContainerRepo,
+                  containerApiOverride: mockContainerApi,
+                  eccUtilsOverride: EccUtils(),
+                ),
+              ),
+              tokenProvider.overrideWith(
+                () => TokenNotifier(repoOverride: mockTokenRepo),
+              ),
+              settingsProvider.overrideWith(
+                () => SettingsNotifier(repoOverride: mockSettingsRepo),
+              ),
+            ],
+          );
+          addTearDown(providerContainer.dispose);
+          final tokenState = await providerContainer.read(tokenProvider.future);
+          final notifier = providerContainer.read(
+            tokenContainerProvider.notifier,
+          );
+
+          final syncFuture = notifier.syncContainers(
+            tokenState: tokenState,
+            isManually: false,
+            isInitSync: false,
+          );
+          await syncStarted.future;
+          final newServerUrl = Uri.parse('https://new.example.com');
+          expect(
+            await notifier.updateContainer(
+              originalContainer,
+              (TokenContainerFinalized current) =>
+                  current.copyWith(serverUrl: newServerUrl),
+            ),
+            isNotNull,
+          );
+
+          syncResponse.complete(
+            ContainerSyncUpdates(
+              containerSerial: originalContainer.serial,
+              newTokens: [
+                TOTPToken(
+                  id: 'old-server-id',
+                  serial: 'OLD-SERVER01',
+                  containerSerial: originalContainer.serial,
+                  period: 30,
+                  algorithm: Algorithms.SHA256,
+                  digits: 6,
+                  secret: 'JBSWY3DPEHPK3PXP',
+                ),
+              ],
+              updatedTokens: const [],
+              deletedTokens: const [],
+              initAssignmentChecked: const [],
+              newPolicies: ContainerPolicies(
+                rolloverAllowed: !originalContainer.policies.rolloverAllowed,
+                initialTokenAssignment:
+                    !originalContainer.policies.initialTokenAssignment,
+                disabledTokenDeletion:
+                    !originalContainer.policies.disabledTokenDeletion,
+                disabledUnregister:
+                    !originalContainer.policies.disabledUnregister,
+              ),
+            ),
+          );
+          await syncFuture;
+
+          final currentContainer =
+              (await providerContainer.read(
+                    tokenContainerProvider.future,
+                  )).containerList.single
+                  as TokenContainerFinalized;
+          expect(currentContainer.serverUrl, newServerUrl);
+          expect(currentContainer.syncState, SyncState.failed);
+          expect(currentContainer.initSynced, isFalse);
+          expect(currentContainer.policies, originalContainer.policies);
+          expect(
+            (await providerContainer.read(tokenProvider.future)).tokens,
+            isEmpty,
+          );
+          verifyNever(mockTokenRepo.saveOrReplaceTokens(any));
+        },
+      );
+
+      test(
+        'serializes overlapping sync requests and refreshes their token state',
+        () async {
+          var containerRepoState = buildFinalizedContainerState();
+          final containerToSync =
+              containerRepoState.containerList.single
+                  as TokenContainerFinalized;
+          final firstStarted = Completer<void>();
+          final firstResponse = Completer<ContainerSyncUpdates?>();
+          final mockContainerApi = MockTokenContainerApi();
+          var apiCalls = 0;
+          var inFlight = 0;
+          var maxInFlight = 0;
+          final requestTokenStates = <TokenState>[];
+          final added = TOTPToken(
+            id: 'new-id',
+            serial: 'TOTP-NEW',
+            containerSerial: containerToSync.serial,
+            algorithm: Algorithms.SHA256,
+            digits: 6,
+            period: 30,
+            secret: 'NEW-SECRET',
+          );
+          when(
+            mockContainerApi.sync(any, any, isInitSync: anyNamed('isInitSync')),
+          ).thenAnswer((invocation) {
+            apiCalls++;
+            inFlight++;
+            if (inFlight > maxInFlight) maxInFlight = inFlight;
+            requestTokenStates.add(
+              invocation.positionalArguments[1] as TokenState,
+            );
+            if (apiCalls == 1) {
+              firstStarted.complete();
+              return firstResponse.future.whenComplete(() => inFlight--);
+            }
+            return Future<ContainerSyncUpdates?>.value(
+              ContainerSyncUpdates(
+                containerSerial: containerToSync.serial,
+                newTokens: const [],
+                updatedTokens: const [],
+                deletedTokens: const [],
+                initAssignmentChecked: const [],
+                newPolicies: ContainerPolicies.defaultSetting,
+              ),
+            ).whenComplete(() => inFlight--);
+          });
+          final mockContainerRepo = setupMockContainerRepo(
+            () => containerRepoState,
+            (state) => containerRepoState = state,
+          );
+          final mockTokenRepo = MockTokenRepository();
+          when(mockTokenRepo.loadTokens()).thenAnswer((_) async => <Token>[]);
+          when(
+            mockTokenRepo.saveOrReplaceTokens(any),
+          ).thenAnswer((_) async => <Token>[]);
+          final mockSettingsRepo = MockSettingsRepository();
+          when(
+            mockSettingsRepo.loadSettings(),
+          ).thenAnswer((_) async => SettingsState());
+          final providerContainer = ProviderContainer(
+            overrides: [
+              tokenContainerProvider.overrideWith(
+                () => TokenContainerNotifier(
+                  repoOverride: mockContainerRepo,
+                  containerApiOverride: mockContainerApi,
+                  eccUtilsOverride: EccUtils(),
+                ),
+              ),
+              tokenProvider.overrideWith(
+                () => TokenNotifier(repoOverride: mockTokenRepo),
+              ),
+              settingsProvider.overrideWith(
+                () => SettingsNotifier(repoOverride: mockSettingsRepo),
+              ),
+            ],
+          );
+          addTearDown(providerContainer.dispose);
+          final initialTokenState = await providerContainer.read(
+            tokenProvider.future,
+          );
+          final notifier = providerContainer.read(
+            tokenContainerProvider.notifier,
+          );
+
+          final first = notifier.syncContainers(
+            tokenState: initialTokenState,
+            isManually: false,
+            isInitSync: false,
+          );
+          final second = notifier.syncContainers(
+            tokenState: initialTokenState,
+            isManually: false,
+            isInitSync: false,
+          );
+          await firstStarted.future;
+          await Future<void>.delayed(Duration.zero);
+          await Future<void>.delayed(Duration.zero);
+
+          expect(apiCalls, 1);
+          expect(maxInFlight, 1);
+          firstResponse.complete(
+            ContainerSyncUpdates(
+              containerSerial: containerToSync.serial,
+              newTokens: [added],
+              updatedTokens: const [],
+              deletedTokens: const [],
+              initAssignmentChecked: const [],
+              newPolicies: ContainerPolicies.defaultSetting,
+            ),
+          );
+          await Future.wait([first, second]);
+
+          expect(apiCalls, 2);
+          expect(maxInFlight, 1);
+          expect(requestTokenStates, hasLength(2));
+          expect(requestTokenStates.first.tokens, isEmpty);
+          expect(requestTokenStates.last.currentOfId(added.id), isNotNull);
+        },
+      );
     });
     test('getRolloverQrData', () async {
       // prepare

--- a/test/unit_test/utils/push_provider_test.dart
+++ b/test/unit_test/utils/push_provider_test.dart
@@ -18,12 +18,21 @@
  * limitations under the License.
  */
 
+import 'dart:async';
+
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart';
 import 'package:mockito/mockito.dart';
+import 'package:privacyidea_authenticator/model/enums/biometric_push_key_status.dart';
+import 'package:privacyidea_authenticator/model/enums/force_biometric_option.dart';
+import 'package:privacyidea_authenticator/model/enums/push_app_biometric_level.dart';
 import 'package:privacyidea_authenticator/model/tokens/push_token.dart';
+import 'package:privacyidea_authenticator/utils/globals.dart';
 import 'package:privacyidea_authenticator/utils/push_provider.dart';
+import 'package:privacyidea_authenticator/utils/riverpod/riverpod_providers/generated_providers/token_notifier.dart';
 
+import '../../tests_app_wrapper.dart';
 import '../../tests_app_wrapper.mocks.dart';
 
 void main() {
@@ -31,6 +40,25 @@ void main() {
     late MockPrivacyideaIOClient mockIOClient;
     late MockRsaUtils mockRsaUtils;
     late PushToken token;
+
+    Future<void> mountCurrentToken(WidgetTester tester) async {
+      final tokenRepo = MockTokenRepository();
+      when(tokenRepo.loadTokens()).thenAnswer((_) async => [token]);
+      when(tokenRepo.saveOrReplaceToken(any)).thenAnswer((_) async => true);
+      when(tokenRepo.saveOrReplaceTokens(any)).thenAnswer((_) async => []);
+      await tester.pumpWidget(
+        TestsAppWrapper(
+          wrapInMaterialApp: false,
+          overrides: [
+            tokenProvider.overrideWith(
+              () => TokenNotifier(repoOverride: tokenRepo),
+            ),
+          ],
+          child: const SizedBox(),
+        ),
+      );
+      await globalRef!.read(tokenProvider.future);
+    }
 
     setUp(() {
       PushProvider.instance = null;
@@ -44,7 +72,11 @@ void main() {
       );
 
       when(
-        mockRsaUtils.trySignWithToken(any, any),
+        mockRsaUtils.trySignWithToken(
+          any,
+          any,
+          onTokenChanged: anyNamed('onTokenChanged'),
+        ),
       ).thenAnswer((_) async => 'signature');
       when(
         mockIOClient.doGet(
@@ -57,6 +89,8 @@ void main() {
       );
     });
 
+    tearDown(() => globalRef = null);
+
     Map<String, String?> capturedParameters() =>
         verify(
               mockIOClient.doGet(
@@ -67,25 +101,28 @@ void main() {
             ).captured.last
             as Map<String, String?>;
 
-    test(
-      'sends the parameters the server rebuilds the signature from',
-      () async {
-        await PushProvider(
-          ioClient: mockIOClient,
-          rsaUtils: mockRsaUtils,
-        ).pollForChallenge(token);
+    testWidgets('sends the parameters the server rebuilds the signature from', (
+      tester,
+    ) async {
+      await mountCurrentToken(tester);
+      await PushProvider(
+        ioClient: mockIOClient,
+        rsaUtils: mockRsaUtils,
+      ).pollForChallenge(token);
 
-        final parameters = capturedParameters();
-        expect(parameters['serial'], token.serial);
-        expect(parameters['timestamp'], isNotNull);
-        expect(parameters['signature'], 'signature');
-      },
-    );
+      final parameters = capturedParameters();
+      expect(parameters['serial'], token.serial);
+      expect(parameters['timestamp'], isNotNull);
+      expect(parameters['signature'], 'signature');
+    });
 
     // privacyidea#5618 phase 2: "Refresh the stored set from the already-signed
     // poll / fbtoken-update channel so it stays current after app upgrades - no
     // new endpoint."
-    test('reports the app capabilities along with the poll', () async {
+    testWidgets('reports the app capabilities along with the poll', (
+      tester,
+    ) async {
+      await mountCurrentToken(tester);
       await PushProvider(
         ioClient: mockIOClient,
         rsaUtils: mockRsaUtils,
@@ -94,7 +131,8 @@ void main() {
       expect(capturedParameters()['capabilities'], '["decline_reason"]');
     });
 
-    test('does not sign the reported capabilities', () async {
+    testWidgets('does not sign the reported capabilities', (tester) async {
+      await mountCurrentToken(tester);
       await PushProvider(
         ioClient: mockIOClient,
         rsaUtils: mockRsaUtils,
@@ -103,10 +141,115 @@ void main() {
       // A server that does not know the parameter rebuilds
       // '{serial}|{timestamp}' and has to arrive at the same signature.
       final signed =
-          verify(mockRsaUtils.trySignWithToken(any, captureAny)).captured.last
+          verify(
+                mockRsaUtils.trySignWithToken(
+                  any,
+                  captureAny,
+                  onTokenChanged: anyNamed('onTokenChanged'),
+                ),
+              ).captured.last
               as String;
       expect(signed, '${token.serial}|${capturedParameters()['timestamp']}');
       expect(signed, isNot(contains('decline_reason')));
+    });
+  });
+
+  test('manual Push polling serializes biometric-capable requests', () async {
+    final firstMayFinish = Completer<void>();
+    final events = <String>[];
+
+    final polling = runPushPollingRequests<int>(
+      [1, 2],
+      sequential: true,
+      request: (token) async {
+        events.add('start-$token');
+        if (token == 1) await firstMayFinish.future;
+        events.add('end-$token');
+      },
+    );
+
+    await Future<void>.delayed(Duration.zero);
+    expect(events, ['start-1']);
+    firstMayFinish.complete();
+    await polling;
+    expect(events, ['start-1', 'end-1', 'start-2', 'end-2']);
+  });
+
+  test('automatic Push polling may run safe requests in parallel', () async {
+    final firstMayFinish = Completer<void>();
+    final secondStarted = Completer<void>();
+    final polling = runPushPollingRequests<int>(
+      [1, 2],
+      sequential: false,
+      request: (token) async {
+        if (token == 1) {
+          await firstMayFinish.future;
+        } else {
+          secondStarted.complete();
+        }
+      },
+    );
+    await secondStarted.future;
+    firstMayFinish.complete();
+    await polling;
+  });
+
+  group('Dart Push key polling authorization', () {
+    final weakToken = PushToken(
+      serial: 'PIPU-weak',
+      id: 'weak-id',
+      forceBiometricOption: ForceBiometricOption.biometric,
+      biometricLevel: PushAppBiometricLevel.any,
+      invalidateOnBiometricChange: false,
+      privateTokenKey: 'private-key',
+    );
+
+    test('automatic polling fails closed without opening a prompt', () async {
+      var promptCount = 0;
+      final authorized = await authorizePushDartKeyUseForPolling(
+        weakToken,
+        isManually: false,
+        authenticate: () async {
+          promptCount++;
+          return true;
+        },
+      );
+      expect(authorized, isFalse);
+      expect(promptCount, 0);
+    });
+
+    test('manual polling authenticates once before Dart key use', () async {
+      var promptCount = 0;
+      final authorized = await authorizePushDartKeyUseForPolling(
+        weakToken,
+        isManually: true,
+        authenticate: () async {
+          promptCount++;
+          return true;
+        },
+      );
+      expect(authorized, isTrue);
+      expect(promptCount, 1);
+    });
+
+    test('native protected key bypasses compatibility prompt', () async {
+      final nativeToken = PushToken(
+        serial: 'PIPU-native',
+        id: 'native-id',
+        forceBiometricOption: ForceBiometricOption.biometric,
+        biometricKeyStatus: BiometricPushKeyStatus.protected,
+      );
+      var promptCount = 0;
+      final authorized = await authorizePushDartKeyUseForPolling(
+        nativeToken,
+        isManually: true,
+        authenticate: () async {
+          promptCount++;
+          return true;
+        },
+      );
+      expect(authorized, isTrue);
+      expect(promptCount, 0);
     });
   });
 }

--- a/test/unit_test/utils/riverpod/riverpod_providers/generated_providers/token_notifier_test.dart
+++ b/test/unit_test/utils/riverpod/riverpod_providers/generated_providers/token_notifier_test.dart
@@ -28,6 +28,9 @@ import 'package:mockito/mockito.dart';
 import 'package:pointycastle/export.dart';
 import 'package:privacyidea_authenticator/model/enums/algorithms.dart';
 import 'package:privacyidea_authenticator/model/push_request/push_capabilities.dart';
+import 'package:privacyidea_authenticator/model/enums/biometric_push_key_status.dart';
+import 'package:privacyidea_authenticator/model/enums/force_biometric_option.dart';
+import 'package:privacyidea_authenticator/model/enums/push_app_biometric_level.dart';
 import 'package:privacyidea_authenticator/model/enums/push_token_rollout_state.dart';
 import 'package:privacyidea_authenticator/model/enums/token_origin_source_type.dart';
 import 'package:privacyidea_authenticator/model/extensions/enums/token_origin_source_type.dart';
@@ -130,6 +133,817 @@ void _testTokenNotifier() {
       expect(state, isNotNull);
       expect(state.tokens, after);
       verify(mockRepo.loadTokens()).called(2);
+    });
+    test('cold start persists native biometric invalidation', () async {
+      final mockSettingsRepo = MockSettingsRepository();
+      when(
+        mockSettingsRepo.loadSettings(),
+      ).thenAnswer((_) async => SettingsState());
+      final container = ProviderContainer(
+        overrides: [
+          settingsProvider.overrideWith(
+            () => SettingsNotifier(repoOverride: mockSettingsRepo),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      final mockRepo = MockTokenRepository();
+      final mockRsaUtils = MockRsaUtils();
+      final before = PushToken(
+        label: 'Push',
+        issuer: 'issuer',
+        id: 'push-id',
+        serial: 'serial',
+        isRolledOut: true,
+        forceBiometricOption: ForceBiometricOption.biometric,
+        biometricKeyStatus: BiometricPushKeyStatus.protected,
+      );
+      final invalidated = before.copyWith(
+        privateTokenKey: () => null,
+        biometricKeyStatus: BiometricPushKeyStatus.invalidated,
+      );
+      when(mockRepo.loadTokens()).thenAnswer((_) async => [before]);
+      when(
+        mockRepo.saveOrReplaceToken(invalidated),
+      ).thenAnswer((_) async => true);
+      when(mockRsaUtils.supportsBiometricPushKeyProtection).thenReturn(true);
+      when(
+        mockRsaUtils.biometricPushKeyStatus(before.id),
+      ).thenAnswer((_) async => RsaUtils.biometricKeyStatusInvalidated);
+      final testProvider = tokenProviderOf(
+        repo: mockRepo,
+        rsaUtils: mockRsaUtils,
+        ioClient: const PrivacyideaIOClient(),
+        firebaseUtils: MockFirebaseUtils(),
+      );
+
+      final state = await container.read(testProvider.future);
+
+      expect(state.tokens.single, invalidated);
+      verify(mockRepo.saveOrReplaceToken(invalidated)).called(1);
+    });
+    test(
+      'cold start never revives a locally invalidated biometric key',
+      () async {
+        final mockSettingsRepo = MockSettingsRepository();
+        when(
+          mockSettingsRepo.loadSettings(),
+        ).thenAnswer((_) async => SettingsState());
+        final container = ProviderContainer(
+          overrides: [
+            settingsProvider.overrideWith(
+              () => SettingsNotifier(repoOverride: mockSettingsRepo),
+            ),
+          ],
+        );
+        addTearDown(container.dispose);
+        final mockRepo = MockTokenRepository();
+        final mockRsaUtils = MockRsaUtils();
+        final invalidated = PushToken(
+          label: 'Push',
+          issuer: 'issuer',
+          id: 'push-id',
+          serial: 'serial',
+          isRolledOut: true,
+          forceBiometricOption: ForceBiometricOption.biometric,
+          biometricKeyStatus: BiometricPushKeyStatus.invalidated,
+        );
+        when(mockRepo.loadTokens()).thenAnswer((_) async => [invalidated]);
+        when(mockRsaUtils.supportsBiometricPushKeyProtection).thenReturn(true);
+        when(
+          mockRsaUtils.biometricPushKeyStatus(invalidated.id),
+        ).thenAnswer((_) async => RsaUtils.biometricKeyStatusProtected);
+        when(
+          mockRsaUtils.deleteBiometricPushKey(invalidated.id),
+        ).thenAnswer((_) async {});
+        final testProvider = tokenProviderOf(
+          repo: mockRepo,
+          rsaUtils: mockRsaUtils,
+          ioClient: const PrivacyideaIOClient(),
+          firebaseUtils: MockFirebaseUtils(),
+        );
+
+        final state = await container.read(testProvider.future);
+
+        expect(state.tokens.single, invalidated);
+        verify(mockRsaUtils.deleteBiometricPushKey(invalidated.id)).called(1);
+        verifyNever(mockRsaUtils.biometricPushKeyStatus(invalidated.id));
+        verifyNever(mockRepo.saveOrReplaceToken(any));
+      },
+    );
+    group('applyContainerSync', () {
+      test(
+        'does not recreate a token deleted during synchronization',
+        () async {
+          final mockSettingsRepo = MockSettingsRepository();
+          when(
+            mockSettingsRepo.loadSettings(),
+          ).thenAnswer((_) async => SettingsState());
+          final container = ProviderContainer(
+            overrides: [
+              settingsProvider.overrideWith(
+                () => SettingsNotifier(repoOverride: mockSettingsRepo),
+              ),
+            ],
+          );
+          addTearDown(container.dispose);
+          final mockRepo = MockTokenRepository();
+          when(mockRepo.loadTokens()).thenAnswer((_) async => <Token>[]);
+          final staleUpdate = PushToken(
+            id: 'deleted-push-id',
+            serial: 'deleted-push-serial',
+            label: 'server label',
+            issuer: 'server issuer',
+            url: Uri.parse('https://privacyidea.example/ttype/push'),
+            isRolledOut: true,
+            fbToken: 'stale-firebase-token',
+          );
+          final testProvider = tokenProviderOf(
+            repo: mockRepo,
+            rsaUtils: const RsaUtils(),
+            ioClient: const PrivacyideaIOClient(),
+            firebaseUtils: MockFirebaseUtils(),
+          );
+          await container.read(testProvider.future);
+
+          final failed = await container
+              .read(testProvider.notifier)
+              .applyContainerSync(
+                updatedTokens: [staleUpdate],
+                newTokens: const [],
+                checkedContainersByTokenId: const {},
+              );
+
+          expect(failed, isEmpty);
+          expect((await container.read(testProvider.future)).tokens, isEmpty);
+          verifyNever(mockRepo.saveOrReplaceTokens(any));
+        },
+      );
+
+      test(
+        'rebases server fields onto the latest local Push lifecycle state',
+        () async {
+          final mockSettingsRepo = MockSettingsRepository();
+          when(
+            mockSettingsRepo.loadSettings(),
+          ).thenAnswer((_) async => SettingsState());
+          final container = ProviderContainer(
+            overrides: [
+              settingsProvider.overrideWith(
+                () => SettingsNotifier(repoOverride: mockSettingsRepo),
+              ),
+            ],
+          );
+          addTearDown(container.dispose);
+          final mockRepo = MockTokenRepository();
+          final localOrigin = TokenOriginSourceType.manually.toTokenOrigin(
+            data: 'local-origin-data',
+            originName: 'Local enrollment',
+            createdAt: DateTime.utc(2026),
+          );
+          final serverOrigin = TokenOriginSourceType.container.toTokenOrigin(
+            data: 'server-origin-data',
+            originName: 'Server container',
+            isPrivacyIdeaToken: true,
+            createdAt: DateTime.utc(2026, 1, 2),
+          );
+          final current = PushToken(
+            id: 'push-id',
+            serial: 'push-serial',
+            label: 'local label',
+            issuer: 'local issuer',
+            containerSerial: 'old-container',
+            checkedContainer: const ['already-checked'],
+            folderId: 42,
+            sortIndex: 7,
+            origin: localOrigin,
+            url: Uri.parse('https://local.example/ttype/push'),
+            forceBiometricOption: ForceBiometricOption.biometric,
+            invalidateOnBiometricChange: true,
+            biometricKeyStatus: BiometricPushKeyStatus.protected,
+            publicTokenKey: 'current-token-public-key',
+            publicServerKey: 'current-server-public-key',
+            isRolledOut: true,
+            rolloutState: PushTokenRollOutState.rolloutComplete,
+            fbToken: 'current-firebase-token',
+          );
+          final incoming = PushToken(
+            id: current.id,
+            serial: current.serial,
+            label: 'server label',
+            issuer: 'server issuer',
+            containerSerial: 'new-container',
+            checkedContainer: const ['stale-server-check'],
+            folderId: 999,
+            sortIndex: 999,
+            origin: serverOrigin,
+            url: Uri.parse('https://server.example/ttype/push'),
+            forceBiometricOption: ForceBiometricOption.biometric,
+            invalidateOnBiometricChange: true,
+            publicTokenKey: 'stale-token-public-key',
+            publicServerKey: 'stale-server-public-key',
+            privateTokenKey: 'stale-private-key',
+            isRolledOut: false,
+            rolloutState: PushTokenRollOutState.rolloutNotStarted,
+            fbToken: 'stale-firebase-token',
+          );
+          when(mockRepo.loadTokens()).thenAnswer((_) async => [current]);
+          List<Token>? persisted;
+          when(mockRepo.saveOrReplaceTokens(any)).thenAnswer((
+            invocation,
+          ) async {
+            persisted = List<Token>.from(
+              invocation.positionalArguments.single as List<Token>,
+            );
+            return <Token>[];
+          });
+          final testProvider = tokenProviderOf(
+            repo: mockRepo,
+            rsaUtils: const RsaUtils(),
+            ioClient: const PrivacyideaIOClient(),
+            firebaseUtils: MockFirebaseUtils(),
+          );
+          await container.read(testProvider.future);
+
+          final failed = await container
+              .read(testProvider.notifier)
+              .applyContainerSync(
+                updatedTokens: [incoming],
+                newTokens: const [],
+                checkedContainersByTokenId: const {
+                  'push-id': ['new-container'],
+                },
+              );
+
+          final updated =
+              (await container.read(testProvider.future)).tokens.single
+                  as PushToken;
+          expect(failed, isEmpty);
+          expect(updated.label, 'server label');
+          expect(updated.issuer, 'server issuer');
+          expect(updated.url, Uri.parse('https://server.example/ttype/push'));
+          expect(updated.containerSerial, 'new-container');
+          expect(updated.origin, serverOrigin);
+          expect(updated.checkedContainer, [
+            'already-checked',
+            'new-container',
+          ]);
+          expect(updated.folderId, 42);
+          expect(updated.sortIndex, 7);
+          expect(updated.fbToken, 'current-firebase-token');
+          expect(updated.isRolledOut, isTrue);
+          expect(updated.rolloutState, PushTokenRollOutState.rolloutComplete);
+          expect(updated.publicServerKey, 'current-server-public-key');
+          expect(updated.publicTokenKey, 'current-token-public-key');
+          expect(updated.privateTokenKey, isNull);
+          expect(updated.biometricKeyStatus, BiometricPushKeyStatus.protected);
+          expect(persisted, hasLength(1));
+          expect(persisted!.single, same(updated));
+          verify(mockRepo.saveOrReplaceTokens(any)).called(1);
+        },
+      );
+
+      test(
+        'invalidates and removes the native key when binding is tightened',
+        () async {
+          final mockSettingsRepo = MockSettingsRepository();
+          when(
+            mockSettingsRepo.loadSettings(),
+          ).thenAnswer((_) async => SettingsState());
+          final container = ProviderContainer(
+            overrides: [
+              settingsProvider.overrideWith(
+                () => SettingsNotifier(repoOverride: mockSettingsRepo),
+              ),
+            ],
+          );
+          addTearDown(container.dispose);
+          final mockRepo = MockTokenRepository();
+          final mockRsaUtils = MockRsaUtils();
+          final current = PushToken(
+            id: 'push-id',
+            serial: 'push-serial',
+            label: 'local label',
+            issuer: 'issuer',
+            url: Uri.parse('https://privacyidea.example/ttype/push'),
+            forceBiometricOption: ForceBiometricOption.biometric,
+            invalidateOnBiometricChange: false,
+            privateTokenKey: 'legacy-private-key',
+            publicTokenKey: 'token-public-key',
+            isRolledOut: true,
+            rolloutState: PushTokenRollOutState.rolloutComplete,
+            fbToken: 'firebase-token',
+          );
+          final incoming = current.copyWith(
+            label: 'server label',
+            invalidateOnBiometricChange: true,
+          );
+          when(mockRepo.loadTokens()).thenAnswer((_) async => [current]);
+          when(
+            mockRepo.saveOrReplaceTokens(any),
+          ).thenAnswer((_) async => <Token>[]);
+          when(
+            mockRsaUtils.supportsBiometricPushKeyProtection,
+          ).thenReturn(false);
+          when(
+            mockRsaUtils.deleteBiometricPushKey(current.id),
+          ).thenAnswer((_) async {});
+          final testProvider = tokenProviderOf(
+            repo: mockRepo,
+            rsaUtils: mockRsaUtils,
+            ioClient: const PrivacyideaIOClient(),
+            firebaseUtils: MockFirebaseUtils(),
+          );
+          await container.read(testProvider.future);
+
+          final failed = await container
+              .read(testProvider.notifier)
+              .applyContainerSync(
+                updatedTokens: [incoming],
+                newTokens: const [],
+                checkedContainersByTokenId: const {},
+              );
+
+          final updated =
+              (await container.read(testProvider.future)).tokens.single
+                  as PushToken;
+          expect(failed, isEmpty);
+          expect(updated.invalidateOnBiometricChange, isTrue);
+          expect(
+            updated.biometricKeyStatus,
+            BiometricPushKeyStatus.invalidated,
+          );
+          expect(updated.privateTokenKey, isNull);
+          final persisted =
+              verify(mockRepo.saveOrReplaceTokens(captureAny)).captured.single
+                  as List<Token>;
+          final persistedPush = persisted.single as PushToken;
+          expect(
+            persistedPush.biometricKeyStatus,
+            BiometricPushKeyStatus.invalidated,
+          );
+          expect(persistedPush.privateTokenKey, isNull);
+          verify(mockRsaUtils.deleteBiometricPushKey(current.id)).called(1);
+        },
+      );
+
+      test(
+        'deduplicates repeated Push updates and keeps the strongest policies',
+        () async {
+          final mockSettingsRepo = MockSettingsRepository();
+          when(
+            mockSettingsRepo.loadSettings(),
+          ).thenAnswer((_) async => SettingsState());
+          final container = ProviderContainer(
+            overrides: [
+              settingsProvider.overrideWith(
+                () => SettingsNotifier(repoOverride: mockSettingsRepo),
+              ),
+            ],
+          );
+          addTearDown(container.dispose);
+          final mockRepo = MockTokenRepository();
+          final mockRsaUtils = MockRsaUtils();
+          final current = PushToken(
+            id: 'push-id',
+            serial: 'push-serial',
+            label: 'local label',
+            issuer: 'issuer',
+            url: Uri.parse('https://privacyidea.example/ttype/push'),
+            biometricLevel: PushAppBiometricLevel.any,
+            invalidateOnBiometricChange: false,
+            privateTokenKey: 'legacy-private-key',
+            publicTokenKey: 'token-public-key',
+            isRolledOut: true,
+            rolloutState: PushTokenRollOutState.rolloutComplete,
+            fbToken: 'firebase-token',
+          );
+          final strict = current.copyWith(
+            label: 'strict update',
+            forceBiometricOption: ForceBiometricOption.biometric,
+            biometricLevel: PushAppBiometricLevel.strong,
+            invalidateOnBiometricChange: true,
+          );
+          final weakBiometric = current.copyWith(
+            label: 'weak biometric update',
+            forceBiometricOption: ForceBiometricOption.biometric,
+            biometricLevel: PushAppBiometricLevel.any,
+            invalidateOnBiometricChange: false,
+          );
+          final noBiometric = current.copyWith(
+            label: 'no biometric update',
+            forceBiometricOption: ForceBiometricOption.none,
+            biometricLevel: PushAppBiometricLevel.any,
+            invalidateOnBiometricChange: false,
+          );
+          when(mockRepo.loadTokens()).thenAnswer((_) async => [current]);
+          when(
+            mockRepo.saveOrReplaceTokens(any),
+          ).thenAnswer((_) async => <Token>[]);
+          when(
+            mockRsaUtils.supportsBiometricPushKeyProtection,
+          ).thenReturn(false);
+          when(
+            mockRsaUtils.deleteBiometricPushKey(current.id),
+          ).thenAnswer((_) async {});
+          final testProvider = tokenProviderOf(
+            repo: mockRepo,
+            rsaUtils: mockRsaUtils,
+            ioClient: const PrivacyideaIOClient(),
+            firebaseUtils: MockFirebaseUtils(),
+          );
+          await container.read(testProvider.future);
+
+          final failed = await container
+              .read(testProvider.notifier)
+              .applyContainerSync(
+                updatedTokens: [strict, weakBiometric, noBiometric],
+                newTokens: const [],
+                checkedContainersByTokenId: const {},
+              );
+
+          final updated =
+              (await container.read(testProvider.future)).tokens.single
+                  as PushToken;
+          expect(failed, isEmpty);
+          expect(updated.label, 'no biometric update');
+          expect(updated.forceBiometricOption, ForceBiometricOption.biometric);
+          expect(updated.biometricLevel, PushAppBiometricLevel.strong);
+          expect(updated.invalidateOnBiometricChange, isTrue);
+          expect(
+            updated.biometricKeyStatus,
+            BiometricPushKeyStatus.invalidated,
+          );
+          expect(updated.privateTokenKey, isNull);
+          final persisted =
+              verify(mockRepo.saveOrReplaceTokens(captureAny)).captured.single
+                  as List<Token>;
+          expect(persisted, hasLength(1));
+          expect((persisted.single as PushToken).id, current.id);
+          verify(mockRsaUtils.deleteBiometricPushKey(current.id)).called(1);
+        },
+      );
+
+      test('matches bulk persistence failures by token id', () async {
+        final mockSettingsRepo = MockSettingsRepository();
+        when(
+          mockSettingsRepo.loadSettings(),
+        ).thenAnswer((_) async => SettingsState());
+        final container = ProviderContainer(
+          overrides: [
+            settingsProvider.overrideWith(
+              () => SettingsNotifier(repoOverride: mockSettingsRepo),
+            ),
+          ],
+        );
+        addTearDown(container.dispose);
+        final mockRepo = MockTokenRepository();
+        final mockRsaUtils = MockRsaUtils();
+        PushToken token(String id, String label) => PushToken(
+          id: id,
+          serial: 'shared-serial',
+          label: label,
+          issuer: 'issuer',
+          url: Uri.parse('https://privacyidea.example/ttype/push'),
+          isRolledOut: true,
+          rolloutState: PushTokenRollOutState.rolloutComplete,
+          fbToken: 'firebase-token',
+        );
+
+        final first = token('first-id', 'first local');
+        final second = token('second-id', 'second local');
+        when(mockRepo.loadTokens()).thenAnswer((_) async => [first, second]);
+        when(mockRepo.saveOrReplaceTokens(any)).thenAnswer((invocation) async {
+          final candidates =
+              invocation.positionalArguments.single as List<Token>;
+          return [candidates.singleWhere((token) => token.id == first.id)];
+        });
+        when(mockRsaUtils.supportsBiometricPushKeyProtection).thenReturn(false);
+        final testProvider = tokenProviderOf(
+          repo: mockRepo,
+          rsaUtils: mockRsaUtils,
+          ioClient: const PrivacyideaIOClient(),
+          firebaseUtils: MockFirebaseUtils(),
+        );
+        await container.read(testProvider.future);
+
+        final failed = await container
+            .read(testProvider.notifier)
+            .applyContainerSync(
+              updatedTokens: [
+                first.copyWith(label: 'first server'),
+                second.copyWith(label: 'second server'),
+              ],
+              newTokens: const [],
+              checkedContainersByTokenId: const {},
+            );
+
+        final state = await container.read(testProvider.future);
+        expect(failed.map((token) => token.id), [first.id]);
+        expect(state.currentOfId<PushToken>(first.id)!.label, 'first local');
+        expect(state.currentOfId<PushToken>(second.id)!.label, 'second server');
+      });
+
+      test(
+        'rebases a colliding new Push token by identity instead of duplicating it',
+        () async {
+          final mockSettingsRepo = MockSettingsRepository();
+          when(
+            mockSettingsRepo.loadSettings(),
+          ).thenAnswer((_) async => SettingsState());
+          final container = ProviderContainer(
+            overrides: [
+              settingsProvider.overrideWith(
+                () => SettingsNotifier(repoOverride: mockSettingsRepo),
+              ),
+            ],
+          );
+          addTearDown(container.dispose);
+          final mockRepo = MockTokenRepository();
+          final mockRsaUtils = MockRsaUtils();
+          final current = PushToken(
+            id: 'local-id',
+            serial: 'PIPU01',
+            label: 'local label',
+            issuer: 'privacyIDEA',
+            url: Uri.parse('https://privacyidea.example/ttype/push'),
+            publicServerKey: 'server-key',
+            publicTokenKey: 'public-key',
+            privateTokenKey: 'private-key',
+            enrollmentCredentials: 'credential',
+            isRolledOut: true,
+            rolloutState: PushTokenRollOutState.rolloutComplete,
+            fbToken: 'firebase-token',
+          );
+          final incoming = current.copyWith(
+            id: 'server-id',
+            label: 'server label',
+            containerSerial: () => 'CONTAINER01',
+          );
+          when(mockRepo.loadTokens()).thenAnswer((_) async => [current]);
+          List<Token>? persisted;
+          when(mockRepo.saveOrReplaceTokens(any)).thenAnswer((
+            invocation,
+          ) async {
+            persisted = List<Token>.from(
+              invocation.positionalArguments.single as List<Token>,
+            );
+            return <Token>[];
+          });
+          when(
+            mockRsaUtils.supportsBiometricPushKeyProtection,
+          ).thenReturn(false);
+          final testProvider = tokenProviderOf(
+            repo: mockRepo,
+            rsaUtils: mockRsaUtils,
+            ioClient: const PrivacyideaIOClient(),
+            firebaseUtils: MockFirebaseUtils(),
+          );
+          await container.read(testProvider.future);
+
+          final failed = await container
+              .read(testProvider.notifier)
+              .applyContainerSync(
+                updatedTokens: const [],
+                newTokens: [incoming],
+                checkedContainersByTokenId: const {
+                  'server-id': ['CONTAINER01'],
+                },
+              );
+
+          final tokenState = await container.read(testProvider.future);
+          expect(failed, isEmpty);
+          expect(tokenState.tokens, hasLength(1));
+          expect(tokenState.tokens.single.id, current.id);
+          expect(tokenState.tokens.single.label, 'server label');
+          expect(
+            tokenState.tokens.single.checkedContainer,
+            contains('CONTAINER01'),
+          );
+          expect(persisted, hasLength(1));
+          expect(persisted!.single.id, current.id);
+          expect(persisted!.any((token) => token.id == incoming.id), isFalse);
+        },
+      );
+
+      test(
+        'fail-closes a new rolled-out strong Push token before saving',
+        () async {
+          final mockSettingsRepo = MockSettingsRepository();
+          when(
+            mockSettingsRepo.loadSettings(),
+          ).thenAnswer((_) async => SettingsState());
+          final container = ProviderContainer(
+            overrides: [
+              settingsProvider.overrideWith(
+                () => SettingsNotifier(repoOverride: mockSettingsRepo),
+              ),
+            ],
+          );
+          addTearDown(container.dispose);
+          final mockRepo = MockTokenRepository();
+          final mockRsaUtils = MockRsaUtils();
+          final incoming = PushToken(
+            id: 'server-id',
+            serial: 'PIPU02',
+            issuer: 'privacyIDEA',
+            forceBiometricOption: ForceBiometricOption.biometric,
+            biometricLevel: PushAppBiometricLevel.strong,
+            invalidateOnBiometricChange: true,
+            privateTokenKey: 'legacy-private-key',
+            publicTokenKey: 'public-key',
+            publicServerKey: 'server-key',
+            isRolledOut: true,
+            rolloutState: PushTokenRollOutState.rolloutComplete,
+            fbToken: 'firebase-token',
+          );
+          when(mockRepo.loadTokens()).thenAnswer((_) async => <Token>[]);
+          List<Token>? persisted;
+          when(mockRepo.saveOrReplaceTokens(any)).thenAnswer((
+            invocation,
+          ) async {
+            persisted = List<Token>.from(
+              invocation.positionalArguments.single as List<Token>,
+            );
+            return <Token>[];
+          });
+          when(
+            mockRsaUtils.supportsBiometricPushKeyProtection,
+          ).thenReturn(false);
+          when(
+            mockRsaUtils.deleteBiometricPushKey(incoming.id),
+          ).thenAnswer((_) async {});
+          final testProvider = tokenProviderOf(
+            repo: mockRepo,
+            rsaUtils: mockRsaUtils,
+            ioClient: const PrivacyideaIOClient(),
+            firebaseUtils: MockFirebaseUtils(),
+          );
+          await container.read(testProvider.future);
+
+          final failed = await container
+              .read(testProvider.notifier)
+              .applyContainerSync(
+                updatedTokens: const [],
+                newTokens: [incoming],
+                checkedContainersByTokenId: const {},
+              );
+
+          final saved = persisted!.single as PushToken;
+          final current =
+              (await container.read(testProvider.future)).tokens.single
+                  as PushToken;
+          expect(failed, isEmpty);
+          expect(saved.biometricKeyStatus, BiometricPushKeyStatus.invalidated);
+          expect(saved.privateTokenKey, isNull);
+          expect(
+            current.biometricKeyStatus,
+            BiometricPushKeyStatus.invalidated,
+          );
+          expect(current.privateTokenKey, isNull);
+          verify(mockRsaUtils.deleteBiometricPushKey(incoming.id)).called(1);
+        },
+      );
+
+      test(
+        'does not delete tokens when another container update cannot be saved',
+        () async {
+          final mockSettingsRepo = MockSettingsRepository();
+          when(
+            mockSettingsRepo.loadSettings(),
+          ).thenAnswer((_) async => SettingsState());
+          final container = ProviderContainer(
+            overrides: [
+              settingsProvider.overrideWith(
+                () => SettingsNotifier(repoOverride: mockSettingsRepo),
+              ),
+            ],
+          );
+          addTearDown(container.dispose);
+          final mockRepo = MockTokenRepository();
+          final toUpdate = HOTPToken(
+            id: 'update-id',
+            serial: 'HOTP-UPDATE',
+            issuer: 'privacyIDEA',
+            algorithm: Algorithms.SHA1,
+            digits: 6,
+            secret: 'JBSWY3DPEHPK3PXP',
+            counter: 1,
+          );
+          final toDelete = HOTPToken(
+            id: 'delete-id',
+            serial: 'HOTP-DELETE',
+            issuer: 'privacyIDEA',
+            algorithm: Algorithms.SHA1,
+            digits: 6,
+            secret: 'JBSWY3DPEHPK3PXP',
+            counter: 2,
+          );
+          when(
+            mockRepo.loadTokens(),
+          ).thenAnswer((_) async => [toUpdate, toDelete]);
+          when(mockRepo.saveOrReplaceTokens(any)).thenAnswer((
+            invocation,
+          ) async {
+            return List<Token>.from(
+              invocation.positionalArguments.single as List<Token>,
+            );
+          });
+          final testProvider = tokenProviderOf(
+            repo: mockRepo,
+            rsaUtils: const RsaUtils(),
+            ioClient: const PrivacyideaIOClient(),
+            firebaseUtils: MockFirebaseUtils(),
+          );
+          await container.read(testProvider.future);
+
+          final failed = await container
+              .read(testProvider.notifier)
+              .applyContainerSync(
+                updatedTokens: [toUpdate.copyWith(counter: 3)],
+                newTokens: const [],
+                deletedTokens: [toDelete],
+                checkedContainersByTokenId: const {},
+              );
+
+          final tokenState = await container.read(testProvider.future);
+          expect(failed.map((token) => token.id), [toUpdate.id]);
+          expect(tokenState.currentOfId<HOTPToken>(toUpdate.id)!.counter, 1);
+          expect(tokenState.currentOfId<HOTPToken>(toDelete.id), isNotNull);
+          verifyNever(mockRepo.deleteTokens(any));
+        },
+      );
+
+      test('keeps a failed biometric tightening terminally blocked', () async {
+        final mockSettingsRepo = MockSettingsRepository();
+        when(
+          mockSettingsRepo.loadSettings(),
+        ).thenAnswer((_) async => SettingsState());
+        final container = ProviderContainer(
+          overrides: [
+            settingsProvider.overrideWith(
+              () => SettingsNotifier(repoOverride: mockSettingsRepo),
+            ),
+          ],
+        );
+        addTearDown(container.dispose);
+        final mockRepo = MockTokenRepository();
+        final mockRsaUtils = MockRsaUtils();
+        final current = PushToken(
+          id: 'push-id',
+          serial: 'PIPU03',
+          issuer: 'privacyIDEA',
+          url: Uri.parse('https://privacyidea.example/ttype/push'),
+          biometricLevel: PushAppBiometricLevel.any,
+          invalidateOnBiometricChange: false,
+          privateTokenKey: 'legacy-private-key',
+          publicTokenKey: 'public-key',
+          publicServerKey: 'server-key',
+          isRolledOut: true,
+          rolloutState: PushTokenRollOutState.rolloutComplete,
+          fbToken: 'firebase-token',
+        );
+        final incoming = current.copyWith(
+          forceBiometricOption: ForceBiometricOption.biometric,
+          biometricLevel: PushAppBiometricLevel.strong,
+          invalidateOnBiometricChange: true,
+        );
+        when(mockRepo.loadTokens()).thenAnswer((_) async => [current]);
+        when(mockRepo.saveOrReplaceTokens(any)).thenAnswer((invocation) async {
+          return List<Token>.from(
+            invocation.positionalArguments.single as List<Token>,
+          );
+        });
+        when(mockRepo.saveOrReplaceToken(any)).thenAnswer((_) async => true);
+        when(mockRsaUtils.supportsBiometricPushKeyProtection).thenReturn(false);
+        when(
+          mockRsaUtils.deleteBiometricPushKey(current.id),
+        ).thenAnswer((_) async {});
+        final testProvider = tokenProviderOf(
+          repo: mockRepo,
+          rsaUtils: mockRsaUtils,
+          ioClient: const PrivacyideaIOClient(),
+          firebaseUtils: MockFirebaseUtils(),
+        );
+        await container.read(testProvider.future);
+
+        final failed = await container
+            .read(testProvider.notifier)
+            .applyContainerSync(
+              updatedTokens: [incoming],
+              newTokens: const [],
+              checkedContainersByTokenId: const {},
+            );
+
+        final blocked =
+            (await container.read(testProvider.future)).tokens.single
+                as PushToken;
+        expect(failed.map((token) => token.id), [current.id]);
+        expect(blocked.biometricKeyStatus, BiometricPushKeyStatus.invalidated);
+        expect(blocked.privateTokenKey, isNull);
+        verify(mockRepo.saveOrReplaceToken(any)).called(1);
+        verify(mockRsaUtils.deleteBiometricPushKey(current.id)).called(1);
+      });
     });
     test('getTokenFromId', () async {
       final mockSettingsRepo = MockSettingsRepository();
@@ -861,7 +1675,11 @@ void _testTokenNotifier() {
       when(mockRepo.saveOrReplaceTokens(any)).thenAnswer((_) async => []);
       when(mockRepo.saveOrReplaceToken(any)).thenAnswer((_) async => true);
       when(
-        mockRsaUtils.trySignWithToken(any, any),
+        mockRsaUtils.trySignWithToken(
+          any,
+          any,
+          onTokenChanged: anyNamed('onTokenChanged'),
+        ),
       ).thenAnswer((_) async => 'signature');
       when(
         mockIOClient.doPost(
@@ -899,11 +1717,157 @@ void _testTokenNotifier() {
       expect(body['capabilities'], '["decline_reason"]');
 
       final signed =
-          verify(mockRsaUtils.trySignWithToken(any, captureAny)).captured.last
+          verify(
+                mockRsaUtils.trySignWithToken(
+                  any,
+                  captureAny,
+                  onTokenChanged: anyNamed('onTokenChanged'),
+                ),
+              ).captured.last
               as String;
       expect(signed, 'newFbToken|serial|${body['timestamp']}');
       expect(signed, isNot(contains('decline_reason')));
     });
+    test(
+      'biometric rollout stops when protected state cannot be persisted',
+      () async {
+        final mockSettingsRepo = MockSettingsRepository();
+        when(
+          mockSettingsRepo.loadSettings(),
+        ).thenAnswer((_) async => SettingsState());
+        final container = ProviderContainer(
+          overrides: [
+            settingsProvider.overrideWith(
+              () => SettingsNotifier(repoOverride: mockSettingsRepo),
+            ),
+          ],
+        );
+        addTearDown(container.dispose);
+        final mockRepo = MockTokenRepository();
+        final mockIOClient = MockPrivacyideaIOClient();
+        final mockFirebaseUtils = MockFirebaseUtils();
+        final mockRsaUtils = MockRsaUtils();
+        final before = PushToken(
+          label: 'label',
+          issuer: 'issuer',
+          id: 'id',
+          serial: 'serial',
+          isRolledOut: false,
+          isPollOnly: true,
+          url: Uri.parse('https://example.com'),
+          publicTokenKey: 'public-key',
+          privateTokenKey: 'private-key',
+          forceBiometricOption: ForceBiometricOption.biometric,
+        );
+        final protected = before.copyWith(
+          privateTokenKey: () => null,
+          biometricKeyStatus: BiometricPushKeyStatus.protected,
+        );
+        when(mockRepo.loadTokens()).thenAnswer((_) async => [before]);
+        when(
+          mockRepo.saveOrReplaceToken(protected),
+        ).thenAnswer((_) async => false);
+        when(
+          mockRsaUtils.protectBiometricPushKey(any),
+        ).thenAnswer((_) async {});
+        final testProvider = tokenProviderOf(
+          repo: mockRepo,
+          ioClient: mockIOClient,
+          rsaUtils: mockRsaUtils,
+          firebaseUtils: mockFirebaseUtils,
+        );
+        await container.read(testProvider.future);
+
+        final result = await container
+            .read(testProvider.notifier)
+            .rolloutPushToken(before);
+
+        expect(result, isFalse);
+        verifyNever(
+          mockIOClient.doPost(
+            url: anyNamed('url'),
+            body: anyNamed('body'),
+            sslVerify: anyNamed('sslVerify'),
+          ),
+        );
+      },
+    );
+    test(
+      'retry keeps the public key paired with a protected private key',
+      () async {
+        final mockSettingsRepo = MockSettingsRepository();
+        when(
+          mockSettingsRepo.loadSettings(),
+        ).thenAnswer((_) async => SettingsState());
+        final container = ProviderContainer(
+          overrides: [
+            settingsProvider.overrideWith(
+              () => SettingsNotifier(repoOverride: mockSettingsRepo),
+            ),
+          ],
+        );
+        addTearDown(container.dispose);
+        final mockRepo = MockTokenRepository();
+        final mockIOClient = MockPrivacyideaIOClient();
+        final mockRsaUtils = MockRsaUtils();
+        final keyPair = await const RsaUtils().generateRSAKeyPair();
+        final publicKey = const RsaUtils().serializeRSAPublicKeyPKCS1(
+          keyPair.publicKey,
+        );
+        final before = PushToken(
+          label: 'label',
+          issuer: 'issuer',
+          id: 'id',
+          serial: 'serial',
+          isRolledOut: false,
+          isPollOnly: true,
+          url: Uri.parse('https://example.com'),
+          publicTokenKey: publicKey,
+          biometricKeyStatus: BiometricPushKeyStatus.protected,
+          forceBiometricOption: ForceBiometricOption.biometric,
+        );
+        when(mockRepo.loadTokens()).thenAnswer((_) async => [before]);
+        when(mockRepo.saveOrReplaceToken(any)).thenAnswer((_) async => true);
+        when(
+          mockRsaUtils.serializeRSAPublicKeyPKCS8(any),
+        ).thenReturn('public-key-for-server');
+        when(
+          mockRsaUtils.deserializeRSAPublicKeyPKCS1('server-public-key'),
+        ).thenReturn(RSAPublicKey(BigInt.one, BigInt.one));
+        when(
+          mockIOClient.doPost(
+            url: anyNamed('url'),
+            body: anyNamed('body'),
+            sslVerify: anyNamed('sslVerify'),
+          ),
+        ).thenAnswer(
+          (_) async =>
+              Response('{"detail": {"public_key": "server-public-key"}}', 200),
+        );
+        final testProvider = tokenProviderOf(
+          repo: mockRepo,
+          ioClient: mockIOClient,
+          rsaUtils: mockRsaUtils,
+          firebaseUtils: MockFirebaseUtils(),
+        );
+        await container.read(testProvider.future);
+
+        final result = await container
+            .read(testProvider.notifier)
+            .rolloutPushToken(before);
+
+        expect(result, isTrue);
+        verifyNever(mockRsaUtils.generateRSAKeyPair());
+        verifyNever(mockRsaUtils.protectBiometricPushKey(any));
+        verify(
+          mockIOClient.doPost(
+            url: anyNamed('url'),
+            body: anyNamed('body'),
+            sslVerify: anyNamed('sslVerify'),
+          ),
+        ).called(1);
+      },
+    );
     test(
       'removeTokens does not run push tokens through the generic bulk-delete path',
       () async {
@@ -974,6 +1938,129 @@ void _testTokenNotifier() {
 
         // The push token is removed exactly once, via its own dedicated path.
         verify(mockRepo.deleteToken(pushToken)).called(1);
+      },
+    );
+    test(
+      'removeTokens reflects partial bulk deletion success in memory',
+      () async {
+        final mockSettingsRepo = MockSettingsRepository();
+        when(
+          mockSettingsRepo.loadSettings(),
+        ).thenAnswer((_) async => SettingsState());
+        final container = ProviderContainer(
+          overrides: [
+            settingsProvider.overrideWith(
+              () => SettingsNotifier(repoOverride: mockSettingsRepo),
+            ),
+          ],
+        );
+        addTearDown(container.dispose);
+        final mockRepo = MockTokenRepository();
+        final deleted = HOTPToken(
+          id: 'deleted-id',
+          serial: 'HOTP-DELETED',
+          algorithm: Algorithms.SHA1,
+          digits: 6,
+          secret: 'deleted-secret',
+        );
+        final failed = HOTPToken(
+          id: 'failed-id',
+          serial: 'HOTP-FAILED',
+          algorithm: Algorithms.SHA1,
+          digits: 6,
+          secret: 'failed-secret',
+        );
+        when(mockRepo.loadTokens()).thenAnswer((_) async => [deleted, failed]);
+        when(
+          mockRepo.deleteTokens(any),
+        ).thenAnswer((_) async => <Token>[failed]);
+        final testProvider = tokenProviderOf(
+          repo: mockRepo,
+          rsaUtils: const RsaUtils(),
+          ioClient: const PrivacyideaIOClient(),
+          firebaseUtils: MockFirebaseUtils(),
+        );
+        final notifier = container.read(testProvider.notifier);
+        await container.read(testProvider.future);
+
+        await notifier.removeTokens([deleted, failed]);
+
+        final tokenState = await container.read(testProvider.future);
+        expect(tokenState.currentOfId(deleted.id), isNull);
+        expect(tokenState.currentOfId(failed.id), isNotNull);
+        expect(tokenState.tokens.map((token) => token.id), [failed.id]);
+      },
+    );
+    test(
+      'waits for native key cleanup before re-adding the same Push id',
+      () async {
+        final mockSettingsRepo = MockSettingsRepository();
+        when(
+          mockSettingsRepo.loadSettings(),
+        ).thenAnswer((_) async => SettingsState());
+        final container = ProviderContainer(
+          overrides: [
+            settingsProvider.overrideWith(
+              () => SettingsNotifier(repoOverride: mockSettingsRepo),
+            ),
+          ],
+        );
+        addTearDown(container.dispose);
+        final mockRepo = MockTokenRepository();
+        final mockRsaUtils = MockRsaUtils();
+        final mockFirebaseUtils = MockFirebaseUtils();
+        final current = PushToken(
+          id: 'push-id',
+          serial: 'PIPU-RACE',
+          label: 'old',
+          issuer: 'privacyIDEA',
+          isRolledOut: true,
+        );
+        final replacement = PushToken(
+          id: current.id,
+          serial: 'PIPU-NEW',
+          label: 'new',
+          issuer: 'privacyIDEA',
+          isRolledOut: true,
+          fbToken: 'firebase-token',
+        );
+        final cleanupStarted = Completer<void>();
+        final allowCleanup = Completer<void>();
+        var saveStarted = false;
+        when(mockRepo.loadTokens()).thenAnswer((_) async => [current]);
+        when(mockRepo.deleteToken(current)).thenAnswer((_) async => true);
+        when(mockRsaUtils.deleteBiometricPushKey(current.id)).thenAnswer((_) {
+          cleanupStarted.complete();
+          return allowCleanup.future;
+        });
+        when(mockRepo.saveOrReplaceToken(any)).thenAnswer((_) async {
+          saveStarted = true;
+          return true;
+        });
+        when(mockRsaUtils.supportsBiometricPushKeyProtection).thenReturn(false);
+        final testProvider = tokenProviderOf(
+          repo: mockRepo,
+          rsaUtils: mockRsaUtils,
+          ioClient: const PrivacyideaIOClient(),
+          firebaseUtils: mockFirebaseUtils,
+        );
+        final notifier = container.read(testProvider.notifier);
+        await container.read(testProvider.future);
+
+        final removeFuture = notifier.removeToken(current);
+        await cleanupStarted.future;
+        final addFuture = notifier.addOrReplaceToken(replacement);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(saveStarted, isFalse);
+        allowCleanup.complete();
+        await removeFuture;
+        expect(await addFuture, isTrue);
+        expect(saveStarted, isTrue);
+        final tokenState = await container.read(testProvider.future);
+        expect(tokenState.tokens, hasLength(1));
+        expect(tokenState.tokens.single.id, replacement.id);
+        expect(tokenState.tokens.single.label, replacement.label);
       },
     );
     test(

--- a/test/unit_test/utils/rsa_utils_test.dart
+++ b/test/unit_test/utils/rsa_utils_test.dart
@@ -1,11 +1,205 @@
 import 'dart:convert';
 
+import 'package:asn1lib/asn1lib.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/services.dart';
 import 'package:pointycastle/export.dart';
+import 'package:privacyidea_authenticator/model/enums/biometric_push_key_status.dart';
+import 'package:privacyidea_authenticator/model/enums/force_biometric_option.dart';
+import 'package:privacyidea_authenticator/model/tokens/push_token.dart';
+import 'package:privacyidea_authenticator/utils/biometric_push_key_manager.dart';
+import 'package:privacyidea_authenticator/utils/helpers/base32_helper.dart';
 import 'package:privacyidea_authenticator/utils/rsa_utils.dart';
 
 void main() {
   _testSerializingRSAKeys();
+  _testBiometricPushKeyProtection();
+}
+
+void _testBiometricPushKeyProtection() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const channel = MethodChannel('test_biometric_push_key');
+  const manager = BiometricPushKeyManager(
+    channel: channel,
+    supportedPlatformOverride: true,
+  );
+  const rsaUtils = RsaUtils(biometricPushKeyManager: manager);
+
+  PushToken token() => PushToken(
+    serial: 'PIPU0001',
+    id: 'push-1',
+    forceBiometricOption: ForceBiometricOption.biometric,
+    privateTokenKey: 'legacy-private-key',
+  );
+
+  group('biometric Push key protection', () {
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null);
+    });
+
+    test(
+      'passes the legacy private key to native biometric protection',
+      () async {
+        MethodCall? received;
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, (call) async {
+              received = call;
+              return null;
+            });
+
+        await rsaUtils.protectBiometricPushKey(token());
+
+        expect(received?.method, 'protect');
+        expect(received?.arguments['privateKey'], 'legacy-private-key');
+        expect(received?.arguments['invalidateOnBiometricChange'], isTrue);
+      },
+    );
+
+    test('persists migration before returning a biometric signature', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+            expect(call.method, 'sign');
+            expect(call.arguments['invalidateOnBiometricChange'], isTrue);
+            return {
+              'signature': base64.encode([1, 2, 3, 4]),
+              'protectedNow': true,
+            };
+          });
+      PushToken? persisted;
+
+      final signature = await rsaUtils.trySignWithToken(
+        token(),
+        'message',
+        onTokenChanged: (updated) async {
+          persisted = updated;
+          return true;
+        },
+      );
+
+      expect(signature, base32Encode(Uint8List.fromList([1, 2, 3, 4])));
+      expect(persisted?.privateTokenKey, isNull);
+      expect(persisted?.biometricKeyStatus, BiometricPushKeyStatus.protected);
+    });
+
+    test('marks the token invalid when Android invalidates the key', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+            throw PlatformException(
+              code: BiometricPushKeyManager.invalidatedCode,
+            );
+          });
+      final protectedToken = token().copyWith(
+        privateTokenKey: () => null,
+        biometricKeyStatus: BiometricPushKeyStatus.protected,
+      );
+      PushToken? persisted;
+
+      await expectLater(
+        rsaUtils.trySignWithToken(
+          protectedToken,
+          'message',
+          onTokenChanged: (updated) async {
+            persisted = updated;
+            return true;
+          },
+        ),
+        throwsA(
+          isA<BiometricPushKeyException>().having(
+            (error) => error.isInvalidated,
+            'isInvalidated',
+            isTrue,
+          ),
+        ),
+      );
+
+      expect(persisted?.privateTokenKey, isNull);
+      expect(persisted?.biometricKeyStatus, BiometricPushKeyStatus.invalidated);
+    });
+
+    test(
+      'repairs Dart state when native protection survived an interrupted migration',
+      () async {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, (call) async {
+              expect(call.method, 'sign');
+              return {
+                'signature': base64.encode([5, 6, 7, 8]),
+                'protectedNow': false,
+              };
+            });
+        PushToken? persisted;
+
+        final signature = await rsaUtils.trySignWithToken(
+          token(),
+          'message',
+          onTokenChanged: (updated) async {
+            persisted = updated;
+            return true;
+          },
+        );
+
+        expect(signature, base32Encode(Uint8List.fromList([5, 6, 7, 8])));
+        expect(persisted?.privateTokenKey, isNull);
+        expect(persisted?.biometricKeyStatus, BiometricPushKeyStatus.protected);
+      },
+    );
+
+    test(
+      'does not return a signature until migration state is durable',
+      () async {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+              channel,
+              (call) async => {
+                'signature': base64.encode([1, 2, 3, 4]),
+                'protectedNow': true,
+              },
+            );
+
+        await expectLater(
+          rsaUtils.trySignWithToken(
+            token(),
+            'message',
+            onTokenChanged: (_) async => false,
+          ),
+          throwsA(
+            isA<BiometricPushKeyException>().having(
+              (error) => error.isStateNotPersisted,
+              'isStateNotPersisted',
+              isTrue,
+            ),
+          ),
+        );
+      },
+    );
+
+    test(
+      'fails closed when native strong-biometric protection is unavailable',
+      () async {
+        const unsupported = RsaUtils(
+          biometricPushKeyManager: BiometricPushKeyManager(
+            supportedPlatformOverride: false,
+          ),
+        );
+
+        await expectLater(
+          unsupported.trySignWithToken(token(), 'message'),
+          throwsA(
+            isA<BiometricPushKeyException>().having(
+              (error) => error.code,
+              'code',
+              BiometricPushKeyManager.unsupportedCode,
+            ),
+          ),
+        );
+        await expectLater(
+          unsupported.protectBiometricPushKey(token()),
+          throwsA(isA<BiometricPushKeyException>()),
+        );
+      },
+    );
+  });
 }
 
 void _testSerializingRSAKeys() {
@@ -119,19 +313,70 @@ void _testSerializingRSAKeys() {
 
   group('Serialize RSA private keys', () {
     const rsaUtils = RsaUtils();
-    test('Converting key', () async {
-      RSAPrivateKey privateKey =
-          (await rsaUtils.generateRSAKeyPair()).privateKey;
-      String base64String = rsaUtils.serializeRSAPrivateKeyPKCS1(privateKey);
-      RSAPrivateKey convertedKey = rsaUtils.deserializeRSAPrivateKeyPKCS1(
-        base64String,
-      );
+    test(
+      'writes standard PKCS#1 and reads the legacy duplicate exponent shape',
+      () async {
+        RSAPrivateKey privateKey =
+            (await rsaUtils.generateRSAKeyPair()).privateKey;
+        String base64String = rsaUtils.serializeRSAPrivateKeyPKCS1(privateKey);
+        final standardSequence =
+            ASN1Parser(base64.decode(base64String)).nextObject()
+                as ASN1Sequence;
 
-      expect(privateKey.modulus, convertedKey.modulus);
-      expect(privateKey.exponent, convertedKey.exponent);
-      expect(privateKey.p, convertedKey.p);
-      expect(privateKey.q, convertedKey.q);
-    }, timeout: const Timeout(Duration(seconds: 60)));
+        expect(
+          (standardSequence.elements[2] as ASN1Integer).valueAsBigInteger,
+          privateKey.publicExponent,
+        );
+        expect(
+          (standardSequence.elements[3] as ASN1Integer).valueAsBigInteger,
+          privateKey.privateExponent,
+        );
+
+        final convertedKey = rsaUtils.deserializeRSAPrivateKeyPKCS1(
+          base64String,
+        );
+        expect(privateKey.modulus, convertedKey.modulus);
+        expect(privateKey.privateExponent, convertedKey.privateExponent);
+        expect(privateKey.publicExponent, convertedKey.publicExponent);
+        expect(privateKey.p, convertedKey.p);
+        expect(privateKey.q, convertedKey.q);
+
+        final legacySequence = ASN1Sequence()
+          ..add(ASN1Integer.fromInt(0))
+          ..add(ASN1Integer(privateKey.modulus!))
+          ..add(ASN1Integer(privateKey.privateExponent!))
+          ..add(ASN1Integer(privateKey.privateExponent!))
+          ..add(ASN1Integer(privateKey.p!))
+          ..add(ASN1Integer(privateKey.q!))
+          ..add(
+            ASN1Integer(
+              privateKey.privateExponent! % (privateKey.p! - BigInt.one),
+            ),
+          )
+          ..add(
+            ASN1Integer(
+              privateKey.privateExponent! % (privateKey.q! - BigInt.one),
+            ),
+          )
+          ..add(ASN1Integer(privateKey.q!.modInverse(privateKey.p!)));
+        final recovered = rsaUtils.deserializeRSAPrivateKeyPKCS1(
+          base64.encode(legacySequence.encodedBytes),
+        );
+
+        expect(recovered.privateExponent, privateKey.privateExponent);
+        expect(recovered.publicExponent, privateKey.publicExponent);
+        final message = utf8.encode('legacy compatibility');
+        expect(
+          rsaUtils.verifyRSASignature(
+            RSAPublicKey(privateKey.modulus!, privateKey.publicExponent!),
+            message,
+            rsaUtils.createRSASignature(recovered, message),
+          ),
+          isTrue,
+        );
+      },
+      timeout: const Timeout(Duration(seconds: 60)),
+    );
   });
 
   group('RSA signing and verifying', () {

--- a/test/unit_test/widgets/push_request_listener_test.dart
+++ b/test/unit_test/widgets/push_request_listener_test.dart
@@ -20,6 +20,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
+import 'package:privacyidea_authenticator/model/enums/biometric_push_key_status.dart';
 import 'package:privacyidea_authenticator/model/push_request/push_default_request.dart';
 import 'package:privacyidea_authenticator/model/riverpod_states/push_request_state.dart';
 import 'package:privacyidea_authenticator/model/riverpod_states/token_state.dart';
@@ -28,6 +29,7 @@ import 'package:privacyidea_authenticator/utils/custom_int_buffer.dart';
 import 'package:privacyidea_authenticator/utils/push_provider.dart';
 import 'package:privacyidea_authenticator/utils/riverpod/riverpod_providers/generated_providers/push_request_provider.dart';
 import 'package:privacyidea_authenticator/utils/riverpod/riverpod_providers/generated_providers/token_notifier.dart';
+import 'package:privacyidea_authenticator/widgets/dialog_widgets/push_request_dialogs/push_request_dialog.dart';
 import 'package:privacyidea_authenticator/widgets/push_request_listener.dart';
 
 import '../../tests_app_wrapper.dart';
@@ -172,5 +174,190 @@ void main() {
       expect(find.text('NEWEST_PUSH'), findsOneWidget);
       expect(find.text('OLDER_PUSH'), findsNothing);
     });
+
+    testWidgets(
+      'skips a newer invalidated-token request and shows the latest actionable request',
+      (tester) async {
+        final validToken = PushToken(
+          serial: 'PUSH-VALID',
+          id: 'valid-id',
+          isRolledOut: true,
+        );
+        final invalidatedToken = PushToken(
+          serial: 'PUSH-INVALID',
+          id: 'invalid-id',
+          isRolledOut: true,
+          biometricKeyStatus: BiometricPushKeyStatus.invalidated,
+        );
+        final now = DateTime.now();
+        final validRequest = PushDefaultRequest(
+          title: 'Valid request',
+          question: 'VALID_PUSH',
+          uri: Uri.parse('https://example.com/valid'),
+          nonce: 'valid-nonce',
+          sslVerify: true,
+          expirationDate: now.add(const Duration(minutes: 1)),
+          signature: 'valid-signature',
+          serial: validToken.serial,
+        );
+        final invalidatedRequest = PushDefaultRequest(
+          title: 'Invalidated request',
+          question: 'INVALIDATED_PUSH',
+          uri: Uri.parse('https://example.com/invalidated'),
+          nonce: 'invalidated-nonce',
+          sslVerify: true,
+          expirationDate: now.add(const Duration(minutes: 2)),
+          signature: 'invalidated-signature',
+          serial: invalidatedToken.serial,
+        );
+
+        await tester.pumpWidget(
+          TestsAppWrapper(
+            overrides: [
+              tokenProvider.overrideWith(
+                () => FakeTokenNotifierForPush(
+                  TokenState(tokens: [validToken, invalidatedToken]),
+                ),
+              ),
+              pushRequestProvider.overrideWith(
+                () => FakePushRequestNotifier(
+                  PushRequestState(
+                    pushRequests: [validRequest, invalidatedRequest],
+                    knownPushRequests: CustomIntBuffer(
+                      list: [validRequest.id, invalidatedRequest.id],
+                    ),
+                  ),
+                ),
+              ),
+            ],
+            child: const PushRequestListener(child: Text('Main Content')),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('VALID_PUSH'), findsOneWidget);
+        expect(find.text('INVALIDATED_PUSH'), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'skips a newer orphan request and shows the latest request with a token',
+      (tester) async {
+        final validToken = PushToken(
+          serial: 'PUSH-VALID',
+          id: 'valid-id',
+          isRolledOut: true,
+        );
+        final now = DateTime.now();
+        final validRequest = PushDefaultRequest(
+          title: 'Valid request',
+          question: 'VALID_PUSH',
+          uri: Uri.parse('https://example.com/valid'),
+          nonce: 'valid-nonce',
+          sslVerify: true,
+          expirationDate: now.add(const Duration(minutes: 1)),
+          signature: 'valid-signature',
+          serial: validToken.serial,
+        );
+        final orphanRequest = PushDefaultRequest(
+          title: 'Orphan request',
+          question: 'ORPHAN_PUSH',
+          uri: Uri.parse('https://example.com/orphan'),
+          nonce: 'orphan-nonce',
+          sslVerify: true,
+          expirationDate: now.add(const Duration(minutes: 2)),
+          signature: 'orphan-signature',
+          serial: 'PUSH-MISSING',
+        );
+
+        await tester.pumpWidget(
+          TestsAppWrapper(
+            overrides: [
+              tokenProvider.overrideWith(
+                () =>
+                    FakeTokenNotifierForPush(TokenState(tokens: [validToken])),
+              ),
+              pushRequestProvider.overrideWith(
+                () => FakePushRequestNotifier(
+                  PushRequestState(
+                    pushRequests: [validRequest, orphanRequest],
+                    knownPushRequests: CustomIntBuffer(
+                      list: [validRequest.id, orphanRequest.id],
+                    ),
+                  ),
+                ),
+              ),
+            ],
+            child: const PushRequestListener(child: Text('Main Content')),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('VALID_PUSH'), findsOneWidget);
+        expect(find.text('ORPHAN_PUSH'), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'does not render a request dialog when every request is invalidated or orphaned',
+      (tester) async {
+        final invalidatedToken = PushToken(
+          serial: 'PUSH-INVALID',
+          id: 'invalid-id',
+          isRolledOut: true,
+          biometricKeyStatus: BiometricPushKeyStatus.invalidated,
+        );
+        final now = DateTime.now();
+        final invalidatedRequest = PushDefaultRequest(
+          title: 'Invalidated request',
+          question: 'INVALIDATED_PUSH',
+          uri: Uri.parse('https://example.com/invalidated'),
+          nonce: 'invalidated-nonce',
+          sslVerify: true,
+          expirationDate: now.add(const Duration(minutes: 1)),
+          signature: 'invalidated-signature',
+          serial: invalidatedToken.serial,
+        );
+        final orphanRequest = PushDefaultRequest(
+          title: 'Orphan request',
+          question: 'ORPHAN_PUSH',
+          uri: Uri.parse('https://example.com/orphan'),
+          nonce: 'orphan-nonce',
+          sslVerify: true,
+          expirationDate: now.add(const Duration(minutes: 2)),
+          signature: 'orphan-signature',
+          serial: 'PUSH-MISSING',
+        );
+
+        await tester.pumpWidget(
+          TestsAppWrapper(
+            overrides: [
+              tokenProvider.overrideWith(
+                () => FakeTokenNotifierForPush(
+                  TokenState(tokens: [invalidatedToken]),
+                ),
+              ),
+              pushRequestProvider.overrideWith(
+                () => FakePushRequestNotifier(
+                  PushRequestState(
+                    pushRequests: [invalidatedRequest, orphanRequest],
+                    knownPushRequests: CustomIntBuffer(
+                      list: [invalidatedRequest.id, orphanRequest.id],
+                    ),
+                  ),
+                ),
+              ),
+            ],
+            child: const PushRequestListener(child: Text('Main Content')),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Main Content'), findsOneWidget);
+        expect(find.byType(PushRequestDialog), findsNothing);
+        expect(find.text('INVALIDATED_PUSH'), findsNothing);
+        expect(find.text('ORPHAN_PUSH'), findsNothing);
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

Protect Push private keys with policy-controlled, biometric-only access and
optionally bind them to the biometric enrollment that was present when the
token was registered.

The app accepts the following Push enrollment parameters:

- `app_biometric_level=any|strong`
- `app_invalidate_on_biometric_change=true|false`

For compatibility with an initial server implementation, the corresponding
`push_app_*` parameter names are accepted as aliases.

## Motivation

`app_force_unlock=biometric` currently controls the unlock prompt, but it does
not express the required biometric strength or bind the Push key to the
biometric enrollment used during registration. A biometric can therefore be
changed later without invalidating the existing key. Device credentials may
also be offered by platform authentication unless they are explicitly
excluded.

## Implementation

On Android, the Push RSA private key is wrapped by an Android Keystore key.
Strong mode uses `BIOMETRIC_STRONG`, requires authentication for every
cryptographic operation, excludes device credentials, and uses
`setInvalidatedByBiometricEnrollment(true)` when requested.

On iOS, the private key is stored in a non-synchronizing Keychain item using
biometric-only access. `biometryCurrentSet` binds it to the current Face ID or
Touch ID enrollment, while `biometryAny` provides per-use biometric access
without enrollment binding.

The private key is removed from the Dart token record once native protection
has been stored successfully. An existing deployed biometric Push token that
cannot prove such protection is invalidated and must be enrolled again; it is
not silently rebound to biometrics that may have changed since registration.

When `app_force_unlock=biometric` is present and either new parameter is
missing, the app defaults to `strong` and `true`. This provides a fail-safe
default for existing server policies. Explicit values remain configurable:

| Level | Invalidate | Behavior |
| --- | --- | --- |
| `strong` | `true` | Strong biometric for each signature; key invalidated after enrollment change |
| `strong` | `false` | Strong biometric for each signature; key survives enrollment change |
| `any` | `true` | Treated as strong because weak Android biometrics cannot safely protect an enrollment-bound cryptographic key |
| `any` | `false` | Any platform biometric before use, without enrollment binding |

PIN, pattern, and device password are not accepted as fallback methods for a
biometric Push token.

The Push approval path also verifies both the HTTP response and the
privacyIDEA result before removing a request. If signing or server validation
fails, the request remains available and the app shows an error instead of a
successful approval.

## Validation

- `flutter analyze`: no issues
- 135 focused Dart and Flutter tests: passed
- Android native key codec tests: passed
- regression coverage for policy parsing, secure persistence, interrupted
  migration, invalidated keys, container synchronization, Push approval
  failures, and request restoration

The iOS implementation is included but was not compiled in the local Linux
validation environment.
