### PR TITLE
Fix lost HOTP counter increments during queued updates

### DIFF
--- a/lib/utils/riverpod/riverpod_providers/generated_providers/token_notifier.dart
+++ b/lib/utils/riverpod/riverpod_providers/generated_providers/token_notifier.dart
@@ -181,24 +181,31 @@ class TokenNotifier extends _$TokenNotifier with ResultHandler {
     });
   }
 
-  /// Replaces a token if it exists and returns true if successful, false if not.
-  /// Updates repo and state.
-  Future<bool> _replaceToken(Token token) {
+  /// Updates a token if it exists and returns the updated token if successful,
+  /// the current token if saving fails and null if the token does not exist.
+  /// Updates repo and state atomically.
+  Future<T?> _replaceToken<T extends Token>(T token, T Function(T) updater) {
     return _stateMutex.protect(() async {
-      final (newState, replaced) = (await future).replaceToken(token);
+      final current = (await future).currentOf<T>(token);
+      if (current == null) {
+        Logger.warning('Tried to update a token that does not exist.');
+        return null;
+      }
+      final updated = updater(current);
+      final (newState, replaced) = (await future).replaceToken(updated);
       if (!replaced) {
         Logger.warning('Tried to replace a token that does not exist.');
-        return false;
+        return current;
       }
       final saved = await _repoMutex.protect(
-        () => repo.saveOrReplaceToken(token),
+        () => repo.saveOrReplaceToken(updated),
       );
       if (!saved) {
-        Logger.warning('Saving token failed. Token: ${token.id}');
-        return false;
+        Logger.warning('Saving token failed. Token: ${updated.id}');
+        return current;
       }
       state = AsyncValue.data(newState);
-      return true;
+      return updated;
     });
   }
 
@@ -313,19 +320,8 @@ class TokenNotifier extends _$TokenNotifier with ResultHandler {
   */
 
   /// Updates a token and returns the updated token if successful, the old token if not and null if the token does not exist.
-  Future<T?> _updateToken<T extends Token>(
-    T token,
-    T Function(T) updater,
-  ) async {
-    final current = (await future).currentOf<T>(token);
-    if (current == null) {
-      Logger.warning('Tried to update a token that does not exist.');
-      return null;
-    }
-    final updated = updater(current);
-    final replaced = await _replaceToken(updated);
-    return replaced ? updated : current;
-  }
+  Future<T?> _updateToken<T extends Token>(T token, T Function(T) updater) =>
+      _replaceToken(token, updater);
 
   /// Updates a list of tokens and returns the updated tokens if successful.
   /// Returns the old tokens if not and an empty list if the tokens does not exist.
@@ -389,8 +385,10 @@ class TokenNotifier extends _$TokenNotifier with ResultHandler {
   ) => _updateTokens(tokens, updater);
 
   /// Increments the counter of a HOTPToken and returns the updated token if successful, the old token if not and null if the token does not exist.
-  Future<HOTPToken?> incrementCounter(HOTPToken token) =>
-      _updateToken(token, (p0) => p0.copyWith(counter: token.counter + 1));
+  Future<HOTPToken?> incrementCounter(HOTPToken token) => _updateToken(
+    token,
+    (current) => current.copyWith(counter: current.counter + 1),
+  );
 
   /// Hides a token and returns the updated token ifTok successful, the old token if not and null if the token does not exist.
   Future<T?> hideToken<T extends Token>(T token) =>

--- a/test/unit_test/utils/riverpod/riverpod_providers/generated_providers/token_notifier_test.dart
+++ b/test/unit_test/utils/riverpod/riverpod_providers/generated_providers/token_notifier_test.dart
@@ -175,7 +175,7 @@ void _testTokenNotifier() {
       expect(state, isNotNull);
       expect(state.tokens, after);
     });
-    test('incrementCounter', () async {
+    test('incrementCounter uses the latest counter for queued calls', () async {
       final mockSettingsRepo = MockSettingsRepository();
       when(
         mockSettingsRepo.loadSettings(),
@@ -209,13 +209,11 @@ void _testTokenNotifier() {
           algorithm: Algorithms.SHA1,
           digits: 6,
           secret: 'secret',
-          counter: 523,
+          counter: 524,
         ),
       ];
       when(mockRepo.loadTokens()).thenAnswer((_) async => before);
-      when(
-        mockRepo.saveOrReplaceToken(after.first),
-      ).thenAnswer((_) async => true);
+      when(mockRepo.saveOrReplaceToken(any)).thenAnswer((_) async => true);
       when(mockRepo.saveOrReplaceTokens(any)).thenAnswer((_) async => []);
       when(
         mockFirebaseUtils.getFBToken(),
@@ -229,11 +227,17 @@ void _testTokenNotifier() {
       final notifier = container.read(testProvider.notifier);
       final stateBefore = await container.read(testProvider.future);
       expect(stateBefore.tokens, before);
-      await notifier.incrementCounter(before.first);
+      await Future.wait([
+        notifier.incrementCounter(before.first),
+        notifier.incrementCounter(before.first),
+      ]);
       final state = await container.read(testProvider.future);
       expect(state, isNotNull);
       expect(state.tokens, after);
-      verify(mockRepo.saveOrReplaceToken(after.first)).called(1);
+      final savedTokens = verify(
+        mockRepo.saveOrReplaceToken(captureAny),
+      ).captured.cast<HOTPToken>();
+      expect(savedTokens.map((token) => token.counter), [523, 524]);
     });
     test('removeToken', () async {
       final mockSettingsRepo = MockSettingsRepository();


### PR DESCRIPTION
## Summary

Apply token updates to the latest state while holding the existing state mutex. This prevents overlapping HOTP increment requests from persisting the same next counter value.

## Current behavior

The HOTP tile starts `incrementCounter` without waiting for its returned `Future`. The button's fixed one-second cooldown can expire while the previous repository write is still pending, so another press can pass the same token snapshot.

In the current implementation, `_updateToken` resolves the token before `_replaceToken` acquires `_stateMutex`, while `incrementCounter` calculates the next value from the supplied snapshot. Two overlapping calls can therefore both persist `N + 1`, losing one increment. The issue is timing-dependent and only manifests when the operations actually overlap, for example during a slower token write.

The user can then see the same HOTP value again instead of the expected next value, which can also leave the app counter out of step with the server.

## Fix

- Resolve the current token inside the existing `_stateMutex`.
- Apply the updater and persist the result in the same critical section.
- Calculate the next HOTP value from `current.counter`.
- Preserve the existing missing-token and save-failure return behavior.

## Regression test

The test starts two increments with the same counter-`522` snapshot and verifies that the repository receives `523` followed by `524`, with a final state of `524`.

## Validation

- Focused regression test: passed.
- Complete `TokenNotifier` test file: 14/14 passed.
- Full Flutter test suite: 1320/1320 passed.
- `flutter analyze --no-pub`: no issues found.
- `git diff --check`: passed.
