### PR TITLE
Fix PKCS#1 private key exponent handling

### DIFF
--- a/lib/utils/rsa_utils.dart
+++ b/lib/utils/rsa_utils.dart
@@ -162,7 +162,7 @@ class RsaUtils {
     ASN1Sequence s = ASN1Sequence()
       ..add(ASN1Integer.fromInt(0)) // version
       ..add(ASN1Integer(key.modulus!)) // modulus
-      ..add(ASN1Integer(key.exponent!)) // e
+      ..add(ASN1Integer(key.publicExponent!)) // e
       ..add(ASN1Integer(key.privateExponent!)) // d
       ..add(ASN1Integer(key.p!)) // p
       ..add(ASN1Integer(key.q!)) // q
@@ -201,12 +201,12 @@ class RsaUtils {
         ASN1Parser(keyBytes).nextObject() as ASN1Sequence;
     BigInt modulus =
         (asn1sequence.elements[1] as ASN1Integer).valueAsBigInteger;
-    BigInt exponent =
-        (asn1sequence.elements[2] as ASN1Integer).valueAsBigInteger;
+    BigInt privateExponent =
+        (asn1sequence.elements[3] as ASN1Integer).valueAsBigInteger;
     BigInt p = (asn1sequence.elements[4] as ASN1Integer).valueAsBigInteger;
     BigInt q = (asn1sequence.elements[5] as ASN1Integer).valueAsBigInteger;
 
-    return RSAPrivateKey(modulus, exponent, p, q);
+    return RSAPrivateKey(modulus, privateExponent, p, q);
   }
 
   /// signedMessage is what was allegedly signed, signature gets validated

--- a/test/unit_test/utils/rsa_utils_test.dart
+++ b/test/unit_test/utils/rsa_utils_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:asn1lib/asn1lib.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pointycastle/export.dart';
 import 'package:privacyidea_authenticator/utils/rsa_utils.dart';
@@ -119,19 +120,72 @@ void _testSerializingRSAKeys() {
 
   group('Serialize RSA private keys', () {
     const rsaUtils = RsaUtils();
-    test('Converting key', () async {
-      RSAPrivateKey privateKey =
-          (await rsaUtils.generateRSAKeyPair()).privateKey;
-      String base64String = rsaUtils.serializeRSAPrivateKeyPKCS1(privateKey);
-      RSAPrivateKey convertedKey = rsaUtils.deserializeRSAPrivateKeyPKCS1(
-        base64String,
-      );
+    test(
+      'writes standard PKCS#1 and reads the previous encoding',
+      () async {
+        RSAPrivateKey privateKey =
+            (await rsaUtils.generateRSAKeyPair()).privateKey;
+        String base64String = rsaUtils.serializeRSAPrivateKeyPKCS1(privateKey);
+        final standardSequence =
+            ASN1Parser(base64.decode(base64String)).nextObject()
+                as ASN1Sequence;
 
-      expect(privateKey.modulus, convertedKey.modulus);
-      expect(privateKey.exponent, convertedKey.exponent);
-      expect(privateKey.p, convertedKey.p);
-      expect(privateKey.q, convertedKey.q);
-    }, timeout: const Timeout(Duration(seconds: 60)));
+        expect(
+          (standardSequence.elements[2] as ASN1Integer).valueAsBigInteger,
+          privateKey.publicExponent,
+        );
+        expect(
+          (standardSequence.elements[3] as ASN1Integer).valueAsBigInteger,
+          privateKey.privateExponent,
+        );
+
+        RSAPrivateKey convertedKey = rsaUtils.deserializeRSAPrivateKeyPKCS1(
+          base64String,
+        );
+
+        expect(privateKey.modulus, convertedKey.modulus);
+        expect(privateKey.privateExponent, convertedKey.privateExponent);
+        expect(privateKey.publicExponent, convertedKey.publicExponent);
+        expect(privateKey.p, convertedKey.p);
+        expect(privateKey.q, convertedKey.q);
+
+        final legacySequence = ASN1Sequence()
+          ..add(ASN1Integer.fromInt(0))
+          ..add(ASN1Integer(privateKey.modulus!))
+          // Previous versions wrote d into both the e and d fields.
+          ..add(ASN1Integer(privateKey.privateExponent!))
+          ..add(ASN1Integer(privateKey.privateExponent!))
+          ..add(ASN1Integer(privateKey.p!))
+          ..add(ASN1Integer(privateKey.q!))
+          ..add(
+            ASN1Integer(
+              privateKey.privateExponent! % (privateKey.p! - BigInt.one),
+            ),
+          )
+          ..add(
+            ASN1Integer(
+              privateKey.privateExponent! % (privateKey.q! - BigInt.one),
+            ),
+          )
+          ..add(ASN1Integer(privateKey.q!.modInverse(privateKey.p!)));
+        final recoveredKey = rsaUtils.deserializeRSAPrivateKeyPKCS1(
+          base64.encode(legacySequence.encodedBytes),
+        );
+
+        expect(recoveredKey.privateExponent, privateKey.privateExponent);
+        expect(recoveredKey.publicExponent, privateKey.publicExponent);
+        final message = utf8.encode('PKCS#1 compatibility');
+        expect(
+          rsaUtils.verifyRSASignature(
+            RSAPublicKey(privateKey.modulus!, privateKey.publicExponent!),
+            message,
+            rsaUtils.createRSASignature(recoveredKey, message),
+          ),
+          isTrue,
+        );
+      },
+      timeout: const Timeout(Duration(seconds: 60)),
+    );
   });
 
   group('RSA signing and verifying', () {


### PR DESCRIPTION
## Description

`RSAPrivateKey.exponent` in PointyCastle is the private exponent `d`, while
`publicExponent` is `e`. The serializer currently writes `key.exponent` into
the PKCS#1 `publicExponent` field and then writes `privateExponent` into the
following field. This produces `n, d, d, p, q, ...` instead of
`n, e, d, p, q, ...`.

The deserializer currently reads element 2 (the public-exponent position) and
passes it to `RSAPrivateKey` as `d`, instead of reading element 3. These two
mistakes mask each other for keys generated by the app: the serializer puts
`d` in element 2 and the deserializer reads the same value back. Nevertheless,
the DER structure is not standards-compliant, and a standard parser can reject
or misinterpret it. Conversely, a valid PKCS#1 key is currently deserialized
using `e` as though it were `d`.

This change:

- writes `publicExponent` to the PKCS#1 public-exponent field;
- reads `privateExponent` from the PKCS#1 private-exponent field;
- retains compatibility with existing app-generated keys. Their correct `d`
  is already present in element 3, so no migration or format detection is
  required.

## Tests

Regression coverage verifies that:

- newly serialized keys contain `e` and `d` in the correct fields;
- standards-compliant keys round-trip correctly;
- keys using the previous duplicate-exponent encoding remain readable and
  produce valid signatures.
