### PR TITLE
Fix Steam codes during second half of time step

### DIFF
--- a/lib/model/tokens/steam_token.dart
+++ b/lib/model/tokens/steam_token.dart
@@ -137,9 +137,7 @@ class SteamToken extends TOTPToken {
   // --- Methods ---
   @override
   String otpFromTime(DateTime time) {
-    final counterBytes = (time.millisecondsSinceEpoch / 1000 / period)
-        .round()
-        .bytes;
+    final counterBytes = (time.millisecondsSinceEpoch ~/ 1000 ~/ period).bytes;
     final secretList = base32Decode(secret.toUpperCase());
     final hmac = Hmac(sha1, secretList);
     final digest = hmac.convert(counterBytes).bytes;

--- a/test/unit_test/model/tokens/steam_token_test.dart
+++ b/test/unit_test/model/tokens/steam_token_test.dart
@@ -126,13 +126,27 @@ void main() {
     });
 
     group('4. Logic & Edge Cases', () {
-      test('otpFromTime calculation with Steam alphabet', () {
-        final time = DateTime.fromMillisecondsSinceEpoch(1712666212056);
+      test('otpFromTime uses the current counter until the period ends', () {
         final token = createTestToken(secret: 'SECRETA=');
 
-        final otp = token.otpFromTime(time);
-        expect(otp, 'JGPCJ');
-        expect(otp.length, 5);
+        expect(
+          token.otpFromTime(
+            DateTime.fromMillisecondsSinceEpoch(1712666212056, isUtc: true),
+          ),
+          'QJTQN',
+        );
+        expect(
+          token.otpFromTime(
+            DateTime.fromMillisecondsSinceEpoch(1712666219999, isUtc: true),
+          ),
+          'QJTQN',
+        );
+        expect(
+          token.otpFromTime(
+            DateTime.fromMillisecondsSinceEpoch(1712666220000, isUtc: true),
+          ),
+          'JGPCJ',
+        );
       });
 
       test('isSameTokenAs logic (ID vs Parameters)', () {


### PR DESCRIPTION
## Problem

`SteamToken.otpFromTime` rounded the Unix time-step value to the nearest integer. This advanced the counter halfway through each 30-second period, so the app generated the next period's Steam code during the final 15 seconds of the current period.

The existing test used a timestamp from that second half and expected the prematurely advanced code, which masked the boundary error.

## Solution

- Derive the counter with integer division so it changes only at the exact 30-second boundary.
- Update the regression test to cover the second half of a period, its final millisecond, and the following boundary.
- Keep the Steam alphabet, HMAC-SHA1 calculation, five-character output, and 30-second period unchanged.

## Validation

- `flutter test --no-pub test/unit_test/model/tokens/steam_token_test.dart` (8 tests passed)
- `flutter test --no-pub` (1320 tests passed)
- `flutter analyze --no-pub` (no issues found)
- `git diff --check`
